### PR TITLE
Expose contained-site open in browser SDK

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -394,6 +394,18 @@
 		return new URL( '/wp-json/wp-codebox/v1/runtime-task', window.location.origin ).toString();
 	};
 
+	const abilityRestPath = ( abilityName ) => `/wp-abilities/v1/abilities/${ String( abilityName || '' ).replace( /^\/+|\/+$/g, '' ) }/run`;
+
+	const abilityRestEndpoint = ( abilityName ) => {
+		const root = window.wpApiSettings?.root || window.wp?.apiFetch?.root;
+		const path = abilityRestPath( abilityName ).replace( /^\//, '' );
+		if ( typeof root === 'string' && root ) {
+			return new URL( path, root ).toString();
+		}
+
+		return new URL( `/wp-json/${ path }`, window.location.origin ).toString();
+	};
+
 	const codeboxRestHeaders = () => {
 		const nonce = window.wpApiSettings?.nonce;
 		return {
@@ -458,6 +470,37 @@
 
 		return data;
 	};
+
+	const executeRestAbility = async ( abilityName, input = {}, options = {} ) => {
+		if ( typeof options.executeAbility === 'function' ) {
+			return options.executeAbility( abilityName, input );
+		}
+		if ( window.wp?.apiFetch ) {
+			return window.wp.apiFetch( {
+				path: abilityRestPath( abilityName ),
+				method: 'POST',
+				data: { input },
+			} );
+		}
+		if ( typeof fetch !== 'function' ) {
+			throw runtimeError( 'ability_run', 'ability_fetch_unavailable', 'Browser fetch or wp.apiFetch is required to run abilities.' );
+		}
+
+		const response = await fetch( abilityRestEndpoint( abilityName ), {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: codeboxRestHeaders(),
+			body: JSON.stringify( { input } ),
+		} );
+		const data = await response.json().catch( () => null );
+		if ( ! response.ok ) {
+			throw runtimeError( 'ability_run', data?.code || 'ability_request_failed', data?.message || `Ability request failed: ${ abilityName }`, { status: response.status, response: data } );
+		}
+
+		return data;
+	};
+
+	const openOrCreateBrowserContainedSite = async ( input = {}, options = {} ) => executeRestAbility( 'wp-codebox/open-or-create-browser-contained-site', input, options );
 
 	const containedSiteSyncRoute = ( delegation, name ) => {
 		const route = String( delegation?.routes?.[ name ] || '' );
@@ -709,6 +752,7 @@
 		createRuntimeTaskRequest,
 		runRuntimeTask,
 		consumeContainedSiteSync: ( client, delegation, options = {} ) => api.consumeContainedSiteSync( client, delegation, options ),
+		openOrCreateBrowserContainedSite: ( input = {}, options = {} ) => api.openOrCreateBrowserContainedSite( input, options ),
 		startBrowserPreview: ( input, options = {} ) => api.startBrowserPreview( input, options ),
 		aggregateFanoutOutputs: ( input ) => api.aggregateFanoutOutputs( input ),
 		validateBrowserRuntimeMaterialization: ( client, session, options = {} ) => api.validateBrowserRuntimeMaterialization( client, session, options ),
@@ -738,6 +782,7 @@
 			executeBrowserConnectorRequest: api.executeBrowserConnectorRequest,
 			executeBrowserProviderProxyRequest: api.executeBrowserProviderProxyRequest,
 			consumeContainedSiteSync: api.consumeContainedSiteSync,
+			openOrCreateBrowserContainedSite: api.openOrCreateBrowserContainedSite,
 			startBrowserPreview: api.startBrowserPreview,
 			bootExecutableBrowserSession: api.bootExecutableBrowserSession,
 			createParentToolRequest: api.createParentToolRequest,
@@ -3084,6 +3129,7 @@ echo wp_json_encode( array(
 		browserSessionRecipe,
 		bootExecutableBrowserSession,
 		consumeContainedSiteSync,
+		openOrCreateBrowserContainedSite,
 		createBrowserConnectorRequest: browserConnectorRequest,
 		executeBrowserConnectorRequest,
 		executeBrowserProviderProxyRequest,

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -74,9 +74,11 @@ assert.equal(api.v1.methods.setFrontendAdminBarVisible, api.setFrontendAdminBarV
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
 assert.equal(typeof api.v1.startBrowserPreview, "function")
 assert.equal(typeof api.v1.consumeContainedSiteSync, "function")
+assert.equal(typeof api.v1.openOrCreateBrowserContainedSite, "function")
 const studioNativeConsumedTopLevelMethods = [
   "consumeContainedSiteSync",
   "ensureDirectory",
+  "openOrCreateBrowserContainedSite",
   "runBrowserSessionRecipe",
   "runRecipe",
   "setFrontendAdminBarVisible",
@@ -149,6 +151,26 @@ assert.deepEqual(plain(browserRun.artifactRefs), [
   { kind: "browser-html", path: "files/browser/index.html", digest: { algorithm: "sha256", value: "def" } },
 ])
 assert.equal(api.v1.browserArtifactPersistenceRef(browserRun.result).schema, "wp-codebox/browser-artifact-persistence/ref/v1")
+
+const previousAbilityWp = sandbox.window.wp
+let abilityRequest: { path?: string, method?: string, data?: unknown } | null = null
+sandbox.window.wp = {
+  apiFetch: async (request: { path?: string, method?: string, data?: unknown }) => {
+    abilityRequest = request
+    return { schema: "wp-codebox/browser-contained-site-open-or-create/v1", success: true, action: "opened" }
+  },
+}
+const containedSiteOpen = await api.v1.openOrCreateBrowserContainedSite({
+  mode: "open-only",
+  contained_site: { site_id: "site-1" },
+})
+assert.deepEqual(plain(containedSiteOpen), { schema: "wp-codebox/browser-contained-site-open-or-create/v1", success: true, action: "opened" })
+assert.deepEqual(plain(abilityRequest), {
+  path: "/wp-abilities/v1/abilities/wp-codebox/open-or-create-browser-contained-site/run",
+  method: "POST",
+  data: { input: { mode: "open-only", contained_site: { site_id: "site-1" } } },
+})
+sandbox.window.wp = previousAbilityWp
 
 const previousFetch = (sandbox as any).fetch
 const requestedRoutes: Array<{ route: string, method: string, body?: string }> = []


### PR DESCRIPTION
## Summary
- Exposes `openOrCreateBrowserContainedSite` on `window.wpCodeboxBrowser.v1` and the legacy method map.
- Routes the browser SDK method through the WordPress Abilities REST runner for `wp-codebox/open-or-create-browser-contained-site`.
- Extends the browser SDK facade test to cover the exact Studio Native-consumed top-level method and REST payload.

## Testing
- `perl -e 'alarm shift; exec @ARGV' 300 npm run test:browser-sdk-facade`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — orchestrated by Claude (claude-fable-5), implementation by GPT-5.5 subagent
- **Used for:** Root-cause analysis, patch drafting, targeted test update, and verification.