### PR TITLE
Fix recipe-run policy override discoverability

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -19,6 +19,19 @@ npm run wp-codebox -- recipe validate --recipe ./path/to/recipe.json --json
 npm run wp-codebox -- recipe-run --recipe ./path/to/recipe.json --dry-run --json
 ```
 
+`recipe-run` derives the runtime policy from the recipe by default. To run with a
+stricter or caller-owned policy, pass `--policy <json|file>` to both validation
+and execution:
+
+```bash
+npm run wp-codebox -- recipe validate --recipe ./path/to/recipe.json --policy ./runtime-policy.json --json
+npm run wp-codebox -- recipe-run --recipe ./path/to/recipe.json --policy ./runtime-policy.json --json
+```
+
+The override must include every runtime command required by recipe setup, probes,
+and workflow steps. Use `recipe-run --dry-run --json` to inspect the resolved
+`plan.policy.commands` list before tightening a policy.
+
 ## Minimal Shape
 
 ```json

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,4 +1,4 @@
-import type { AgentTerminalResult, ArtifactBundle, ArtifactPackageProvenance, BenchResults, ExecutionResult, PreviewLease, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipe, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
+import type { AgentTerminalResult, ArtifactBundle, ArtifactPackageProvenance, BenchResults, ExecutionResult, PreviewLease, RecipeRunSummary, RuntimeInfo, RuntimePolicy, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipe, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
 import type { RecipeExternalServiceBoundaryHostCorrelation } from "../recipe-external-services.js"
@@ -20,6 +20,7 @@ export interface RecipeRunOptions {
   previewLeaseId?: string
   previewLeaseFile?: string
   timeoutMs: number
+  policy?: RuntimePolicy
   json: boolean
   summary: boolean
   dryRun: boolean
@@ -27,6 +28,7 @@ export interface RecipeRunOptions {
 
 export interface RecipeValidateOptions {
   recipePath: string
+  policy?: RuntimePolicy
   json: boolean
 }
 

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, type ArtifactBundle, type ArtifactPackageIdentity, type ArtifactPackageProvenance, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, validateRuntimePolicy, type ArtifactBundle, type ArtifactPackageIdentity, type ArtifactPackageProvenance, type Runtime, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
@@ -14,7 +14,7 @@ import { recipeExternalServiceBoundarySummaries } from "../recipe-external-servi
 import { resolveRecipeSecretEnv } from "../recipe-secret-env.js"
 import type { PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
-import { loadWorkspaceRecipe, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
+import { loadWorkspaceRecipe, recipePolicy, recipeWorkflowSteps, validateRecipeRuntimePolicy, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { resolveCliRuntimeBackend } from "../runtime-backends.js"
 import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
 import { artifactManifestFilesByPath, parseBenchResults, writeBenchmarkArtifactEvidence } from "./recipe-run-benchmark-artifacts.js"
@@ -106,7 +106,10 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let { runRecord } = context
   runRecord = await runRegistry.update(runRecord.runId, { metadata: { provenance: recipeRunProvenance(recipe, recipePath) } })
   await artifactPointer.update({ commandStatus: "queued" })
-  const issues = await validateWorkspaceRecipe(recipe, recipePath)
+  const issues = [
+    ...await validateWorkspaceRecipe(recipe, recipePath),
+    ...validateRecipeRuntimePolicy(recipe, options.policy),
+  ]
   if (issues.length > 0) {
     const failure = {
       name: "RecipeValidationError",
@@ -127,7 +130,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   }
 
   const plan = await planWorkspaceRecipe(recipe, recipeDirectory, { recipePath, artifactsDirectory: configuredArtifactsDirectory }, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec })
-  const { valid: _policyValid, issues: _policyIssues, ...policy } = plan.policy
+  const { valid: _policyValid, issues: _policyIssues, ...plannedPolicy } = plan.policy
+  const policy = options.policy ?? plannedPolicy
   const runtimeEnv = {
     ...distributionRuntimeEnv(recipe),
     ...normalizeRuntimeEnv(recipe.inputs?.runtimeEnv ?? {}),
@@ -610,7 +614,10 @@ async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeVal
   const recipePath = resolve(options.recipePath)
   try {
     const recipe = await loadWorkspaceRecipe(recipePath)
-    const issues = await validateWorkspaceRecipe(recipe, recipePath)
+    const issues = [
+      ...await validateWorkspaceRecipe(recipe, recipePath),
+      ...validateRecipeRuntimePolicy(recipe, options.policy),
+    ]
 
     return {
       success: issues.length === 0,
@@ -711,6 +718,9 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
       case "--timeout":
         options.timeoutMs = parseRecipeRunTimeoutMs(value)
         break
+      case "--policy":
+        options.policy = parseRecipePolicy(value)
+        break
       default:
         throw new Error(`Unknown option: ${name}`)
     }
@@ -741,6 +751,17 @@ function parseRecipeRunTimeoutMs(value: unknown): number {
   return timeoutMs
 }
 
+function parseRecipePolicy(value: string): RuntimePolicy {
+  const raw = value.trim().startsWith("{") ? value : readFileSync(resolve(value), "utf8")
+  const policy = JSON.parse(raw) as unknown
+  const result = validateRuntimePolicy(policy)
+  if (!result.valid) {
+    throw new Error(`Runtime policy is invalid: ${result.issues.map((issue) => issue.message).join("; ")}`)
+  }
+
+  return policy as RuntimePolicy
+}
+
 function parseRecipeValidateOptions(args: string[]): RecipeValidateOptions {
   const parsed = parseCommandOptions(args, new Set(["--json"]))
   if (parsed.positionals.length > 0) {
@@ -754,6 +775,9 @@ function parseRecipeValidateOptions(args: string[]): RecipeValidateOptions {
     switch (name) {
       case "--recipe":
         options.recipePath = value
+        break
+      case "--policy":
+        options.policy = parseRecipePolicy(value)
         break
       default:
         throw new Error(`Unknown option: ${name}`)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -307,7 +307,7 @@ export function printHelp(): void {
   wp-codebox cleanup [--json] [--archive-root <dir>] [--stale-after-seconds <n>]
   wp-codebox workspace-policy check --workspace-root <path> --writable-root <path> [options]
   wp-codebox recipe build phpunit|bench|template|generic-ability-runtime-run|runtime-package-run --options <path> [--output <path>]
-  wp-codebox recipe validate --recipe <path> [--json]
+  wp-codebox recipe validate --recipe <path> [--policy <json|file>] [--json]
   wp-codebox bench matrix --matrix <path> [--recipe <path>] [--artifacts <dir>] [--json]
   wp-codebox bench summarize (--input <recipe-run.json>|--bundle <dir>) [--json]
   wp-codebox bench compare --baseline <recipe-run.json> --candidate <recipe-run.json> [--json]
@@ -427,7 +427,7 @@ Options:
   --preview-lease-json <json>
                          wp-codebox/preview-lease/v1 envelope for public/local URL, expiry, alignment, and handoff metadata.
   --timeout <duration>  Maximum live recipe-run duration before emitting a structured timeout failure. Defaults to 25m.
-  --policy <json|file> Runtime policy JSON or path to a JSON file.
+  --policy <json|file> Runtime policy JSON or path to a JSON file. For recipe-run and recipe validate, this overrides the recipe-derived runtime policy and must include every command required by the recipe setup, probes, and workflow.
   --dry-run            Validate recipe-run and emit a resolved JSON plan without booting Playground or writing temp workspaces.
   --json               Emit machine-readable JSON.
 

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -6,12 +6,13 @@ import { RecipeArtifactsMountConflictError, recipeArtifactsMountConflict } from 
 import { resolveRecipeSecretEnv, type RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
 import { recipeExternalServiceBoundarySummaries, type RecipeExternalServiceBoundarySummary } from "./recipe-external-services.js"
 import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPluginSource, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
-import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
+import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateRecipeRuntimePolicy, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
 import { runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 
 export interface RecipeDryRunOptions {
   recipePath: string
   artifactsDirectory?: string
+  policy?: RuntimePolicy
 }
 
 export interface RecipeDryRunContext {
@@ -267,7 +268,10 @@ export async function dryRunRecipe(options: RecipeDryRunOptions, context: Recipe
       }
     }
 
-    const issues = await validateWorkspaceRecipe(recipe, recipePath)
+    const issues = [
+      ...await validateWorkspaceRecipe(recipe, recipePath),
+      ...validateRecipeRuntimePolicy(recipe, options.policy),
+    ]
 
     if (issues.length > 0) {
       return {
@@ -315,7 +319,7 @@ export async function dryRunRecipe(options: RecipeDryRunOptions, context: Recipe
 }
 
 export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirectory: string, options: RecipePlanOptions, context: RecipePlanContext): Promise<RecipePlan> {
-  const policy = recipePolicy(recipe)
+  const policy = options.policy ?? recipePolicy(recipe)
   const policyValidation = validateRuntimePolicy(policy)
   const workspaces = recipeDryRunWorkspaces(recipe, recipeDirectory)
   const extraPlugins = recipeDryRunExtraPlugins(recipe, recipeDirectory)

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateRuntimePolicy, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { commandValidationDescriptorFor, effectivePolicyCommandsFor, type CommandArgValidationDescriptor } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPluginSource, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { loadConfiguredRuntimeOverlayDescriptors, registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
@@ -477,6 +477,35 @@ function validateRecipeDependencyOverlays(overlays: WorkspaceRecipeDependencyOve
 
 export async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: string): Promise<RecipeValidationIssue[]> {
   return validateWorkspaceRecipeSemantics(recipe, recipePath)
+}
+
+export function validateRecipeRuntimePolicy(recipe: WorkspaceRecipe, policy: RuntimePolicy | undefined): RecipeValidationIssue[] {
+  if (!policy) {
+    return []
+  }
+
+  const issues: RecipeValidationIssue[] = []
+  const policyValidation = validateRuntimePolicy(policy)
+  for (const issue of policyValidation.issues) {
+    issues.push({
+      code: issue.code,
+      path: `$.policy.${issue.field}`,
+      message: issue.message,
+    })
+  }
+
+  const requiredCommands = recipePolicy(recipe).commands
+  for (const command of requiredCommands) {
+    if (!policy.commands.includes(command)) {
+      issues.push({
+        code: "runtime-policy-missing-command",
+        path: "$.policy.commands",
+        message: `Runtime policy commands must include ${command} for this recipe. Run recipe-run --dry-run --json to inspect the resolved plan.policy.commands list.`,
+      })
+    }
+  }
+
+  return issues
 }
 
 export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, recipePath: string): Promise<RecipeValidationIssue[]> {

--- a/tests/recipe-run-policy-override.test.ts
+++ b/tests/recipe-run-policy-override.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import { writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { runRecipeRunCommand, runRecipeValidateCommand } from "../packages/cli/src/commands/recipe-run.js"
+import { printHelp } from "../packages/cli/src/output.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+function captureStdout(callback: () => void): string {
+  const original = console.log
+  const lines: string[] = []
+  console.log = (...args: unknown[]) => lines.push(args.join(" "))
+  try {
+    callback()
+  } finally {
+    console.log = original
+  }
+  return lines.join("\n")
+}
+
+await withTempDir("wp-codebox-recipe-run-policy-override-", async (directory) => {
+  const recipePath = join(directory, "recipe.json")
+  const restrictivePolicyPath = join(directory, "restrictive-policy.json")
+  const completePolicyPath = join(directory, "complete-policy.json")
+
+  await writeFile(recipePath, JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    workflow: {
+      steps: [
+        { command: "wordpress.run-php", args: ["code=echo 'ok';"] },
+      ],
+    },
+  }))
+  await writeFile(restrictivePolicyPath, JSON.stringify({
+    network: "deny",
+    filesystem: "readwrite-mounts",
+    commands: ["inspect-mounted-inputs"],
+    secrets: "none",
+    approvals: "never",
+  }))
+  await writeFile(completePolicyPath, JSON.stringify({
+    network: "deny",
+    filesystem: "readwrite-mounts",
+    commands: ["inspect-mounted-inputs", "wordpress.run-php"],
+    secrets: "none",
+    approvals: "never",
+  }))
+
+  const restrictiveExitCode = await runRecipeValidateCommand(["--recipe", recipePath, "--policy", restrictivePolicyPath, "--json"])
+  assert.equal(restrictiveExitCode, 1)
+
+  const restrictiveDryRunExitCode = await runRecipeRunCommand(["--recipe", recipePath, "--policy", restrictivePolicyPath, "--dry-run", "--json"])
+  assert.equal(restrictiveDryRunExitCode, 1)
+
+  const completeExitCode = await runRecipeValidateCommand(["--recipe", recipePath, "--policy", completePolicyPath, "--json"])
+  assert.equal(completeExitCode, 0)
+
+  const completeDryRunExitCode = await runRecipeRunCommand(["--recipe", recipePath, "--policy", completePolicyPath, "--dry-run", "--json"])
+  assert.equal(completeDryRunExitCode, 0)
+})
+
+const help = captureStdout(printHelp)
+assert.match(help, /recipe validate --recipe <path> \[--policy <json\|file>\]/)
+assert.match(help, /recipe-run and recipe validate/)
+
+console.log("recipe-run policy override validation ok")


### PR DESCRIPTION
## Summary
- Fixes https://github.com/Automattic/wp-codebox/issues/1730.
- Makes recipe runtime policy overrides usable for `recipe-run --policy <json|file>` and `recipe validate --policy <json|file>`.
- Validates override policies against the recipe-derived required command set so missing grants fail validation/dry-run before runtime execution.
- Documents the override path in CLI help and the recipe contract docs.

## Tests
- `npx tsx tests/recipe-run-policy-override.test.ts` - passed
- `npm run test:recipe-validation-descriptors` - passed
- `npm run test:schema-parity` - passed
- `npm run build` - passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the recipe-run policy validation path, implemented the focused CLI/docs/test changes, and ran targeted verification.