### PR TITLE
Add sandbox PHPUnit preload files

### DIFF
--- a/packages/cli/src/commands/recipe-build.ts
+++ b/packages/cli/src/commands/recipe-build.ts
@@ -24,6 +24,7 @@ interface WordPressPhpunitBuilderOptions {
   testsDir?: string
   dependencyMounts?: string[]
   bootstrapFiles?: string[]
+  preloadFiles?: string[]
   phpunitArgs?: string[]
   bootstrapMode?: string
   projectBootstrap?: string
@@ -86,6 +87,7 @@ function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: Word
         testsDir: stringOrUndefined(phpunitOptions.testsDir),
         dependencyMounts: Array.isArray(phpunitOptions.dependencyMounts) ? phpunitOptions.dependencyMounts : [],
         bootstrapFiles: Array.isArray(phpunitOptions.bootstrapFiles) ? phpunitOptions.bootstrapFiles : [],
+        preloadFiles: Array.isArray(phpunitOptions.preloadFiles) ? phpunitOptions.preloadFiles : [],
         phpunitArgs: Array.isArray(phpunitOptions.phpunitArgs) ? phpunitOptions.phpunitArgs : [],
         bootstrapMode: stringOrUndefined(phpunitOptions.bootstrapMode),
         projectBootstrap: stringOrUndefined(phpunitOptions.projectBootstrap),

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -30,6 +30,7 @@ export interface WordPressPhpunitRecipeOptions {
   phpunitXml?: string
   dependencyMounts?: string[]
   bootstrapFiles?: string[]
+  preloadFiles?: string[]
   phpunitArgs?: string[]
   bootstrapMode?: "managed" | "project" | (string & {})
   projectBootstrap?: string
@@ -97,6 +98,7 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
           commandArg("phpunit-xml", options.phpunitXml ?? `${pluginTarget}/phpunit.xml.dist`),
           commandStringListArg("dependency-mounts", options.dependencyMounts ?? []),
           commandJsonArg("bootstrap-files-json", options.bootstrapFiles ?? []),
+          commandJsonArg("preload-files-json", options.preloadFiles ?? []),
           commandJsonArg("phpunit-args-json", options.phpunitArgs ?? []),
           commandArg("bootstrap-mode", options.bootstrapMode ?? "managed"),
           commandArg("project-bootstrap", options.projectBootstrap ?? ""),

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -15,6 +15,7 @@ export interface PhpunitRunCodeOptions {
   wpConfigDefines: Record<string, unknown>
   dependencyMounts: string[]
   bootstrapFiles: string[]
+  preloadFiles?: string[]
   bootstrapMode: string
   projectBootstrap: string
   multisite: boolean
@@ -301,6 +302,7 @@ $bench_env = json_decode(${JSON.stringify(JSON.stringify(options.env))}, true);
 $wp_config_defines = json_decode(${JSON.stringify(JSON.stringify(options.wpConfigDefines))}, true);
 $dep_mounts = ${JSON.stringify(options.dependencyMounts.join("\\n"))};
 $bootstrap_files = json_decode(${JSON.stringify(JSON.stringify(options.bootstrapFiles))}, true);
+$preload_files = json_decode(${JSON.stringify(JSON.stringify(options.preloadFiles ?? []))}, true);
 $bootstrap_mode = ${JSON.stringify(options.bootstrapMode || "managed")};
 $project_bootstrap = ${JSON.stringify(options.projectBootstrap)};
 $multisite = ${JSON.stringify(options.multisite)};
@@ -1056,6 +1058,29 @@ try {
     pg_stage_ok('load_bootstrap_files');
 } catch (Throwable $e) {
     pg_stage_fail('load_bootstrap_files', $e);
+    exit(1);
+}
+
+pg_stage_begin('load_preload_files');
+try {
+    if (is_array($preload_files)) {
+        foreach ($preload_files as $preload_file) {
+            if (!is_string($preload_file) || $preload_file === '' || strpos($preload_file, '..') !== false || $preload_file[0] !== '/') {
+                pg_log('NOTICE:skipping invalid preload file entry: ' . var_export($preload_file, true));
+                continue;
+            }
+            $preload_real = realpath($preload_file);
+            if ($preload_real === false || strpos($preload_real, '/wordpress/') !== 0 || !is_file($preload_real)) {
+                pg_log('NOTICE:preload file not found under /wordpress: ' . $preload_file);
+                continue;
+            }
+            pg_log('PRELOAD_FILE:' . $preload_file);
+            require_once $preload_real;
+        }
+    }
+    pg_stage_ok('load_preload_files');
+} catch (Throwable $e) {
+    pg_stage_fail('load_preload_files', $e);
     exit(1);
 }
 }

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -921,6 +921,7 @@ export async function runPhpunitCommand({
     wpConfigDefines: jsonObjectArg(args, "wp-config-defines-json"),
     dependencyMounts: commaListArg(args, "dependency-mounts"),
     bootstrapFiles: jsonArrayArg(args, "bootstrap-files-json").filter((value): value is string => typeof value === "string"),
+    preloadFiles: jsonArrayArg(args, "preload-files-json").filter((value): value is string => typeof value === "string"),
     bootstrapMode: argValue(args, "bootstrap-mode")?.trim() || "managed",
     projectBootstrap: argValue(args, "project-bootstrap")?.trim() || "",
     multisite: booleanArg(args, "multisite"),


### PR DESCRIPTION
## Summary
- Add a generic `preloadFiles` option to WordPress PHPUnit recipe building.
- Pass `preload-files-json` through the CLI and runtime command runner.
- Require readable absolute preload files under `/wordpress/` during managed PHPUnit bootstrap.

## Verification
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and validated the generic preload-file implementation with Chris reviewing direction and constraints.