### PR TITLE
Add recipe step metadata evidence

### DIFF
--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -6,7 +6,7 @@ import { serializeError } from "../output.js"
 import { finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeTerminalResultOutput } from "../recipe-evidence.js"
 import { recipeRunFailureStatus, serializeRecipeRunError } from "./recipe-run-output.js"
 import type { RecipeArtifactPointerTracker } from "./recipe-run-artifact-pointers.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeStepFailure } from "./recipe-run-types.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 
 export interface RunResourceCleanupEvidence {
@@ -46,6 +46,7 @@ interface RecipeRunCommonOutputFields {
   distributionStartupProbes?: RecipeRunOutput["distributionStartupProbes"]
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
+  stepFailures?: RecipeStepFailure[]
   phaseEvidence?: RecipePhaseEvidence[]
   advisoryFailures?: RecipeAdvisoryFailure[]
   browserEvidence?: RecipeBrowserEvidence[]
@@ -105,6 +106,7 @@ export function completedRecipeOutputFields(args: {
   distributionStartupProbes: NonNullable<RecipeRunOutput["distributionStartupProbes"]>
   probes: RecipeRunProbe[]
   declaredArtifacts: RecipeRunDeclaredArtifact[]
+  stepFailures?: RecipeStepFailure[]
   phaseEvidence: RecipePhaseEvidence[]
   advisoryFailures: RecipeAdvisoryFailure[]
   browserEvidence: RecipeBrowserEvidence[]
@@ -122,6 +124,7 @@ export function completedRecipeOutputFields(args: {
     ...(args.distributionStartupProbes.length > 0 ? { distributionStartupProbes: args.distributionStartupProbes } : {}),
     probes: args.probes,
     declaredArtifacts: args.declaredArtifacts,
+    ...(args.stepFailures && args.stepFailures.length > 0 ? { stepFailures: args.stepFailures } : {}),
     phaseEvidence: args.phaseEvidence,
     ...(args.advisoryFailures.length > 0 ? { advisoryFailures: args.advisoryFailures } : {}),
     ...(args.browserEvidence.length > 0 ? { browserEvidence: args.browserEvidence } : {}),
@@ -184,7 +187,7 @@ export async function finalizeCompletedRecipeRun(args: FinalizeCompletedRecipeRu
   }) as RecipeRunOutput)
   runRecord = await args.runRegistry.update(args.runRecord.runId, { result: runtimeRunResultFromRecipeSummary(output.result!) })
   output.run = runRecord
-  await args.artifactPointer.update({ commandStatus: args.success ? "completed" : "failed", runtime: args.runtime, artifacts: args.artifacts, failure: args.failure, phases: args.phaseEvidence, browserEvidence: args.browserEvidence, result: output.result })
+  await args.artifactPointer.update({ commandStatus: args.success ? "completed" : "failed", runtime: args.runtime, artifacts: args.artifacts, failure: args.failure, phases: args.phaseEvidence, stepFailures: args.output.stepFailures, browserEvidence: args.browserEvidence, result: output.result })
   return output
 }
 
@@ -210,7 +213,7 @@ export async function finalizeRecoveredRecipeFailure(args: FinalizeRecoveredReci
   }) as RecipeRunOutput)
   runRecord = await args.runRegistry.update(args.runRecord.runId, { result: runtimeRunResultFromRecipeSummary(output.result!) })
   output.run = runRecord
-  await args.artifactPointer.update({ commandStatus: "failed", ...(args.runtime ? { runtime: args.runtime } : {}), ...(args.artifacts ? { artifacts: args.artifacts } : {}), failure: args.serializedError, phases: args.phaseEvidence, browserEvidence: args.browserEvidence, diagnosticArtifacts: args.diagnosticArtifacts, result: output.result })
+  await args.artifactPointer.update({ commandStatus: "failed", ...(args.runtime ? { runtime: args.runtime } : {}), ...(args.artifacts ? { artifacts: args.artifacts } : {}), failure: args.serializedError, phases: args.phaseEvidence, stepFailures: args.output.stepFailures, browserEvidence: args.browserEvidence, diagnosticArtifacts: args.diagnosticArtifacts, result: output.result })
   return output
 }
 

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -60,6 +60,7 @@ export interface RecipeRunOutput {
   distributionStartupProbes?: RecipeRunDistributionStartupProbe[]
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
+  stepFailures?: RecipeStepFailure[]
   phaseEvidence?: RecipePhaseEvidence[]
   advisoryFailures?: RecipeAdvisoryFailure[]
   browserEvidence?: RecipeBrowserEvidence[]
@@ -117,6 +118,7 @@ export type RecipeExecutionResult = ExecutionResult & {
   recipePhase?: RecipeWorkflowPhase
   recipeStepIndex?: number
   recipeCommand?: string
+  recipeStepMetadata?: Record<string, unknown>
   recipeArgs?: RecipeWorkflowArgsEvidence
   recipeAdvisory?: boolean
   fuzzCaseId?: string
@@ -205,6 +207,20 @@ export interface RecipeAdvisoryFailure {
   error: RunOutput["error"]
 }
 
+export interface RecipeStepFailure {
+  schema: "wp-codebox/recipe-step-failure/v1"
+  phase: RecipeWorkflowPhase
+  index: number
+  command: string
+  metadata?: Record<string, unknown>
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  classification: "timeout" | "error"
+  timeoutMs?: number
+  error: RunOutput["error"]
+}
+
 export interface RecipeBrowserEvidenceFileRef {
   path: string
   kind?: string
@@ -217,6 +233,7 @@ export interface RecipeBrowserEvidence {
   phase?: RecipeWorkflowPhase
   index?: number
   command: string
+  metadata?: Record<string, unknown>
   status: "completed" | "failed"
   requestedUrl?: string
   finalUrl?: string
@@ -236,6 +253,7 @@ export interface RecipeArtifactPointerState {
   artifacts?: ArtifactBundle
   failure?: RunOutput["error"]
   phases?: RecipePhaseEvidence[]
+  stepFailures?: RecipeStepFailure[]
   browserEvidence?: RecipeBrowserEvidence[]
   diagnosticArtifacts?: RecipeDiagnosticArtifactRef[]
   result?: RecipeRunSummary

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -9,16 +9,17 @@ import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { recipeWorkflowSteps, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { artifactManifestFilesByPath } from "./recipe-run-benchmark-artifacts.js"
 import { assertResolvedInputMountPathArgs, rewriteInputMountPathArgs, rewriteInputMountPathJsonArgs, type InputMountPathMapping } from "../input-mount-paths.js"
-import { serializeRecipeRunError } from "./recipe-run-output.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe, RecipeWorkflowArgsEvidence } from "./recipe-run-types.js"
+import { RecipeRunTimeoutError, serializeRecipeRunError } from "./recipe-run-output.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe, RecipeStepFailure, RecipeWorkflowArgsEvidence } from "./recipe-run-types.js"
 
-export function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number, recipeCommand?: string, recipeArgs?: RecipeWorkflowArgsEvidence): RecipeExecutionResult {
+export function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number, recipeCommand?: string, recipeArgs?: RecipeWorkflowArgsEvidence, recipeStepMetadata?: Record<string, unknown>): RecipeExecutionResult {
   return {
     ...execution,
     recipePhase,
     recipeStepIndex,
     recipeCommand,
     ...(recipeArgs ? { recipeArgs } : {}),
+    ...(recipeStepMetadata ? { recipeStepMetadata } : {}),
   }
 }
 
@@ -50,6 +51,29 @@ export function recipeAdvisoryFailure(workflowStep: ReturnType<typeof recipeWork
     status: "failed",
     error: serializeRecipeRunError(error),
   }
+}
+
+export function recipeStepFailure(workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], error: unknown, startedAtMs: number, finishedAtMs = Date.now()): RecipeStepFailure {
+  const timeoutError = recipeTimeoutError(error)
+  return stripUndefined({
+    schema: "wp-codebox/recipe-step-failure/v1",
+    phase: workflowStep.phase,
+    index: workflowStep.index,
+    command: workflowStep.step.command,
+    metadata: workflowStep.step.metadata,
+    startedAt: new Date(startedAtMs).toISOString(),
+    finishedAt: new Date(finishedAtMs).toISOString(),
+    durationMs: Math.max(0, finishedAtMs - startedAtMs),
+    classification: timeoutError ? "timeout" as const : "error" as const,
+    timeoutMs: timeoutError?.timeoutMs,
+    error: serializeRecipeRunError(error),
+  }) as RecipeStepFailure
+}
+
+function recipeTimeoutError(error: unknown): RecipeRunTimeoutError | undefined {
+  if (error instanceof RecipeRunTimeoutError) return error
+  if (error instanceof Error && error.cause instanceof RecipeRunTimeoutError) return error.cause
+  return undefined
 }
 
 export async function recipeBrowserEvidence(artifacts: ArtifactBundle, executions: RecipeExecutionResult[], recipe?: WorkspaceRecipe): Promise<RecipeBrowserEvidence[]> {
@@ -96,6 +120,7 @@ function recipeBrowserEvidenceFromParsedExecution(execution: RecipeExecutionResu
     phase: execution.recipePhase,
     index: execution.recipeStepIndex,
     command,
+    metadata: execution.recipeStepMetadata,
     status: execution.exitCode === 0 ? "completed" : "failed",
     requestedUrl: stringValue(parsed.requestedUrl),
     finalUrl: stringValue(parsed.finalUrl ?? summaryObject?.finalUrl),
@@ -154,7 +179,7 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
   const step = { ...workflowStep.step, args: resolvedArgs }
   const argsEvidence = recipeWorkflowArgsEvidence(originalArgs, resolvedArgs)
   const mappedWorkflowStep = { ...workflowStep, step }
-  const phase = (execution: ExecutionResult, command = step.command, evidence = argsEvidence) => withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, command, evidence)
+  const phase = (execution: ExecutionResult, command = step.command, evidence = argsEvidence) => withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, command, evidence, step.metadata)
   try {
     if (step.command === "wp-codebox.agent-fanout") {
       const startedAt = new Date().toISOString()
@@ -197,7 +222,7 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
     const spec = await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace, { inputMountPathMap })
     const execution = await runtime.execute(spec)
     return {
-      ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, step.command, recipeWorkflowArgsEvidence(spec.originalArgs, spec.resolvedArgs)),
+      ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, step.command, recipeWorkflowArgsEvidence(spec.originalArgs, spec.resolvedArgs), step.metadata),
       ...(workflowStep.fuzzCaseId ? { fuzzCaseId: workflowStep.fuzzCaseId } : {}),
       ...(workflowStep.fuzzCaseIndex !== undefined ? { fuzzCaseIndex: workflowStep.fuzzCaseIndex } : {}),
       ...(workflowStep.fuzzPhase ? { fuzzPhase: workflowStep.fuzzPhase } : {}),

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -29,8 +29,8 @@ import { RecipePhaseError } from "./recipe-run-phases.js"
 import { markPreviewLeaseAvailable, markPreviewLeaseFailed, markPreviewLeaseReleased, startPreviewLeaseRecipeRun } from "./preview-lease.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
 import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile, rewriteInputMountPathArgs } from "./recipe-runtime-setup.js"
-import { distributionStartupProbeFailure, executeRecipeCollectWorkloadResult, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowArgsEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeEffectiveRecipeArtifact, RecipeExecutionResult, RecipeFuzzCaseCommandRef, RecipeFuzzCaseResult, RecipeFuzzCaseStatus, RecipeFuzzRunResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunProvenance, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import { distributionStartupProbeFailure, executeRecipeCollectWorkloadResult, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeStepFailure, recipeWorkflowArgsEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeEffectiveRecipeArtifact, RecipeExecutionResult, RecipeFuzzCaseCommandRef, RecipeFuzzCaseResult, RecipeFuzzCaseStatus, RecipeFuzzRunResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunProvenance, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeStepFailure, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
@@ -150,6 +150,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let distributionStartupProbes: RecipeRunDistributionStartupProbe[] = []
   let probes: RecipeRunProbe[] = []
   let declaredArtifacts: RecipeRunDeclaredArtifact[] = []
+  let stepFailures: RecipeStepFailure[] = []
   let advisoryFailures: RecipeAdvisoryFailure[] = []
   let browserEvidence: RecipeBrowserEvidence[] = []
   let artifacts: ArtifactBundle | undefined
@@ -271,13 +272,17 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     await phaseTracker.run("run_workloads", phaseWorkflowData(workflowSteps), async () => {
       for (const workflowStep of workflowSteps) {
         const operation = `workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`
+        const stepStartedAtMs = Date.now()
         try {
           const execution = await awaitRecipe(operation, async () => workflowStep.step.command === "wordpress.collect-workload-result"
-            ? withRecipeExecutionArgs(withRecipeExecutionPhase(executeRecipeCollectWorkloadResult(workflowStep.step, executions, new Date().toISOString()), workflowStep.phase, workflowStep.index, workflowStep.step.command), recipeWorkflowArgsEvidence(workflowStep.step.args, workflowStep.step.args))
+            ? withRecipeExecutionPhase(executeRecipeCollectWorkloadResult(workflowStep.step, executions, new Date().toISOString()), workflowStep.phase, workflowStep.index, workflowStep.step.command, recipeWorkflowArgsEvidence(workflowStep.step.args, workflowStep.step.args), workflowStep.step.metadata)
             : executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options, inputMountPathMap))
           executions.push({ ...execution, ...(recipeWorkflowStepIsAdvisory(workflowStep.step) ? { recipeAdvisory: true } : {}) })
           interruption?.throwIfInterrupted()
         } catch (error) {
+          const failure = recipeStepFailure(workflowStep, error, stepStartedAtMs)
+          stepFailures.push(failure)
+          await artifactPointer.update({ command: operation, commandStatus: "failed", failure: failure.error, phases: phaseTracker.list(), stepFailures })
           if (!recipeWorkflowStepIsAdvisory(workflowStep.step)) {
             throw error
           }
@@ -383,7 +388,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         browserEvidence,
         replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
         failure: recipeFailure,
-        output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), provenance: recipeRunProvenance(recipe, recipePath) },
+        output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, stepFailures, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), provenance: recipeRunProvenance(recipe, recipePath) },
       })
     }
 
