### PR TITLE
Advertise front-page editor target

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -1260,7 +1260,7 @@ export const commandRegistry = [
     id: "wordpress.editor-open",
     description: "Open a generic WordPress block editor target and capture replayable editor evidence artifacts.",
     acceptedArgs: [
-      { name: "target", description: "Editor target to open; defaults to post-new.", format: "post-new|site" },
+      { name: "target", description: "Editor target to open; defaults to post-new. Use front-page to open the site's configured static front page.", format: "post-new|site|front-page" },
       { name: "post-id", description: "Existing post ID to open in the post editor.", format: "positive integer" },
       { name: "post-type", description: "Post type for post-new or post-id targets; defaults to post.", format: "post type slug" },
       { name: "url", description: "Explicit editor path or absolute URL to open instead of resolving a target.", format: "path or URL" },
@@ -1277,7 +1277,7 @@ export const commandRegistry = [
     id: "wordpress.editor-actions",
     description: "Open a generic WordPress block editor target, run a bounded editor action script, and capture replayable mutation evidence artifacts.",
     acceptedArgs: [
-      { name: "target", description: "Editor target to open; defaults to post-new.", format: "post-new|site" },
+      { name: "target", description: "Editor target to open; defaults to post-new. Use front-page to open the site's configured static front page.", format: "post-new|site|front-page" },
       { name: "post-id", description: "Existing post ID to open in the post editor.", format: "positive integer" },
       { name: "post-type", description: "Post type for post-new or post-id targets; defaults to post.", format: "post type slug" },
       { name: "url", description: "Explicit editor path or absolute URL to open instead of resolving a target.", format: "path or URL" },
@@ -1300,7 +1300,7 @@ export const commandRegistry = [
     acceptedArgs: [
       { name: "content", description: "Serialized block markup to validate. When omitted, the command validates the opened post's edited content.", format: "string" },
       { name: "content-file", description: "Path to a file whose serialized block markup should be validated instead of inline content.", format: "path" },
-      { name: "target", description: "Editor target to open; defaults to post-new.", format: "post-new|site" },
+      { name: "target", description: "Editor target to open; defaults to post-new. Use front-page to open the site's configured static front page.", format: "post-new|site|front-page" },
       { name: "post-id", description: "Existing post ID to open in the post editor. The post's edited content is validated when content is not supplied.", format: "positive integer" },
       { name: "post-type", description: "Post type for post-new or post-id targets; defaults to post.", format: "post type slug" },
       { name: "url", description: "Explicit editor path or absolute URL to open instead of resolving a target.", format: "path or URL" },

--- a/packages/runtime-playground/src/editor-actions.ts
+++ b/packages/runtime-playground/src/editor-actions.ts
@@ -46,7 +46,7 @@ export function editorOpenTargetFromArgs(args: string[]): EditorOpenTarget {
   // The site's static front page (`page_on_front`). Its concrete post id is only
   // known at runtime — e.g. after an importer materializes pages and points
   // `page_on_front` at the imported home page — so the URL is resolved against
-  // the running WordPress by `resolveEditorOpenTargetUrl` before navigation,
+  // the running WordPress by `resolveEditorOpenTarget` before navigation,
   // turning into `post.php?post=<page_on_front>&action=edit`. This lets a recipe
   // open and validate the actual imported front page without knowing its id when
   // the recipe is built.


### PR DESCRIPTION
## Summary
- Documents the existing generic target=front-page editor target in the command registry for wordpress.editor-open, wordpress.editor-actions, and wordpress.editor-validate-blocks.
- Keeps the runtime behavior generic: the resolver opens the configured WordPress static front page instead of requiring recipe step output interpolation.
- Fixes a stale source comment naming the resolver.

## Context
SSI editor-fidelity gate needs to open the imported front-page post in the WordPress block editor and capture editor evidence. Workspace recipes are static JSON, so they cannot interpolate a post ID emitted by an earlier import step into a later editor command. The generic resolver target avoids that larger templating surface: recipes can request target=front-page, and wp-codebox resolves show_on_front=page plus page_on_front inside the sandbox at execution time.

Current origin/main already contains the runtime resolver and focused tests for target=front-page; this PR completes the discoverable command surface so recipe/tool introspection advertises the target.

## Tests
- npm run test:editor-actions
- npm run test:recipe-validation-descriptors
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Diagnosing the recipe interpolation gap and designing the front-page editor-open resolver