### PR TITLE
Add async agent task public contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:editor-actions": "tsx tests/editor-actions.test.ts",
     "test:editor-validate-blocks": "tsx tests/editor-validate-blocks.test.ts",
     "test:artifact-result-envelope": "tsx tests/artifact-result-envelope.test.ts",
+    "test:async-agent-task-contracts": "tsx tests/async-agent-task-contracts.test.ts",
     "test:artifact-reference-dtos": "tsx tests/artifact-reference-dtos.test.ts",
     "test:artifact-path-primitives": "tsx tests/artifact-path-primitives.test.ts",
     "test:browser-callback-materialization-contracts": "tsx tests/browser-callback-materialization-contracts.test.ts",

--- a/packages/runtime-core/src/async-agent-task-contracts.ts
+++ b/packages/runtime-core/src/async-agent-task-contracts.ts
@@ -1,0 +1,255 @@
+import { normalizeAgentTaskRunResult, type AgentTaskRunResultSummary } from "./agent-task-run-result.js"
+import { artifactResultEnvelope, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
+import { normalizeRuntimeAccess, previewLease, type PreviewLease, type RuntimeAccess } from "./runtime-boundary-contracts.js"
+import { isPlainObject, objectValue, stringValue, stripUndefined } from "./object-utils.js"
+
+export const CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA = "wp-codebox/async-agent-task-handle/v1" as const
+export const CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA = "wp-codebox/async-agent-task-status/v1" as const
+export const CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA = "wp-codebox/async-agent-task-result/v1" as const
+
+export type CodeboxAsyncAgentTaskState = "queued" | "running" | "succeeded" | "failed" | "cancelled" | "expired" | "unknown" | (string & {})
+
+export interface CodeboxAsyncAgentTaskHandle {
+  schema: typeof CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA
+  run_id: string
+  state: CodeboxAsyncAgentTaskState
+  status_url?: string
+  result_url?: string
+  cancel_url?: string
+  runtime_access?: RuntimeAccess
+  lease?: PreviewLease
+  artifact_result?: ArtifactResultEnvelope
+  metadata: Record<string, unknown>
+}
+
+export interface CodeboxAsyncAgentTaskStatus {
+  schema: typeof CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA
+  run_id: string
+  state: CodeboxAsyncAgentTaskState
+  complete: boolean
+  success?: boolean
+  updated_at?: string
+  runtime_access?: RuntimeAccess
+  lease?: PreviewLease
+  artifact_result?: ArtifactResultEnvelope
+  diagnostics: Array<Record<string, unknown>>
+  metadata: Record<string, unknown>
+}
+
+export interface CodeboxAsyncAgentTaskResult {
+  schema: typeof CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA
+  run_id: string
+  state: CodeboxAsyncAgentTaskState
+  success: boolean
+  result: AgentTaskRunResultSummary
+  artifact_result: ArtifactResultEnvelope
+  runtime_access?: RuntimeAccess
+  lease?: PreviewLease
+  diagnostics: Array<Record<string, unknown>>
+  metadata: Record<string, unknown>
+}
+
+export function codeboxAsyncAgentTaskHandle(input: {
+  runId?: string
+  run_id?: string
+  state?: unknown
+  statusUrl?: string
+  status_url?: string
+  resultUrl?: string
+  result_url?: string
+  cancelUrl?: string
+  cancel_url?: string
+  runtimeAccess?: unknown
+  runtime_access?: unknown
+  lease?: unknown
+  artifactResult?: unknown
+  artifact_result?: unknown
+  metadata?: Record<string, unknown>
+}): CodeboxAsyncAgentTaskHandle {
+  const runId = stringValue(input.runId) || stringValue(input.run_id)
+  if (!runId) throw new Error("codeboxAsyncAgentTaskHandle requires run_id")
+
+  return stripUndefined({
+    schema: CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA,
+    run_id: runId,
+    state: normalizeAsyncAgentTaskState(input.state),
+    status_url: stringValue(input.statusUrl) || stringValue(input.status_url) || undefined,
+    result_url: stringValue(input.resultUrl) || stringValue(input.result_url) || undefined,
+    cancel_url: stringValue(input.cancelUrl) || stringValue(input.cancel_url) || undefined,
+    runtime_access: normalizeOptionalRuntimeAccess(input.runtimeAccess ?? input.runtime_access),
+    lease: normalizeOptionalPreviewLease(input.lease),
+    artifact_result: normalizeOptionalArtifactResult(input.artifactResult ?? input.artifact_result),
+    metadata: isPlainObject(input.metadata) ? input.metadata : {},
+  })
+}
+
+export function normalizeCodeboxAsyncAgentTaskHandle(input: unknown): CodeboxAsyncAgentTaskHandle | undefined {
+  const record = objectValue(input)
+  const runId = stringValue(record.run_id) || stringValue(record.runId) || stringValue(record.id) || stringValue(record.job_id) || stringValue(record.jobId)
+  if (!runId) return undefined
+
+  return codeboxAsyncAgentTaskHandle({
+    run_id: runId,
+    state: record.state ?? record.status,
+    status_url: stringValue(record.status_url) || stringValue(record.statusUrl) || undefined,
+    result_url: stringValue(record.result_url) || stringValue(record.resultUrl) || undefined,
+    cancel_url: stringValue(record.cancel_url) || stringValue(record.cancelUrl) || undefined,
+    runtime_access: record.runtime_access ?? record.runtimeAccess,
+    lease: record.lease ?? objectValue(record.runtime_access).lease,
+    artifact_result: record.artifact_result ?? record.artifactResult,
+    metadata: objectValue(record.metadata),
+  })
+}
+
+export function codeboxAsyncAgentTaskStatus(input: {
+  runId?: string
+  run_id?: string
+  state?: unknown
+  complete?: boolean
+  success?: boolean
+  updatedAt?: string
+  updated_at?: string
+  runtimeAccess?: unknown
+  runtime_access?: unknown
+  lease?: unknown
+  artifactResult?: unknown
+  artifact_result?: unknown
+  diagnostics?: unknown
+  metadata?: Record<string, unknown>
+}): CodeboxAsyncAgentTaskStatus {
+  const runId = stringValue(input.runId) || stringValue(input.run_id)
+  if (!runId) throw new Error("codeboxAsyncAgentTaskStatus requires run_id")
+  const state = normalizeAsyncAgentTaskState(input.state, input.success)
+
+  return stripUndefined({
+    schema: CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA,
+    run_id: runId,
+    state,
+    complete: typeof input.complete === "boolean" ? input.complete : isTerminalAsyncAgentTaskState(state),
+    success: typeof input.success === "boolean" ? input.success : state === "succeeded" ? true : state === "failed" ? false : undefined,
+    updated_at: stringValue(input.updatedAt) || stringValue(input.updated_at) || undefined,
+    runtime_access: normalizeOptionalRuntimeAccess(input.runtimeAccess ?? input.runtime_access),
+    lease: normalizeOptionalPreviewLease(input.lease),
+    artifact_result: normalizeOptionalArtifactResult(input.artifactResult ?? input.artifact_result),
+    diagnostics: normalizeRecordList(input.diagnostics),
+    metadata: isPlainObject(input.metadata) ? input.metadata : {},
+  })
+}
+
+export function normalizeCodeboxAsyncAgentTaskStatus(input: unknown): CodeboxAsyncAgentTaskStatus | undefined {
+  const record = objectValue(input)
+  const runId = stringValue(record.run_id) || stringValue(record.runId) || stringValue(record.id) || stringValue(record.job_id) || stringValue(record.jobId)
+  if (!runId) return undefined
+
+  return codeboxAsyncAgentTaskStatus({
+    run_id: runId,
+    state: record.state ?? record.status,
+    complete: typeof record.complete === "boolean" ? record.complete : undefined,
+    success: typeof record.success === "boolean" ? record.success : undefined,
+    updated_at: stringValue(record.updated_at) || stringValue(record.updatedAt) || undefined,
+    runtime_access: record.runtime_access ?? record.runtimeAccess,
+    lease: record.lease ?? objectValue(record.runtime_access).lease,
+    artifact_result: record.artifact_result ?? record.artifactResult,
+    diagnostics: record.diagnostics,
+    metadata: objectValue(record.metadata),
+  })
+}
+
+export function codeboxAsyncAgentTaskResult(input: {
+  runId?: string
+  run_id?: string
+  state?: unknown
+  success?: boolean
+  result?: unknown
+  artifactResult?: unknown
+  artifact_result?: unknown
+  runtimeAccess?: unknown
+  runtime_access?: unknown
+  lease?: unknown
+  diagnostics?: unknown
+  metadata?: Record<string, unknown>
+}): CodeboxAsyncAgentTaskResult {
+  const runId = stringValue(input.runId) || stringValue(input.run_id)
+  if (!runId) throw new Error("codeboxAsyncAgentTaskResult requires run_id")
+  const result = normalizeAgentTaskRunResult(input.result ?? { success: input.success })
+  const state = normalizeAsyncAgentTaskState(input.state ?? result.status, result.success)
+  const artifactResult = normalizeOptionalArtifactResult(input.artifactResult ?? input.artifact_result)
+    ?? artifactResultEnvelope({ operation: "agent-task-run", status: result.success ? "created" : "failed", result: result as unknown as Record<string, unknown> })
+
+  return stripUndefined({
+    schema: CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA,
+    run_id: runId,
+    state,
+    success: typeof input.success === "boolean" ? input.success : result.success,
+    result,
+    artifact_result: artifactResult,
+    runtime_access: normalizeOptionalRuntimeAccess(input.runtimeAccess ?? input.runtime_access ?? result.runtime_access),
+    lease: normalizeOptionalPreviewLease(input.lease ?? result.runtime_access?.lease),
+    diagnostics: normalizeRecordList(input.diagnostics).concat(result.diagnostics),
+    metadata: isPlainObject(input.metadata) ? input.metadata : {},
+  })
+}
+
+export function normalizeCodeboxAsyncAgentTaskResult(input: unknown): CodeboxAsyncAgentTaskResult | undefined {
+  const record = objectValue(input)
+  const resultRecord = objectValue(record.result)
+  const resultMetadata = objectValue(resultRecord.metadata)
+  const runId = stringValue(record.run_id) || stringValue(record.runId) || stringValue(record.id) || stringValue(resultMetadata.run_id) || stringValue(record.job_id) || stringValue(record.jobId)
+  if (!runId) return undefined
+
+  return codeboxAsyncAgentTaskResult({
+    run_id: runId,
+    state: record.state ?? record.status ?? resultRecord.status,
+    success: typeof record.success === "boolean" ? record.success : undefined,
+    result: record.result ?? record,
+    artifact_result: record.artifact_result ?? record.artifactResult,
+    runtime_access: record.runtime_access ?? record.runtimeAccess,
+    lease: record.lease ?? objectValue(record.runtime_access).lease,
+    diagnostics: record.diagnostics,
+    metadata: objectValue(record.metadata),
+  })
+}
+
+export function isTerminalAsyncAgentTaskState(state: unknown): boolean {
+  const normalized = normalizeAsyncAgentTaskState(state)
+  return normalized === "succeeded" || normalized === "failed" || normalized === "cancelled" || normalized === "expired"
+}
+
+export function normalizeAsyncAgentTaskState(state: unknown, success?: boolean): CodeboxAsyncAgentTaskState {
+  const value = stringValue(state).toLowerCase().replace(/_/g, "-")
+  if (value === "queued" || value === "pending" || value === "created") return "queued"
+  if (value === "running" || value === "in-progress" || value === "active") return "running"
+  if (value === "succeeded" || value === "success" || value === "successful" || value === "completed" || value === "complete") return "succeeded"
+  if (value === "failed" || value === "failure" || value === "error" || value === "provider-error" || value === "timeout") return "failed"
+  if (value === "cancelled" || value === "canceled") return "cancelled"
+  if (value === "expired") return "expired"
+  if (typeof success === "boolean") return success ? "succeeded" : "failed"
+  return value || "unknown"
+}
+
+function normalizeOptionalRuntimeAccess(input: unknown): RuntimeAccess | undefined {
+  if (!isPlainObject(input)) return undefined
+  try {
+    return normalizeRuntimeAccess(input)
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeOptionalPreviewLease(input: unknown): PreviewLease | undefined {
+  if (!isPlainObject(input)) return undefined
+  try {
+    return previewLease(input)
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeOptionalArtifactResult(input: unknown): ArtifactResultEnvelope | undefined {
+  if (!isPlainObject(input)) return undefined
+  return normalizeArtifactResultEnvelope(input, "agent-task-run")
+}
+
+function normalizeRecordList(input: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(input) ? input.filter(isPlainObject) : []
+}

--- a/packages/runtime-core/src/public.ts
+++ b/packages/runtime-core/src/public.ts
@@ -4,6 +4,7 @@
  * sandbox backend implementation APIs.
  */
 export * from "./agent-runtime-workload.js"
+export * from "./async-agent-task-contracts.js"
 export * from "./agent-workload.js"
 export * from "./agent-task-run-result.js"
 export * from "./headless-agent-task-contracts.js"

--- a/tests/async-agent-task-contracts.test.ts
+++ b/tests/async-agent-task-contracts.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+
+import {
+  CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA,
+  CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA,
+  CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA,
+  normalizeAsyncAgentTaskState,
+  normalizeCodeboxAsyncAgentTaskHandle,
+  normalizeCodeboxAsyncAgentTaskResult,
+  normalizeCodeboxAsyncAgentTaskStatus,
+} from "../packages/runtime-core/src/public.js"
+
+const lease = {
+  schema: "wp-codebox/preview-lease/v1",
+  public_url: "https://preview.example.com/run-123",
+  lease: { id: "lease-123", status: "active", owner: "homeboy", provider: "codebox" },
+}
+
+const handle = normalizeCodeboxAsyncAgentTaskHandle({
+  id: "run-123",
+  status: "pending",
+  statusUrl: "https://codebox.example.com/runs/run-123/status",
+  resultUrl: "https://codebox.example.com/runs/run-123/result",
+  runtime_access: { schema: "wp-codebox/runtime-access/v1", lease },
+  artifact_result: { success: true, artifactBundle: { kind: "artifact-bundle", path: "artifacts/run-123" } },
+})
+
+assert.equal(handle?.schema, CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA)
+assert.equal(handle?.run_id, "run-123")
+assert.equal(handle?.state, "queued")
+assert.equal(handle?.runtime_access?.lease?.public_url, "https://preview.example.com/run-123")
+assert.equal(handle?.artifact_result?.schema, "wp-codebox/artifact-result-envelope/v1")
+
+const status = normalizeCodeboxAsyncAgentTaskStatus({
+  job_id: "run-123",
+  status: "in_progress",
+  diagnostics: [{ code: "wp-codebox.progress", message: "Agent is still running." }],
+  metadata: { queue: "runtime" },
+})
+
+assert.equal(status?.schema, CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA)
+assert.equal(status?.state, "running")
+assert.equal(status?.complete, false)
+assert.equal(status?.diagnostics[0]?.code, "wp-codebox.progress")
+assert.deepEqual(status?.metadata, { queue: "runtime" })
+
+const result = normalizeCodeboxAsyncAgentTaskResult({
+  run_id: "run-123",
+  state: "completed",
+  result: {
+    success: true,
+    summary: "Agent task completed.",
+    artifacts: [{ kind: "codebox-patch", path: "files/patch.diff" }],
+    runtime_access: { schema: "wp-codebox/runtime-access/v1", lease },
+  },
+  artifact_result: {
+    schema: "wp-codebox/artifact-result-envelope/v1",
+    operation: "agent-task-run",
+    status: "created",
+    artifactRefs: [{ kind: "codebox-patch", path: "files/patch.diff" }],
+    typed_artifacts: [],
+  },
+})
+
+assert.equal(result?.schema, CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA)
+assert.equal(result?.state, "succeeded")
+assert.equal(result?.success, true)
+assert.equal(result?.result.refs.patches[0]?.path, "files/patch.diff")
+assert.equal(result?.artifact_result.artifactRefs[0]?.kind, "codebox-patch")
+assert.equal(result?.runtime_access?.lease?.lease?.id, "lease-123")
+
+assert.equal(normalizeAsyncAgentTaskState("provider_error"), "failed")
+assert.equal(normalizeCodeboxAsyncAgentTaskHandle({ status: "queued" }), undefined)
+
+console.log("async agent task contracts passed")

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -10,6 +10,9 @@ import {
   fuzzSuiteContract,
   fuzzSuiteResultEnvelope,
   normalizeAgentTaskRunResult,
+  normalizeCodeboxAsyncAgentTaskHandle,
+  normalizeCodeboxAsyncAgentTaskResult,
+  normalizeCodeboxAsyncAgentTaskStatus,
   normalizeArtifactResultEnvelope,
   normalizeBrowserRunResult,
   normalizePreviewReviewerAccess,
@@ -29,6 +32,9 @@ import {
   ARTIFACT_APPLY_PAYLOAD_SCHEMA,
   ARTIFACT_APPLY_PREFLIGHT_SCHEMA,
   ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+  CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA,
+  CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA,
+  CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA,
   CODEBOX_PUBLIC_RUNTIME_ABILITIES,
   CODEBOX_RUN_FUZZ_SUITE_ABILITY,
   CODEBOX_RUN_WORDPRESS_WORKLOAD_ABILITY,
@@ -130,6 +136,7 @@ const runnerWorkspaceAdapter = await readFile(new URL("packages/wordpress-plugin
 
 assert.deepEqual(barrelExportModules(publicBarrel), [
   "./agent-runtime-workload.js",
+  "./async-agent-task-contracts.js",
   "./agent-workload.js",
   "./agent-task-run-result.js",
   "./headless-agent-task-contracts.js",
@@ -431,6 +438,9 @@ assert.equal(typeof browserArtifactPersistenceProjection, "function")
 assert.equal(typeof persistedBrowserArtifactRefs, "function")
 assert.equal(typeof artifactBundleFileManifest, "function")
 assert.equal(typeof normalizeAgentTaskRunResult, "function")
+assert.equal(typeof normalizeCodeboxAsyncAgentTaskHandle, "function")
+assert.equal(typeof normalizeCodeboxAsyncAgentTaskStatus, "function")
+assert.equal(typeof normalizeCodeboxAsyncAgentTaskResult, "function")
 assert.equal(typeof artifactResultEnvelope, "function")
 assert.equal(typeof normalizeArtifactResultEnvelope, "function")
 assert.equal(typeof runResultsApi.normalizeAgentTaskRunResult, "function")
@@ -486,6 +496,9 @@ assert.equal(runtimeContractManifest().schemas.agentTask.runRequest, "wp-codebox
 assert.equal(runtimeContractManifest().providerRuntime.tasks.workspaceCommand, "wp-codebox.runner-workspace.command")
 assert.equal("runnerWorkspaceBackend" in runtimeContractManifest(), false)
 assert.equal(normalizeAgentTaskRunResult({ status: "completed", success: true }).schema, AGENT_TASK_RUN_RESULT_SCHEMA)
+assert.equal(normalizeCodeboxAsyncAgentTaskHandle({ id: "run-1" })?.schema, CODEBOX_ASYNC_AGENT_TASK_HANDLE_SCHEMA)
+assert.equal(normalizeCodeboxAsyncAgentTaskStatus({ id: "run-1", status: "running" })?.schema, CODEBOX_ASYNC_AGENT_TASK_STATUS_SCHEMA)
+assert.equal(normalizeCodeboxAsyncAgentTaskResult({ id: "run-1", result: { success: true } })?.schema, CODEBOX_ASYNC_AGENT_TASK_RESULT_SCHEMA)
 assert.equal(wordpressRestMatrixContract({ id: "public-rest-matrix" }).schema, WORDPRESS_REST_MATRIX_SCHEMA)
 assert.equal(artifactResultEnvelope({ operation: "agent-task-run" }).schema, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
 assert.equal(normalizeArtifactResultEnvelope({ success: true }).schema, ARTIFACT_RESULT_ENVELOPE_SCHEMA)


### PR DESCRIPTION
## Summary
- Add public async agent-task handle/status/result DTOs and normalizers to the runtime-core public facade.
- Reuse existing agent task result, runtime access/lease, and artifact result envelope normalizers instead of exposing runtime worker internals.
- Add focused contract coverage and public facade export assertions.

Related: Automattic/wp-codebox#1038, Automattic/wp-codebox#1044, Automattic/wp-codebox#1250.

## Testing
- npm run test:async-agent-task-contracts
- npm run test:public-api-contract
- npm run test:artifact-result-envelope
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and verified the public DTO/normalizer slice, focused tests, and PR preparation.