@@ -402,7 +407,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       phaseEvidence: phaseTracker.list(),
       browserEvidence,
       replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
-      output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), provenance: recipeRunProvenance(recipe, recipePath) },
+      output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, stepFailures, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), provenance: recipeRunProvenance(recipe, recipePath) },
     })
   } catch (error) {
     await markPreviewLeaseFailed(options.previewLeaseFile, error)
@@ -422,6 +427,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       distributionStartupProbes,
       probes,
       declaredArtifacts,
+      stepFailures,
       phaseEvidence: phaseTracker.list(),
       diagnostics: recipeRuntimeDiagnostics(recipe, executions, error) ?? [],
       error: serializedError,
@@ -514,6 +520,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         distributionStartupProbes,
         probes,
         declaredArtifacts,
+        ...(stepFailures.length > 0 ? { stepFailures } : {}),
         phaseEvidence: phaseTracker.list(),
         ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
         ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
@@ -811,6 +818,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
   distributionStartupProbes: RecipeRunDistributionStartupProbe[]
   probes: RecipeRunProbe[]
   declaredArtifacts: RecipeRunDeclaredArtifact[]
+  stepFailures: RecipeStepFailure[]
   phaseEvidence: RecipePhaseEvidence[]
   diagnostics: RecipeRuntimeDiagnostic[]
   error: RunOutput["error"]
@@ -847,6 +855,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
       distributionStartupProbes: args.distributionStartupProbes,
       probes: args.probes,
       declaredArtifacts: args.declaredArtifacts,
+      stepFailures: args.stepFailures,
       phaseEvidence: args.phaseEvidence,
       diagnostics: args.diagnostics,
       error: args.error,

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -99,6 +99,10 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
       throw new Error(`Recipe workflow ${phase} diagnostics must be an object: ${recipePath}`)
     }
 
