### PR TITLE
Fix recipe artifact evidence digest refresh

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, materializeStructuredArtifactFiles, normalizeAgentTerminalResult, normalizeRuntimeBackendKind, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, calculateArtifactManifestFileListDigest, captureArtifactFile, checkWorkspacePolicy, materializeStructuredArtifactFiles, normalizeAgentTerminalResult, normalizeRuntimeBackendKind, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
 import { isPlainObject as isRecord, sha256StableJson, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
@@ -1533,22 +1533,38 @@ async function writeRecipeEvidenceJson(artifactRoot: string, path: string, value
 async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle, evidenceFiles: RecipeArtifactEvidenceFile[]): Promise<void> {
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
   upsertArtifactManifestFiles(manifest, evidenceFiles.map(evidenceFileToManifestFile))
+  refreshManifestFileListDigest(manifest, artifacts)
 
   const evidence = Object.fromEntries(evidenceFiles.map((file) => [file.kind, { path: file.path, sha256: file.sha256 }]))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8")) as Record<string, unknown>
   const metadataArtifacts = isRecord(metadata.artifacts) ? metadata.artifacts : {}
   const metadataEvidence = isRecord(metadata.evidence) ? metadata.evidence : {}
+  metadata.id = manifest.id
+  metadata.contentDigest = manifest.contentDigest
   metadata.artifacts = { ...metadataArtifacts, runtimeEvidence: { ...(isRecord(metadataArtifacts.runtimeEvidence) ? metadataArtifacts.runtimeEvidence : {}), ...evidence } }
   metadata.evidence = { ...metadataEvidence, runtimeEvidence: { ...(isRecord(metadataEvidence.runtimeEvidence) ? metadataEvidence.runtimeEvidence : {}), ...evidence } }
   await writeFile(artifacts.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`)
 
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8")) as Record<string, unknown>
   const reviewEvidence = isRecord(review.evidence) ? review.evidence : {}
-  review.evidence = { ...reviewEvidence, runtimeEvidence: { ...(isRecord(reviewEvidence.runtimeEvidence) ? reviewEvidence.runtimeEvidence : {}), ...evidence } }
+  review.artifactId = manifest.id
+  review.evidence = { ...reviewEvidence, artifactContentDigest: manifest.contentDigest.value, runtimeEvidence: { ...(isRecord(reviewEvidence.runtimeEvidence) ? reviewEvidence.runtimeEvidence : {}), ...evidence } }
   await writeFile(artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
 
   await refreshManifestAfterEvidenceMutation(artifacts.directory, manifest)
   await writeFile(artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+function refreshManifestFileListDigest(manifest: ArtifactManifest, artifacts: ArtifactBundle): void {
+  if (manifest.contentDigest.inputs.length !== 1 || manifest.contentDigest.inputs[0] !== "manifest.files") {
+    return
+  }
+
+  const value = calculateArtifactManifestFileListDigest(manifest.files)
+  manifest.contentDigest = { algorithm: "sha256", inputs: ["manifest.files"], value }
+  manifest.id = `artifact-bundle-sha256-${value}`
+  artifacts.id = manifest.id
+  artifacts.contentDigest = value
 }
 
 async function refreshManifestAfterEvidenceMutation(artifactRoot: string, manifest: ArtifactManifest): Promise<void> {

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -1,13 +1,14 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
-import { cp, link, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { cp, link, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { calculateArtifactContentDigest, calculateArtifactManifestFileSha256 } from "@automattic/wp-codebox-core"
+import { calculateArtifactContentDigest, calculateArtifactManifestFileListDigest, calculateArtifactManifestFileSha256 } from "@automattic/wp-codebox-core"
 import { preflightArtifactBundleApply, verifyArtifactBundle } from "@automattic/wp-codebox-core/artifacts"
-import type { ArtifactManifest } from "@automattic/wp-codebox-core"
+import type { ArtifactBundle, ArtifactManifest } from "@automattic/wp-codebox-core"
+import { appendRecipeRuntimeEvidence } from "../packages/cli/src/recipe-evidence.js"
 
 const execFileAsync = promisify(execFile)
 const root = resolve(import.meta.dirname, "..")
@@ -35,6 +36,15 @@ try {
 
   const artifactsOption = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "verify", "--artifacts", validBundle, "--json"], { cwd: root })
   assert.equal(JSON.parse(artifactsOption.stdout).valid, true)
+
+  const recipeEvidenceBundle = await copyBundle(validBundle, join(workspace, "recipe-evidence-appended"))
+  await rewriteBundleToManifestFileListDigest(recipeEvidenceBundle)
+  const recipeArtifacts = await artifactBundleFixture(recipeEvidenceBundle)
+  await appendRecipeRuntimeEvidence(recipeArtifacts, [{ filename: "run-attestation.json", kind: "run-attestation", value: { schema: "fixture/run-attestation/v1", status: "passed" } }])
+  const recipeEvidenceVerification = await verifyArtifactBundle(recipeEvidenceBundle)
+  assert.equal(recipeEvidenceVerification.valid, true)
+  assert.equal(recipeEvidenceVerification.manifest?.contentDigest.value, recipeArtifacts.contentDigest)
+  assert.equal(recipeEvidenceVerification.manifest?.files.some((file) => file.path === "files/runtime-evidence/run-attestation.json"), true)
 
   const missingManifest = join(workspace, "missing-manifest")
   await mkdir(missingManifest, { recursive: true })
@@ -159,6 +169,56 @@ async function writeValidBundle(directory: string): Promise<void> {
   await attachCaseArtifactHashes(directory, manifest)
   await attachManifestFileHashes(directory, manifest)
   await writeJson(join(directory, "manifest.json"), manifest)
+}
+
+async function rewriteBundleToManifestFileListDigest(directory: string): Promise<void> {
+  const manifest = JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")) as ArtifactManifest
+  const digest = calculateArtifactManifestFileListDigest(manifest.files)
+  manifest.id = `artifact-bundle-sha256-${digest}`
+  manifest.contentDigest = { algorithm: "sha256", inputs: ["manifest.files"], value: digest }
+  await writeJson(join(directory, "files/review.json"), reviewFixture(digest))
+  await writeJson(join(directory, "metadata.json"), {
+    id: manifest.id,
+    contentDigest: manifest.contentDigest,
+    artifacts: {
+      changedFiles: "files/changed-files.json",
+      patch: "files/patch.diff",
+      review: "files/review.json",
+      testResults: "files/test-results.json",
+      runtimeEpisodeTrace: "files/runtime-episode-trace.json",
+      runtimeEpisodeEvents: "files/runtime-episode.jsonl",
+    },
+  })
+  await attachManifestFileHashes(directory, manifest)
+  await writeJson(join(directory, "manifest.json"), manifest)
+}
+
+async function artifactBundleFixture(directory: string): Promise<ArtifactBundle> {
+  const manifest = JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")) as ArtifactManifest
+  return {
+    id: manifest.id,
+    directory,
+    manifestPath: join(directory, "manifest.json"),
+    metadataPath: join(directory, "metadata.json"),
+    blueprintAfterPath: join(directory, "blueprint.after.json"),
+    blueprintAfterNotesPath: join(directory, "blueprint.after-notes.json"),
+    eventsPath: join(directory, "events.jsonl"),
+    commandsPath: join(directory, "commands.jsonl"),
+    observationsPath: join(directory, "observations.jsonl"),
+    runtimeLogPath: join(directory, "logs/runtime.log"),
+    commandsLogPath: join(directory, "logs/commands.log"),
+    mountsPath: join(directory, "files/mounts.json"),
+    capturedMountsPath: join(directory, "files/mounted-files.json"),
+    diffsPath: join(directory, "files/diffs.json"),
+    workspacePatchPath: join(directory, "files/workspace-patch.json"),
+    changedFilesPath: join(directory, "files/changed-files.json"),
+    patchPath: join(directory, "files/patch.diff"),
+    diagnosticsPath: join(directory, "files/diagnostics.json"),
+    testResultsPath: join(directory, "files/test-results.json"),
+    reviewPath: join(directory, "files/review.json"),
+    contentDigest: manifest.contentDigest.value,
+    createdAt: manifest.createdAt,
+  }
 }
 
 function manifestFixture(digest: string): ArtifactManifest {


### PR DESCRIPTION
## Summary
- Fixes https://github.com/Automattic/wp-codebox/issues/1732.
- Recomputes `manifest.contentDigest` and `manifest.id` when recipe-run runtime evidence appends entries to `manifest.files`.
- Refreshes dependent metadata, review evidence, and runtime reference bundle refs so a fresh successful recipe-run bundle verifies without `digest-mismatch`.
- Adds regression coverage for appending recipe runtime evidence to a fresh `manifest.files`-digested bundle and verifying the result.

## Root cause
Recipe-run evidence appends files like `files/runtime-evidence/run-attestation.json` and `files/runtime-evidence/replay-status.json` after the artifact bundle is initially built. The append path refreshed file SHA-256 values, but left the manifest-file-list content digest and bundle id at the pre-evidence value. `artifacts verify` correctly recomputed the expanded manifest-file-list digest and reported `digest-mismatch`.

## Tests
- `npm run build` - passed.
- `npx tsx scripts/artifact-bundle-verifier-smoke.ts` - passed; includes fresh recipe-evidence append regression.
- `node packages/cli/dist/index.js artifacts verify --bundle /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wp-codebox-openai-embeddings-proof/live-artifacts-rerun2/runtime-mr9oaqlw-hp4wr6 --json` - reproduced the old proof bundle's existing stale `digest-mismatch` (`expected 8832db3d..., got fd219f75...`), confirming the supplied bundle is reproduction evidence rather than a verifier false positive.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, implementation, regression test update, and local verification.