### PR TITLE
Support mu-plugin local package URLs

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -45,6 +45,28 @@ private static function normalize_browser_mu_plugins( array $mu_plugins ): array
 					'source' => 'runtime-mu-plugin-path',
 					'path'   => $source_path,
 				);
+			} elseif ( '' !== $source_url && ! empty( $mu_plugin['local_package'] ) ) {
+				$source = self::browser_local_plugin_url( $source_url, $index );
+				if ( is_wp_error( $source ) ) {
+					return $source;
+				}
+
+				$sha256 = strtolower( trim( (string) ( $mu_plugin['sha256'] ?? '' ) ) );
+				if ( '' !== $sha256 && ! preg_match( '/^[a-f0-9]{64}$/', $sha256 ) ) {
+					return new WP_Error( 'wp_codebox_browser_mu_plugin_sha256_invalid', 'Browser mu-plugin sha256 must be a 64-character hex digest.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
+				}
+
+				$package    = array(
+					'url'       => $source['url'],
+					'fetch_url' => $source['url'],
+					'path'      => '',
+					'sha256'    => $sha256,
+				);
+				$provenance = array(
+					'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
+					'source' => 'runtime-mu-plugin-local-package-url',
+					'url'    => $source_url,
+				);
 			} elseif ( '' !== $source_url ) {
 				$package    = self::browser_remote_mu_plugin_package( $slug, $source_url, $index, (string) ( $mu_plugin['sha256'] ?? '' ) );
 				$provenance = array(

--- a/scripts/php-browser-runtime-local-package-smoke.php
+++ b/scripts/php-browser-runtime-local-package-smoke.php
@@ -210,5 +210,36 @@ if ( 'https://example.test/runtime.zip' !== ( $remote_entry['provenance']['url']
 	fail( 'Expected remote package provenance to keep the source URL.' );
 }
 
+$local_url = WP_Codebox_Browser_Runtime_Local_Package_Smoke::normalize(
+	array(
+		array(
+			'slug'          => 'runtime-smoke',
+			'file'          => 'runtime-smoke.php',
+			'url'           => 'https://example.test/runtime.zip',
+			'sha256'        => $sha256,
+			'entry'         => 'runtime-smoke/runtime-smoke.php',
+			'local_package' => true,
+		),
+	)
+);
+
+if ( is_wp_error( $local_url ) ) {
+	fail( 'Expected local package URL normalization to succeed, got ' . $local_url->get_error_code() . ': ' . $local_url->get_error_message() );
+}
+
+$local_url_entry = $local_url[0] ?? array();
+if ( 'https://example.test/runtime.zip' !== ( $local_url_entry['url'] ?? '' ) ) {
+	fail( 'Expected mu-plugin local_package URL mode to preserve the source URL.' );
+}
+if ( ( $local_url_entry['sha256'] ?? '' ) !== $sha256 ) {
+	fail( 'Expected mu-plugin local_package URL mode to preserve the expected sha256.' );
+}
+if ( ( $local_url_entry['local_package_fetch_url'] ?? '' ) !== 'https://example.test/runtime.zip' ) {
+	fail( 'Expected mu-plugin local_package URL mode to expose the browser fetch URL.' );
+}
+if ( ( $local_url_entry['provenance']['source'] ?? '' ) !== 'runtime-mu-plugin-local-package-url' ) {
+	fail( 'Expected mu-plugin local_package URL provenance.' );
+}
+
 remove_tree( $root );
 fwrite( STDOUT, "PHP browser runtime local package smoke passed\n" );


### PR DESCRIPTION
## Summary

WordPress Build needs to serve Static Site Importer to Playground as a URL, never as an inline `data:application/zip;base64` blueprint payload. WP Codebox already supports `local_package` URL mode for regular browser runtime plugins, but browser runtime `mu_plugins` ignored that flag and always treated remote URLs as server-downloadable packages. On protected WP Cloud runtimes that fails with HTTP 403 and, when reachable, rewrites the package into a data URL.

This PR extends the same URL-preserving `local_package` behavior to packaged browser runtime mu-plugins:

- validates the supplied absolute URL through the existing local package URL validator
- preserves the caller-provided URL and expected sha256
- marks provenance as `runtime-mu-plugin-local-package-url`
- avoids server-side predownload/data-url rewrite for this mode

## Verification

- `php scripts/php-browser-runtime-local-package-smoke.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php`
- `php -l scripts/php-browser-runtime-local-package-smoke.php`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** opencode orchestrated by Claude (claude-fable-5), implementation by GPT-5.5 subagent
- **Used for:** Debugging the WordPress Build package delivery blocker, upstream fix, regression test, and PR writeup