### PR TITLE
Fix PHPUnit config fallback tuple discovery

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -100,10 +100,13 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
     $suffixes = array('Test.php');
     $prefixes = array('test-');
     $excludes = array();
-    $files = array();${fallbackXmlDist}
+    $files = array();
+    $return_values = static function() use (&$directories, &$suffixes, &$prefixes, &$excludes, &$files) {
+        return ${returnValues};
+    };${fallbackXmlDist}
     if (!is_readable($xml_path)) {
         ${options.logFunction}('${options.missingConfigMessage}' . $xml_path . '; using defaults');
-        return array($directories, $suffixes, $prefixes, $excludes, $files);
+        return $return_values();
     }
     $prev = libxml_use_internal_errors(true);
     $xml = @simplexml_load_file($xml_path);
@@ -113,7 +116,7 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
     if ($xml === false) {
         $first = $errors ? trim($errors[0]->message) : 'unknown';
         ${parseFailureLog}
-        return array($directories, $suffixes, $prefixes, $excludes, $files);
+        return $return_values();
     }
     $base = ${options.basePathExpression};
     $config_dirs = array();
@@ -157,7 +160,7 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
     if (!empty($config_prefixes)) {
         ${prefixAssignment}
     }
-    return ${returnValues};
+    return $return_values();
 }`
 }
 

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -1,12 +1,68 @@
 import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import { buildWordPressPhpunitRecipe } from "../packages/runtime-core/src/recipe-builders.js"
-import { phpunitRunCode } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
+import { corePhpunitRunCode, phpunitRunCode } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
 import { recipeExtraPluginSourceSubpath } from "../packages/cli/src/recipe-sources.js"
 import { recipeInputMountPathMap, rewriteInputMountPathArgs } from "../packages/cli/src/commands/recipe-runtime-setup.js"
 
 const woocommerceAutoload = "/wordpress/wp-content/plugins/woocommerce/vendor/autoload_packages.php"
+
+function extractPhpFunction(source: string, functionName: string): string {
+  const start = source.indexOf(`function ${functionName}(`)
+  assert.notEqual(start, -1)
+
+  let depth = 0
+  let sawBody = false
+  for (let index = start; index < source.length; index++) {
+    const character = source[index]
+    if (character === "{") {
+      depth++
+      sawBody = true
+    } else if (character === "}") {
+      depth--
+      if (sawBody && depth === 0) {
+        return source.slice(start, index + 1)
+      }
+    }
+  }
+
+  throw new Error(`Could not extract PHP function ${functionName}`)
+}
+
+function phpString(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
+}
+
+function assertPhpunitParseConfigFallbacksReturnFiveTuple(source: string, functionName: string, logFunctionName: string): void {
+  const tempDir = mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-config-"))
+  const malformedXml = join(tempDir, "phpunit.xml.dist")
+  const scriptPath = join(tempDir, "assert-phpunit-config.php")
+  writeFileSync(malformedXml, "<phpunit><testsuites>")
+
+  const parseConfigFunction = extractPhpFunction(source, functionName)
+  writeFileSync(scriptPath, `<?php
+function ${logFunctionName}($message) {}
+${parseConfigFunction}
+function assert_phpunit_config_tuple($tuple, $label) {
+    if (!is_array($tuple) || count($tuple) !== 5) {
+        throw new RuntimeException($label . ' returned ' . gettype($tuple) . ' with ' . (is_array($tuple) ? count($tuple) : 'n/a') . ' values');
+    }
+    if (!is_array($tuple[4])) {
+        throw new RuntimeException($label . ' returned non-array configured files');
+    }
+}
+assert_phpunit_config_tuple(${functionName}(${phpString(join(tempDir, "missing.xml.dist"))}, ${phpString(join(tempDir, "tests"))}), 'missing config');
+assert_phpunit_config_tuple(${functionName}(${phpString(malformedXml)}, ${phpString(join(tempDir, "tests"))}), 'parse failure');
+echo "ok\n";
+`)
+
+  assert.equal(execFileSync("php", [scriptPath], { encoding: "utf8" }), "ok\n")
+}
 
 const recipe = buildWordPressPhpunitRecipe({
   pluginSlug: "woocommerce",
@@ -96,7 +152,26 @@ assert.ok(projectModeCode.includes("foreach ($xml->xpath('//testsuite/file') ?: 
 assert.ok(projectModeCode.includes("list($directories, $suffixes, $prefixes, $excludes, $configured_files) = wp_codebox_phpunit_parse_config"))
 assert.ok(projectModeCode.includes("$test_files = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes, $configured_files);"))
 assert.ok(projectModeCode.includes("' files=' . count($configured_files)"))
-assert.equal(projectModeCode.match(/return array\(\$directories, \$suffixes, \$prefixes, \$excludes, \$files\);/g)?.length, 3)
+assert.equal(projectModeCode.match(/return array\(\$directories, \$suffixes, \$prefixes, \$excludes\);/g)?.length ?? 0, 0)
+assert.equal(projectModeCode.match(/return \$return_values\(\);/g)?.length, 3)
+assertPhpunitParseConfigFallbacksReturnFiveTuple(projectModeCode, "wp_codebox_phpunit_parse_config", "pg_log")
+
+const coreModeCode = corePhpunitRunCode({
+  coreRoot: "/wordpress",
+  testsDir: "/wordpress/tests/phpunit",
+  phpunitXml: "/wordpress/phpunit.xml.dist",
+  selectedTestFile: "",
+  changedTestFiles: [],
+  autoloadFile: "/wp-codebox-vendor/autoload.php",
+  wpConfigDefines: {},
+  multisite: false,
+})
+
+assert.ok(coreModeCode.includes("list($directories, $suffixes, $prefixes, $excludes, $configured_files) = core_pg_parse_phpunit_config"))
+assert.ok(coreModeCode.includes("$test_files = core_pg_discover_tests($directories, $suffixes, $prefixes, $excludes, $configured_files);"))
+assert.equal(coreModeCode.match(/return array\(\$directories, \$suffixes, \$prefixes, \$excludes\);/g)?.length ?? 0, 0)
+assert.equal(coreModeCode.match(/return \$return_values\(\);/g)?.length, 3)
+assertPhpunitParseConfigFallbacksReturnFiveTuple(coreModeCode, "core_pg_parse_phpunit_config", "core_pg_log")
 
 const managedModeCode = phpunitRunCode({
   pluginSlug: "demo-plugin",


### PR DESCRIPTION
## Problem
Downstream static-site-importer CI can fail when PHPUnit config discovery falls back after a missing or malformed phpunit XML file. The generated parser caller destructures five values and passes the fifth value to a typed array parameter, but fallback paths could produce an inconsistent tuple shape.

## Root cause
#1710 added phpunit `<file>` entries to discovery by adding a fifth `$files` tuple entry and a typed fifth discovery argument. The generated config parser had multiple hand-maintained return sites, so fallback returns could drift from the success tuple shape.

## Fix
- Centralized PHPUnit config parser tuple construction behind one generated `$return_values` closure.
- Updated missing-config, XML parse-failure, and success returns to all use the same tuple source.
- Verified both generated parser variants agree with their callers: `wp_codebox_phpunit_parse_config` / `wp_codebox_phpunit_discover` and `core_pg_parse_phpunit_config` / `core_pg_discover_tests`.

## Test evidence
- `npx tsx tests/phpunit-project-autoload.test.ts`
- `npm run build`

The regression test executes the generated PHP parser with `php` for both missing-config and malformed-XML fallback paths and asserts the returned tuple has five values with an array in slot 5. This unblocks static-site-importer CI on main.

Closes #1712

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode subagent, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation, tests, and PR drafting; reviewed by Chris Huber
