### PR TITLE
Fix PHPUnit relative test-file resolution

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -342,6 +342,31 @@ function pg_log($msg) {
     file_put_contents($result_file, $msg . "\n", FILE_APPEND);
 }
 
+function pg_resolve_selected_test_file($selected_test_file, $test_dir, $runtime_cwd, $plugin_path) {
+    if ($selected_test_file === '') {
+        return '';
+    }
+    if ($selected_test_file[0] === '/') {
+        return $selected_test_file;
+    }
+
+    $relative = ltrim($selected_test_file, '/');
+    $candidates = array(
+        rtrim($test_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relative,
+        rtrim($runtime_cwd, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relative,
+        rtrim($plugin_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relative,
+    );
+    $tests_real = realpath($test_dir);
+    foreach (array_unique($candidates) as $candidate) {
+        $candidate_real = realpath($candidate);
+        if ($candidate_real !== false && $tests_real !== false && strpos($candidate_real, rtrim($tests_real, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR) === 0 && is_file($candidate_real)) {
+            return $candidate_real;
+        }
+    }
+
+    return $candidates[0];
+}
+
 ${phpEnvAssignmentFunction("pg_apply_env", "json_encode", "pg_log('NOTICE: skipping invalid bench_env key: ' . var_export($name, true));")}
 
 ${phpWpConfigDefineAppenderFunction("pg_append_wp_config_defines", "pg_log('NOTICE: skipping invalid wp_config_defines key: ' . var_export($name, true));")}
@@ -1139,7 +1164,7 @@ try {
     $test_files = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes, $configured_files);
     $test_files = pg_filter_changed_test_files($test_files, $changed_test_files_raw, $test_dir);
     if ($selected_test_file !== '') {
-        $selected_abs = $selected_test_file[0] === '/' ? $selected_test_file : $test_dir . '/' . ltrim($selected_test_file, '/');
+        $selected_abs = pg_resolve_selected_test_file($selected_test_file, $test_dir, $runtime_cwd, $plugin_path);
         if (!in_array($selected_abs, $test_files, true)) {
             $selected_real = realpath($selected_abs);
             $tests_real = realpath($test_dir);

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
-import { mkdtempSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -62,6 +62,38 @@ echo "ok\n";
 `)
 
   assert.equal(execFileSync("php", [scriptPath], { encoding: "utf8" }), "ok\n")
+}
+
+function assertSelectedTestFileResolution(source: string): void {
+  const tempDir = mkdtempSync(join(tmpdir(), "wp-codebox-selected-test-file-"))
+  const pluginRoot = join(tempDir, "demo-plugin")
+  const testRoot = join(pluginRoot, "tests")
+  const nestedTestDir = join(testRoot, "Feature")
+  const selectedTestFile = join(nestedTestDir, "ExampleTest.php")
+  const scriptPath = join(tempDir, "assert-selected-test-file.php")
+  mkdirSync(nestedTestDir, { recursive: true })
+  writeFileSync(selectedTestFile, "<?php // test\n")
+  const selectedTestFileReal = realpathSync(selectedTestFile)
+
+  const resolverFunction = extractPhpFunction(source, "pg_resolve_selected_test_file")
+  writeFileSync(scriptPath, `<?php
+${resolverFunction}
+$plugin_root = ${phpString(pluginRoot)};
+$test_root = ${phpString(testRoot)};
+$selected_test_file = ${phpString(selectedTestFile)};
+$cases = array(
+    'relative-to-test-root' => pg_resolve_selected_test_file('Feature/ExampleTest.php', $test_root, $plugin_root, $plugin_root),
+    'relative-to-runtime-root' => pg_resolve_selected_test_file('tests/Feature/ExampleTest.php', $test_root, $plugin_root, $plugin_root),
+    'absolute-runtime-path' => pg_resolve_selected_test_file($selected_test_file, $test_root, $plugin_root, $plugin_root),
+);
+echo json_encode($cases);
+`)
+
+  assert.deepEqual(JSON.parse(execFileSync("php", [scriptPath], { encoding: "utf8" })), {
+    "relative-to-test-root": selectedTestFileReal,
+    "relative-to-runtime-root": selectedTestFileReal,
+    "absolute-runtime-path": selectedTestFile,
+  })
 }
 
 const recipe = buildWordPressPhpunitRecipe({
@@ -145,6 +177,7 @@ assert.ok(projectModeCode.includes("configured PHPUnit harness autoload file is 
 assert.ok(projectModeCode.includes("NOTICE:project bootstrap mode continuing without configured PHPUnit harness autoload"))
 assert.ok(projectModeCode.includes("$test_root = \"/home/example/public_html/bin/tests/phpunit\";"))
 assert.ok(projectModeCode.includes("pg_resolve_test_root"))
+assert.ok(projectModeCode.includes("pg_resolve_selected_test_file"))
 assert.ok(projectModeCode.includes("function pg_project_bootstrap_real_path"))
 assert.ok(projectModeCode.includes("$base_dir = dirname($xml_real);"))
 assert.ok(projectModeCode.includes("$bootstrap_real = pg_project_bootstrap_real_path($bootstrap, $phpunit_xml, $from_config);"))
@@ -155,6 +188,7 @@ assert.ok(projectModeCode.includes("' files=' . count($configured_files)"))
 assert.equal(projectModeCode.match(/return array\(\$directories, \$suffixes, \$prefixes, \$excludes\);/g)?.length ?? 0, 0)
 assert.equal(projectModeCode.match(/return \$return_values\(\);/g)?.length, 3)
 assertPhpunitParseConfigFallbacksReturnFiveTuple(projectModeCode, "wp_codebox_phpunit_parse_config", "pg_log")
+assertSelectedTestFileResolution(projectModeCode)
 
 const coreModeCode = corePhpunitRunCode({
   coreRoot: "/wordpress",


### PR DESCRIPTION
## Summary
- Fixes #1729.
- Resolves relative `wordpress.phpunit` `test-file` values against `test-root`, then the runtime/plugin root when the path already includes the tests directory segment.
- Keeps absolute test-file paths and paths already relative to `test-root` working, while preserving the existing guard that selected files must resolve under `test-root`.

## Tests
- `npx tsx tests/phpunit-project-autoload.test.ts` - passed
- `npm run build` - passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the focused path-resolution fix and regression coverage for issue #1729 under Chris's direction.