### PR TITLE
Guard editor state capture stores

### DIFF
--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -1070,11 +1070,14 @@ async function executeEditorActionStep(page: import("playwright").Page, step: Ed
       return { state: await page.evaluate(() => {
         const wpData = (window as unknown as { wp?: { data?: { select?: (store: string) => Record<string, unknown> } } }).wp?.data
         const select = wpData?.select
-        if (!select) {
+        if (typeof select !== "function") {
           return { storesAvailable: false }
         }
         const editor = select("core/editor")
         const blockEditor = select("core/block-editor")
+        if (!editor || !blockEditor) {
+          return { storesAvailable: false }
+        }
         const currentPost = typeof editor.getCurrentPost === "function" ? editor.getCurrentPost() as Record<string, unknown> | null : null
         const blocks = typeof blockEditor.getBlocks === "function" ? blockEditor.getBlocks() as Array<Record<string, unknown>> : []
         return {
@@ -1147,6 +1150,9 @@ async function saveEditorPost(page: import("playwright").Page, step: Extract<Edi
     const editor = select("core/editor")
     const blockEditor = dispatch("core/block-editor")
     const editorDispatch = dispatch("core/editor")
+    if (!editor) {
+      throw new Error("wp-codebox-editor-readiness-unavailable: core/editor store is unavailable")
+    }
     if (typeof editorDispatch?.savePost !== "function") {
       throw new Error("wp-codebox-editor-save-unsupported: core/editor savePost is unavailable")
     }
@@ -1265,15 +1271,18 @@ interface EditorValidityArtifact {
   summary: BrowserEditorValiditySummary
 }
 
-async function captureEditorState(page: import("playwright").Page, target: ReturnType<typeof editorOpenTargetFromArgs>): Promise<EditorStateSnapshot> {
+export async function captureEditorState(page: import("playwright").Page, target: ReturnType<typeof editorOpenTargetFromArgs>): Promise<EditorStateSnapshot> {
   const state = await page.evaluate(() => {
     const wpData = (window as unknown as { wp?: { data?: { select?: (store: string) => Record<string, unknown> } } }).wp?.data
     const select = wpData?.select
-    if (!select) {
+    if (typeof select !== "function") {
       return { storesAvailable: false }
     }
     const editor = select("core/editor")
     const blockEditor = select("core/block-editor")
+    if (!editor || !blockEditor) {
+      return { storesAvailable: false }
+    }
     const currentPost = typeof editor.getCurrentPost === "function" ? editor.getCurrentPost() as Record<string, unknown> | null : null
     const blocks = typeof blockEditor.getBlocks === "function" ? blockEditor.getBlocks() as Array<Record<string, unknown>> : []
     return {

--- a/tests/editor-actions.test.ts
+++ b/tests/editor-actions.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { captureEditorValidity, editorOpenArtifactFilesForCapture, editorOpenArtifactPathPrefixFromArgs } from "../packages/runtime-playground/src/editor-command-runners.js"
+import { captureEditorState, captureEditorValidity, editorOpenArtifactFilesForCapture, editorOpenArtifactPathPrefixFromArgs } from "../packages/runtime-playground/src/editor-command-runners.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, resolveEditorOpenTarget } from "../packages/runtime-playground/src/editor-actions.js"
 
 const steps = await editorActionStepsFromArgs([
@@ -24,6 +24,25 @@ await assert.rejects(
 )
 
 const target = editorOpenTargetFromArgs(["target=post-new"])
+const unavailableEditorState = await captureEditorState({
+  evaluate: async (callback: () => unknown) => {
+    const globals = globalThis as typeof globalThis & { window?: unknown }
+    const previousWindow = globals.window
+    globals.window = {
+      data: {
+        select: (store: string) => store === "core/block-editor" ? { getBlocks: () => [] } : undefined,
+      },
+    }
+    globals.window = { wp: globals.window }
+    try {
+      return callback()
+    } finally {
+      globals.window = previousWindow
+    }
+  },
+} as never, target)
+assert.equal(unavailableEditorState.storesAvailable, false)
+
 const validity = await captureEditorValidity({
   evaluate: async (_callback: unknown, selectors: string[]) => ([{
     source: "dom",


### PR DESCRIPTION
## Summary
- Guard editor-state capture and inspectState when WordPress editor data stores are unavailable.
- Return structured `storesAvailable: false` evidence instead of throwing on `editor.getCurrentPost`.
- Add coverage for missing `core/editor` store during editor-state capture.

## Testing
- `npm run test:editor-actions`
- `npm run build`

## Context
Coffee clean scorecard run `abc8b1fa-3239-4191-b430-a0d5e84556a1` failed in `wordpress.editor-open` with `Cannot read properties of undefined (reading 'getCurrentPost')`. This patch keeps wp-codebox from crashing while collecting diagnostic editor state if navigation lands somewhere without editor stores.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated run artifacts, identified the missing-store dereference, implemented the guard and tests.
