### PR TITLE
Preserve strict_types for run-php code files

### DIFF
--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -25,8 +25,10 @@ export function bootstrapPhpCode(spec: RuntimeCreateSpec, code: string, args: st
     return code
   }
 
+  const command = splitLeadingStrictTypesDeclare(code)
+
   return `<?php
-${phpFatalDiagnosticPhp()}
+${command.strictTypesDeclare ? `${command.strictTypesDeclare}\n` : ""}${phpFatalDiagnosticPhp()}
 ${pluginRuntimeBootstrapPhp(spec)}
 ${saveQueriesBootstrapPhp(args)}
 ${runtimeEnvPhp(spec)}
@@ -37,7 +39,16 @@ ${recipeActivePluginBootstrapPhp(spec, args)}
 ${wpCliBridge ? `putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_URL=${wpCliBridge.url}`)});
 putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)});
 ` : ""}
-${phpBody(code)}`
+${command.body}`
+}
+
+export function splitLeadingStrictTypesDeclare(code: string): { strictTypesDeclare: string; body: string } {
+  const normalized = normalizePhpCode(code)
+  const match = normalized.match(/^<\?php\s*(declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;)\s*/i)
+
+  return match
+    ? { strictTypesDeclare: match[1], body: normalized.slice(match[0].length) }
+    : { strictTypesDeclare: "", body: phpBody(normalized) }
 }
 
 function saveQueriesBootstrapPhp(args: string[]): string {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -49,7 +49,7 @@ import {
   themeCheckRunCode,
   themeSetupInputFromArgs,
 } from "./commands.js"
-import { bootstrapAbilityPhpCode, bootstrapPhpCode, phpCodeFromArgs } from "./php-bootstrap.js"
+import { bootstrapAbilityPhpCode, bootstrapPhpCode, phpCodeFromArgs, splitLeadingStrictTypesDeclare } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { persistCorePhpunitResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitDiagnostic } from "./runtime-diagnostics.js"
@@ -150,12 +150,14 @@ interface RunPhpDiagnosticsPayload {
 }
 
 function runPhpCommandDiagnosticsPhp(code: string, marker: string, maxItems: number, maxBytes: number): string {
+  const command = splitLeadingStrictTypesDeclare(code)
+
   return `
-$wp_codebox_command_observation_started_at = gmdate('Y-m-d\\TH:i:s.v\\Z');
+${command.strictTypesDeclare ? `${command.strictTypesDeclare}\n` : ""}$wp_codebox_command_observation_started_at = gmdate('Y-m-d\\TH:i:s.v\\Z');
 $wp_codebox_command_observation_start_time = microtime(true);
 $wp_codebox_command_observation_start_memory = memory_get_usage(true);
 $wp_codebox_command_diagnostics_start = isset($GLOBALS['wpdb']->queries) && is_array($GLOBALS['wpdb']->queries) ? count($GLOBALS['wpdb']->queries) : 0;
-${code.replace(/^<\?php\s*/, "")}
+${command.body}
 $wp_codebox_command_observation_finished_at = gmdate('Y-m-d\\TH:i:s.v\\Z');
 $wp_codebox_command_observation_duration_ms = round((microtime(true) - $wp_codebox_command_observation_start_time) * 1000, 3);
 $wp_codebox_command_observation_end_memory = memory_get_usage(true);

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os"
 import { mkdtempSync } from "node:fs"
 import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
-import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
+import { bootstrapPhpCode, phpCodeFromArgs } from "../packages/runtime-playground/src/php-bootstrap.js"
 
 const lifecycleReplaySnippet = phpRuntimeComponentLifecycleReplayFunction("contained_runtime_test")
 assert.match(lifecycleReplaySnippet, /function contained_runtime_test_component_lifecycle_replay_prepare\(\): array/)
@@ -93,6 +93,15 @@ const bootstrappedRunPhp = bootstrapPhpCode({
 assert.match(bootstrappedRunPhp, /contained_runtime_run_php_component_lifecycle_replay_prepare/)
 assert.match(bootstrappedRunPhp, /CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON/)
 assert.doesNotMatch(bootstrappedRunPhp, /wp_codebox_run_php|wp_codebox_component_manifest|WP_CODEBOX_COMPONENT_MANIFEST_JSON/)
+
+const strictTypesCodeFileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-run-php-strict-types-"))
+const strictTypesCodeFile = join(strictTypesCodeFileRoot, "strict-types.php")
+writeFileSync(strictTypesCodeFile, "<?php declare(strict_types=1);\necho 'strict';")
+const strictTypesCode = await phpCodeFromArgs([`code-file=${strictTypesCodeFile}`])
+const bootstrappedStrictTypesCodeFile = bootstrapPhpCode({} as never, strictTypesCode, [])
+assert.match(bootstrappedStrictTypesCodeFile, /^<\?php\ndeclare\(strict_types=1\);\nregister_shutdown_function/)
+assert.equal((bootstrappedStrictTypesCodeFile.match(/declare\(strict_types=1\);/g) ?? []).length, 1)
+assert.match(bootstrappedStrictTypesCodeFile, /echo 'strict';/)
 
 const sandboxAgentCode = await resolveSandboxTaskCode({
   task: "Say hello",


### PR DESCRIPTION
## Summary
- Fixes https://github.com/Automattic/wp-codebox/issues/1731.
- Preserves a leading `declare(strict_types=1);` from `wordpress.run-php` code-file input as the first statement in generated PHP wrappers.
- Keeps existing inline code handling, code-file normalization, and diagnostics wrapping behavior intact.

## Tests
- `npm run test:runtime-php-snippets` - passed
- `npm run build` - passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implemented the focused fix and regression test for issue #1731 under Chris's direction.