+    if (step.metadata !== undefined && (!step.metadata || typeof step.metadata !== "object" || Array.isArray(step.metadata))) {
+      throw new Error(`Recipe workflow ${phase} metadata must be an object: ${recipePath}`)
+    }
+
     if (step.allowFailure !== undefined && typeof step.allowFailure !== "boolean") {
       throw new Error(`Recipe workflow ${phase} allowFailure must be boolean: ${recipePath}`)
     }

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -118,6 +118,7 @@ function normalizeRecipeSteps(steps: readonly WorkspaceRecipeStep[], label: stri
     return {
       command: step.command,
       ...(step.args !== undefined ? { args: step.args } : {}),
+      ...(step.metadata !== undefined ? { metadata: step.metadata } : {}),
       ...(step.allowFailure !== undefined ? { allowFailure: step.allowFailure } : {}),
       ...(step.advisory !== undefined ? { advisory: step.advisory } : {}),
     }

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -43,6 +43,7 @@ export interface RecipeRunCommandSummary {
   duration_ms?: number
   recipe_phase?: string
   recipe_step_index?: number
+  recipe_step_metadata?: Record<string, unknown>
   stdout_tail?: string
   stderr_tail?: string
 }
@@ -233,6 +234,7 @@ function recipeRunCommandSummaries(result: Record<string, unknown>): RecipeRunCo
       duration_ms: numberValue(execution.durationMs),
       recipe_phase: stringValue(execution.recipePhase),
       recipe_step_index: numberValue(execution.recipeStepIndex),
+      recipe_step_metadata: objectOrUndefined(execution.recipeStepMetadata),
       stdout_tail: textTail(execution.stdout),
       stderr_tail: textTail(execution.stderr),
     }) as RecipeRunCommandSummary

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -1109,6 +1109,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             items: { type: "string" },
           },
           diagnostics: { $ref: "#/$defs/commandDiagnosticsCapture" },
