### PR TITLE
Guard browser PHP runner without a client

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -1921,10 +1921,10 @@ try {
 			throw runtimeError( 'validate', 'php_code_missing', 'PHP code is required.' );
 		}
 
-		if ( ! options.forceRequest && typeof client.run === 'function' ) {
+		if ( ! options.forceRequest && typeof client?.run === 'function' ) {
 			return await runPhpDirect( client, code, options );
 		}
-		if ( options.forceRequest && typeof client?.writeFile !== 'function' && typeof client.run === 'function' ) {
+		if ( options.forceRequest && typeof client?.writeFile !== 'function' && typeof client?.run === 'function' ) {
 			return await runPhpDirect( client, code, options );
 		}
 
@@ -1944,7 +1944,7 @@ try {
 		try {
 			response = await playgroundRequest( client, request );
 		} catch ( error ) {
-			if ( options.forceRequest && typeof client.run === 'function' && isPlaygroundStructuredCloneError( error ) ) {
+			if ( options.forceRequest && typeof client?.run === 'function' && isPlaygroundStructuredCloneError( error ) ) {
 				return await runPhpDirect( client, code, options );
 			}
 


### PR DESCRIPTION
## Summary
- guard browser PHP runner direct-run fallbacks when the Playground client is null or unavailable
- preserves the existing request-handler fallback and structured runtime error path instead of throwing a raw TypeError

## Testing
- node --check packages/wordpress-plugin/assets/browser-runtime.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode, GPT-5.5
- **Used for:** Identified the null-client runner guard from downstream WP Build e2e evidence and drafted the minimal fix.