### PR TITLE
Expose browser SDK materializer facade methods

### DIFF
--- a/packages/runtime-core/src/materialization-contracts.ts
+++ b/packages/runtime-core/src/materialization-contracts.ts
@@ -295,8 +295,8 @@ export function normalizeMaterializationArtifactRef(input: unknown, defaults: Pa
   }
 
   const kind = stringValue(source.kind ?? source.role ?? source.artifact_type) || defaults.kind
-  const id = stringValue(source.id ?? source.artifact_id) || defaults.id
-  const path = stringValue(source.path ?? source.artifacts_path ?? source.directory) || defaults.path
+  const id = stringValue(source.id ?? source.artifact_id ?? source.artifactId) || defaults.id
+  const path = stringValue(source.path ?? source.artifacts_path ?? source.artifactsPath ?? source.directory) || defaults.path
   const digest = normalizeDigest(source.digest ?? source.contentDigest ?? source.content_digest ?? source.sha256) ?? defaults.digest
 
   if (!id && !path && !digest && !stringValue(source.kind)) {
@@ -410,7 +410,7 @@ function normalizeDigest(input: unknown): MaterializationArtifactRef["digest"] |
   }
   const value = stringValue(input.value)
   const algorithm = stringValue(input.algorithm) || "sha256"
-  return value ? { algorithm, value } : normalizeDigest(input.sha256) ?? normalizeDigest(input.digest)
+  return value ? { algorithm, value } : normalizeDigest(input.sha256) ?? normalizeDigest(input.digest) ?? normalizeDigest(input.contentDigest) ?? normalizeDigest(input.content_digest)
 }
 
 function phaseDiagnostics(phase: MaterializationPhaseResult): MaterializationDiagnostic[] {

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -730,7 +730,7 @@
 		createParentToolRequest: api.createParentToolRequest,
 		dispatchParentTool: api.dispatchParentTool,
 		runBrowserSessionRecipe: async ( client, session, taskPayload, options = {} ) => normalizeBrowserRunResult( await api.runBrowserSessionRecipe( client, session, taskPayload, options ), 'browser-session-recipe' ),
-		setFrontendAdminBarVisible: api.setFrontendAdminBarVisible,
+		setFrontendAdminBarVisible: ( client, args = {}, options = {} ) => api.setFrontendAdminBarVisible( client, args, options ),
 		methods: Object.freeze( {
 			activateTheme: api.activateTheme,
 			browserSessionRecipe: api.browserSessionRecipe,

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -69,11 +69,23 @@ assert.deepEqual(plain(api.v1.info()), {
 assert.equal(api.v1.methods.runPhpRequest, api.runPhpRequest)
 assert.equal(api.v1.methods.writeFile, api.writeFile)
 assert.equal(api.v1.methods.validateBrowserRuntimeMaterialization, api.validateBrowserRuntimeMaterialization)
-assert.equal(api.v1.setFrontendAdminBarVisible, api.setFrontendAdminBarVisible)
+assert.equal(typeof api.v1.setFrontendAdminBarVisible, "function")
 assert.equal(api.v1.methods.setFrontendAdminBarVisible, api.setFrontendAdminBarVisible)
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
 assert.equal(typeof api.v1.startBrowserPreview, "function")
 assert.equal(typeof api.v1.consumeContainedSiteSync, "function")
+const studioNativeConsumedTopLevelMethods = [
+  "consumeContainedSiteSync",
+  "ensureDirectory",
+  "runBrowserSessionRecipe",
+  "runRecipe",
+  "setFrontendAdminBarVisible",
+  "writeFile",
+] as const
+for (const method of studioNativeConsumedTopLevelMethods) {
+  assert.equal(typeof api.v1[method], "function", `Studio Native consumes wpCodeboxBrowser.v1.${method} top-level`)
+}
+assert.equal(Object.isFrozen(api.v1), true, "browser SDK v1 facade remains frozen")
 assert.equal(typeof api.v1.bootExecutableBrowserSession, "function")
 assert.equal(typeof api.v1.createBrowserConnectorRequest, "function")
 assert.equal(typeof api.v1.executeBrowserConnectorRequest, "function")


### PR DESCRIPTION
## Root cause

`packages/wordpress-plugin/assets/browser-runtime.js:699` builds the frozen `window.wpCodeboxBrowser.v1` facade. Studio Native validates required capabilities directly on that top-level facade, but the real regression coverage did not assert the complete consumed top-level contract. This change keeps `v1.methods` intact and makes the `setFrontendAdminBarVisible` top-level entry match the thin passthrough style at `packages/wordpress-plugin/assets/browser-runtime.js:733`.

While running the real facade test, it also exposed a runtime-core/browser-runtime artifact ref normalization parity gap: runtime-core did not accept `artifactId`, `artifactsPath`, or nested `contentDigest` / `content_digest` aliases, producing a duplicate digest-less artifact ref. That parity fix is in `packages/runtime-core/src/materialization-contracts.ts:298` and `packages/runtime-core/src/materialization-contracts.ts:413`.

## Consumed-method audit

| Consumer | Capability | Top-level facade status | Notes |
| --- | --- | --- | --- |
| `plugins/host/studio-native/assets/browser-materializer.js:59` | `ensureDirectory` | Present | Thin passthrough to `api.ensureDirectory`; raw result, no browser-run normalization. |
| `plugins/host/studio-native/assets/browser-materializer.js:65` | `writeFile` | Present | Thin passthrough to `api.writeFile`; raw result, no browser-run normalization. |
| `plugins/host/studio-native/assets/browser-materializer.js:71` | `runBrowserSessionRecipe` | Present | Facade normalizes through `normalizeBrowserRunResult`, matching existing facade behavior. |
| `plugins/host/studio-native/assets/browser-materializer.js:107` | `consumeContainedSiteSync` | Present | Existing SDK method, top-level passthrough to `api.consumeContainedSiteSync`. |
| `plugins/host/studio-native/assets/browser-materializer.js:131` | `runRecipe` | Present | Thin passthrough to `api.runRecipe`; raw result, no browser-run normalization. |
| `plugins/host/studio-native/assets/browser-materializer.js:438` | `setFrontendAdminBarVisible` | Present | Thin passthrough to `api.setFrontendAdminBarVisible`; raw result, no browser-run normalization. |

No other `window.wpCodeboxBrowser.v1.` direct usages were found under `plugins/host/studio-native/assets/`.

## Tests

- `perl -e 'alarm shift; exec @ARGV' 300 npm run test:browser-sdk-facade`\n\nFixes #1714\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode — orchestrated by Claude (claude-fable-5), implementation by GPT-5.5 subagent\n- **Used for:** Root-caused and fixed the v1 facade top-level method gap with facade tests; reviewed by Chris.