### PR TITLE
Wait for editor canvas content before screenshot

### DIFF
--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -536,6 +536,7 @@ export async function runEditorOpenCommand({
   let viewport: BrowserProbeViewport | null = null
   let editorState: EditorStateSnapshot | undefined
   let editorValidity: EditorValidityArtifact | undefined
+  let editorCanvasReadiness: BrowserEditorCanvasProbeSummary | undefined
   let authSummary: BrowserProbeAuthSummary | undefined
   let pendingError: Error | undefined
   let artifact: BrowserArtifact | undefined
@@ -576,8 +577,11 @@ export async function runEditorOpenCommand({
       const waitStartedAtMs = Date.now()
       try {
         await waitForAnyVisibleSelector(page, target.waitSelector, waitTimeoutMs)
+        editorCanvasReadiness = await waitForEditorOpenCanvasReadiness(page, target.waitSelector, waitTimeoutMs)
         finalUrl = page.url()
-        stepRecords.push(browserStepRecord(1, { kind: "waitFor", selector: target.waitSelector }, "ok", waitStartedAt, waitStartedAtMs, finalUrl, {}))
+        stepRecords.push(browserStepRecord(1, { kind: "waitFor", selector: target.waitSelector }, "ok", waitStartedAt, waitStartedAtMs, finalUrl, {
+          ...(editorCanvasReadiness ? { editorCanvas: editorCanvasReadiness } : {}),
+        } as never))
       } catch (error) {
         const serialized = serializeBrowserError("probe-error", error)
         errors.push(serialized)
@@ -600,7 +604,16 @@ export async function runEditorOpenCommand({
       htmlSha256 = sha256(Buffer.from(html, "utf8"))
     }
     if (capture.has("screenshot")) {
-      await artifactSession.writeGenerated("screenshot", "editor-screenshot.png", (path) => page.screenshot({ path, fullPage: true }).then(() => undefined))
+      await artifactSession.writeGenerated("screenshot", "editor-screenshot.png", async (path) => {
+        if (editorCanvasReadiness?.ready) {
+          const frame = await resolveEditorCanvasFrame(page, target.waitSelector)
+          if (frame) {
+            await frame.locator(EDITOR_CANVAS_DEFAULT_LAYOUT_SELECTOR).first().screenshot({ path, timeout: waitTimeoutMs })
+            return
+          }
+        }
+        await page.screenshot({ path, fullPage: true })
+      })
       screenshotSha256 = await fileSha256(screenshotPath)
     }
   } finally {
@@ -648,6 +661,7 @@ export async function runEditorOpenCommand({
         screenshot: capture.has("screenshot"),
         ...(editorSummary ? { editor: editorSummary } : {}),
         ...(editorValidity ? { editorValidity: editorValidity.summary } : {}),
+        ...(editorCanvasReadiness ? { editorCanvas: editorCanvasReadiness } : {}),
         viewport,
       },
     }
@@ -693,6 +707,26 @@ export async function runEditorOpenCommand({
       steps: stepRecords,
     }, null, 2)}\n`,
   }
+}
+
+async function waitForEditorOpenCanvasReadiness(page: import("playwright").Page, waitSelector: string, timeoutMs: number): Promise<BrowserEditorCanvasProbeSummary | undefined> {
+  if (!waitSelector.includes("editor-canvas")) {
+    return undefined
+  }
+
+  const probe = await waitForEditorCanvasProbe(page, {
+    blockSelector: EDITOR_CANVAS_DEFAULT_BLOCK_SELECTOR,
+    iframeSelector: waitSelector,
+    layoutSelector: EDITOR_CANVAS_DEFAULT_LAYOUT_SELECTOR,
+    selectorGroups: editorCanvasSelectorGroups([], EDITOR_CANVAS_DEFAULT_LAYOUT_SELECTOR, EDITOR_CANVAS_DEFAULT_BLOCK_SELECTOR),
+    startedAtMs: Date.now(),
+    timeoutMs,
+  })
+  if (!probe.summary.ready) {
+    throw new Error(`Editor canvas was not ready: ${probe.summary.diagnostics.map((diagnostic) => diagnostic.code).join(", ") || "not-ready"}`)
+  }
+
+  return probe.summary
 }
 
 export async function runEditorActionsCommand({


### PR DESCRIPTION
## Summary

This fixes `wordpress.editor-open` capture readiness for Gutenberg editor screenshots.

## Root cause

`wordpress.editor-open` waited only for the outer `iframe[name="editor-canvas"]` shell, then captured the surrounding admin editor chrome. That made editor-fidelity runs deterministically capture a blank/grey canvas and report false ~90% visual mismatches, even when the imported blocks were present and valid (`blockCount` 9, 211/211 valid).

## Fix

The editor-open action is now frame-aware when the wait target is `editor-canvas`:

- waits inside the Gutenberg iframe for `.block-editor-block-list__layout`
- waits for real block nodes before declaring the canvas ready
- records `summary.editorCanvas` readiness details
- screenshots the canvas layout region instead of the admin chrome, with full-page capture retained as the fallback when a ready canvas is unavailable

## Proof

Before: editor screenshots showed blank admin chrome/grey canvas despite valid imported blocks.

After: editor screenshots show the imported page content inside the canvas; Driftwood Roasters / Mara Vale content is visible, and `editorCanvas.ready` is `true`.

## Why this matters

This unblocks trustworthy editor-to-frontend fidelity measurement for HTML-to-WordPress import validation at fixture-matrix scale. Without frame-aware canvas readiness, the editor parity gate measures screenshot timing/chrome capture failure rather than real Gutenberg rendering fidelity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-causing the blank editor-canvas capture and implementing frame-aware canvas readiness + screenshot