### PR TITLE
Fix PHPUnit config fallback file entries

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -103,7 +103,7 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
     $files = array();${fallbackXmlDist}
     if (!is_readable($xml_path)) {
         ${options.logFunction}('${options.missingConfigMessage}' . $xml_path . '; using defaults');
-        return array($directories, $suffixes, $prefixes, $excludes);
+        return array($directories, $suffixes, $prefixes, $excludes, $files);
     }
     $prev = libxml_use_internal_errors(true);
     $xml = @simplexml_load_file($xml_path);
@@ -113,7 +113,7 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
     if ($xml === false) {
         $first = $errors ? trim($errors[0]->message) : 'unknown';
         ${parseFailureLog}
-        return array($directories, $suffixes, $prefixes, $excludes);
+        return array($directories, $suffixes, $prefixes, $excludes, $files);
     }
     $base = ${options.basePathExpression};
     $config_dirs = array();

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -96,6 +96,7 @@ assert.ok(projectModeCode.includes("foreach ($xml->xpath('//testsuite/file') ?: 
 assert.ok(projectModeCode.includes("list($directories, $suffixes, $prefixes, $excludes, $configured_files) = wp_codebox_phpunit_parse_config"))
 assert.ok(projectModeCode.includes("$test_files = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes, $configured_files);"))
 assert.ok(projectModeCode.includes("' files=' . count($configured_files)"))
+assert.equal(projectModeCode.match(/return array\(\$directories, \$suffixes, \$prefixes, \$excludes, \$files\);/g)?.length, 3)
 
 const managedModeCode = phpunitRunCode({
   pluginSlug: "demo-plugin",


### PR DESCRIPTION
## Summary
- Return the configured PHPUnit file list from missing/unparseable phpunit.xml fallback paths.
- Add generated-code coverage for the five-value parser contract used by discovery.

## Testing
- \phpunit project autoload ok
- \
> wp-codebox-workspace@0.12.1 build
> node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the Homeboy Extensions PHPUnit discovery TypeError, implemented the minimal WP Codebox fix, and ran focused validation.