### PR TITLE
Fix project PHPUnit autoload default

### DIFF
--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -905,11 +905,13 @@ export async function runPhpunitCommand({
   const args = spec.args ?? []
   const explicitCode = argValue(args, "code") || argValue(args, "code-file")
   const pluginSlug = argValue(args, "plugin-slug")?.trim() || ""
+  const bootstrapMode = argValue(args, "bootstrap-mode")?.trim() || "managed"
+  const autoloadFile = argValue(args, "autoload-file")?.trim() || (bootstrapMode === "project" ? "" : "/wp-codebox-vendor/autoload.php")
   const resultFile = PLUGIN_PHPUNIT_RESULT_FILE
   const code = explicitCode ? await phpCodeFromArgs(args, "wordpress.phpunit") : normalizePhpCode(phpunitRunCode({
     pluginSlug,
     cwd: argValue(args, "cwd")?.trim() || `/wordpress/wp-content/plugins/${pluginSlug}`,
-    autoloadFile: argValue(args, "autoload-file")?.trim() || "/wp-codebox-vendor/autoload.php",
+    autoloadFile,
     projectAutoloadFile: argValue(args, "project-autoload-file")?.trim() || "",
     testsDir: argValue(args, "tests-dir")?.trim() || "/wp-codebox-vendor/wp-phpunit/wp-phpunit",
     testRoot: argValue(args, "test-root")?.trim() || `/wordpress/wp-content/plugins/${pluginSlug}/tests`,
@@ -922,7 +924,7 @@ export async function runPhpunitCommand({
     dependencyMounts: commaListArg(args, "dependency-mounts"),
     bootstrapFiles: jsonArrayArg(args, "bootstrap-files-json").filter((value): value is string => typeof value === "string"),
     preloadFiles: jsonArrayArg(args, "preload-files-json").filter((value): value is string => typeof value === "string"),
-    bootstrapMode: argValue(args, "bootstrap-mode")?.trim() || "managed",
+    bootstrapMode,
     projectBootstrap: argValue(args, "project-bootstrap")?.trim() || "",
     multisite: booleanArg(args, "multisite"),
     resultFile,

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path"
 
 import { buildWordPressPhpunitRecipe } from "../packages/runtime-core/src/recipe-builders.js"
 import { corePhpunitRunCode, phpunitRunCode } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
+import { runPhpunitCommand } from "../packages/runtime-playground/src/wordpress-command-runners.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
 import { recipeExtraPluginSourceSubpath } from "../packages/cli/src/recipe-sources.js"
 import { recipeInputMountPathMap, rewriteInputMountPathArgs } from "../packages/cli/src/commands/recipe-runtime-setup.js"
@@ -155,6 +156,28 @@ assert.ok(projectModeCode.includes("' files=' . count($configured_files)"))
 assert.equal(projectModeCode.match(/return array\(\$directories, \$suffixes, \$prefixes, \$excludes\);/g)?.length ?? 0, 0)
 assert.equal(projectModeCode.match(/return \$return_values\(\);/g)?.length, 3)
 assertPhpunitParseConfigFallbacksReturnFiveTuple(projectModeCode, "wp_codebox_phpunit_parse_config", "pg_log")
+
+let capturedDefaultProjectCode = ""
+await runPhpunitCommand({
+  artifactRoot: mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-artifacts-")),
+  mounts: [],
+  runPlaygroundCommand: async (_command, _server, input) => {
+    capturedDefaultProjectCode = input.code
+    return { text: "ok", exitCode: 0 }
+  },
+  server: { playground: {} } as never,
+  spec: {
+    command: "wordpress.phpunit",
+    args: [
+      "plugin-slug=ai-provider-for-openai",
+      "bootstrap-mode=project",
+      "phpunit-xml=phpunit.xml.dist",
+      "test-file=tests/unit/Models/OpenAiEmbeddingGenerationModelTest.php",
+    ],
+  },
+})
+assert.ok(capturedDefaultProjectCode.includes('$autoload_file = "";'))
+assert.ok(capturedDefaultProjectCode.includes("NOTICE:project bootstrap mode continuing without configured PHPUnit harness autoload"))
 
 const coreModeCode = corePhpunitRunCode({
   coreRoot: "/wordpress",


### PR DESCRIPTION
## Summary

Fixes #1728.

When `wordpress.phpunit` runs in `bootstrap-mode=project`, it no longer defaults `autoload-file` to the internal `/wp-codebox-vendor/autoload.php` path that is missing in Playground runtimes. Managed bootstrap mode keeps the existing default.

## Tests

- `npm exec -- tsx tests/phpunit-project-autoload.test.ts`
  - Result: passed (`phpunit project autoload ok`)
- `npm run build`
  - Result: passed

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the existing local fix, adding/verifying the focused regression coverage, and preparing this PR.