+          metadata: { $ref: "#/$defs/metadata" },
           allowFailure: { type: "boolean" },
           advisory: { type: "boolean" },
         },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -254,6 +254,7 @@ export interface WorkspaceRecipeStep {
   command: string
   args?: string[]
   diagnostics?: RuntimeCommandDiagnosticsCaptureSpec
+  metadata?: Record<string, unknown>
   allowFailure?: boolean
   advisory?: boolean
 }

--- a/tests/recipe-step-metadata.test.ts
+++ b/tests/recipe-step-metadata.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+
+import { normalizeRecipeRunSummary, validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { RecipeRunTimeoutError } from "../packages/cli/src/commands/recipe-run-output.js"
+import { recipeStepFailure, withRecipeExecutionPhase } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [{ command: "host/fixture", args: [], metadata: { fixture: "alpha", matrixIndex: 2 } }],
+  },
+}
+
+assert.equal(validateWorkspaceRecipeJsonSchema(recipe).valid, true)
+assert.equal(validateWorkspaceRecipeJsonSchema({ ...recipe, workflow: { steps: [{ command: "host/fixture", metadata: [] }] } }).valid, false)
+
+const execution = withRecipeExecutionPhase({ command: "host/fixture", args: [], exitCode: 0, stdout: "", stderr: "" }, "steps", 0, "host/fixture", undefined, recipe.workflow.steps[0]!.metadata)
+assert.deepEqual(execution.recipeStepMetadata, { fixture: "alpha", matrixIndex: 2 })
+
+const summary = normalizeRecipeRunSummary({
+  success: true,
+  schema: "wp-codebox/recipe-run/v1",
+  executions: [execution],
+})
+assert.deepEqual(summary.commands[0]?.recipe_step_metadata, { fixture: "alpha", matrixIndex: 2 })
+
+const startedAtMs = Date.UTC(2026, 0, 1, 0, 0, 0)
+const timeout = new RecipeRunTimeoutError("workflow.steps[0]:host/fixture", 250, 250)
+const wrapped = new Error("Recipe workflow steps[0] failed: timed out", { cause: timeout })
+const failure = recipeStepFailure({ phase: "steps", index: 0, step: recipe.workflow.steps[0]! }, wrapped, startedAtMs, startedAtMs + 250)
+assert.equal(failure.schema, "wp-codebox/recipe-step-failure/v1")
+assert.equal(failure.phase, "steps")
+assert.equal(failure.index, 0)
+assert.equal(failure.command, "host/fixture")
+assert.deepEqual(failure.metadata, { fixture: "alpha", matrixIndex: 2 })
+assert.equal(failure.startedAt, "2026-01-01T00:00:00.000Z")
+assert.equal(failure.finishedAt, "2026-01-01T00:00:00.250Z")
+assert.equal(failure.durationMs, 250)
+assert.equal(failure.classification, "timeout")
+assert.equal(failure.timeoutMs, 250)
+
+console.log("recipe step metadata contract ok")


### PR DESCRIPTION
## Summary
- Allow generic metadata on workspace recipe steps.
- Propagate step metadata into completed executions, browser evidence, and recipe run summaries.
- Record structured stepFailures for workflow step errors/timeouts so callers can attribute failed steps without parsing console text.

## Testing
- npm exec tsx tests/recipe-step-metadata.test.ts
- npm run test:recipe-validation-descriptors
- npm exec tsx tests/recipe-run-summary-output.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted the recipe metadata/evidence contract, implemented tests, resolved rebase conflicts, and ran verification. Chris remains responsible for review and final changes.
