### PR TITLE
Persist visual compare DOM snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:browser-visual-compare-fair-ratio": "tsx tests/browser-visual-compare-fair-ratio.test.ts",
     "test:browser-visual-compare-layout-drift": "tsx tests/browser-visual-compare-layout-drift.test.ts",
     "test:browser-visual-compare-capture-reliability": "tsx tests/browser-visual-compare-capture-reliability.test.ts",
+    "test:browser-visual-compare-dom-snapshots": "npm run build && tsx tests/browser-visual-compare-dom-snapshots.test.ts",
     "test:browser-session-public-dto": "tsx tests/browser-session-public-dto.test.ts",
     "test:browser-playground-session-run": "tsx tests/browser-playground-session-run.test.ts",
     "test:browser-contained-site-status": "tsx tests/browser-contained-site-status.test.ts",

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -85,6 +85,8 @@ export interface BrowserArtifactFiles {
   actionCorpus?: string
   sourceScreenshot?: string | string[]
   candidateScreenshot?: string | string[]
+  sourceDomSnapshot?: string | string[]
+  candidateDomSnapshot?: string | string[]
   diffScreenshot?: string | string[]
   visualDiff?: string | string[]
   visualExplanation?: string | string[]
@@ -1081,6 +1083,8 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   actionCorpus: { kind: "browser-action-corpus", contentType: "application/json", redact: true },
   sourceScreenshot: { kind: "browser-visual-source-screenshot", contentType: "image/png", redact: false },
   candidateScreenshot: { kind: "browser-visual-candidate-screenshot", contentType: "image/png", redact: false },
+  sourceDomSnapshot: { kind: "browser-visual-source-dom-snapshot", contentType: "application/json", redact: true },
+  candidateDomSnapshot: { kind: "browser-visual-candidate-dom-snapshot", contentType: "application/json", redact: true },
   diffScreenshot: { kind: "browser-visual-diff-screenshot", contentType: "image/png", redact: false },
   visualDiff: { kind: "browser-visual-diff", contentType: "application/json", redact: true },
   visualExplanation: { kind: "browser-visual-explanation", contentType: "application/json", redact: true },

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -676,6 +676,10 @@ async function runVisualComparePairCommand({
   const files = {
     sourceScreenshot: `${artifactPathPrefix}/source.png`,
     candidateScreenshot: `${artifactPathPrefix}/candidate.png`,
+    ...(sourceDomSnapshot && candidateDomSnapshot ? {
+      sourceDomSnapshot: `${artifactPathPrefix}/source-dom-snapshot.json`,
+      candidateDomSnapshot: `${artifactPathPrefix}/candidate-dom-snapshot.json`,
+    } : {}),
     diffScreenshot: `${artifactPathPrefix}/diff.png`,
     visualDiff: `${artifactPathPrefix}/visual-diff.json`,
     ...(explanation ? { visualExplanation: `${artifactPathPrefix}/visual-explanation.json` } : {}),
@@ -708,6 +712,22 @@ async function runVisualComparePairCommand({
   }
   const blocksEngineVisualParity = blocksEngineVisualParityReportFromVisualCompare({ ...summary, explanation })
   const summaryWithBlocksEngineVisualParity = { ...summary, blocksEngineVisualParity }
+  if (sourceDomSnapshot && candidateDomSnapshot) {
+    await artifactSession.writeJson("sourceDomSnapshot", "source-dom-snapshot.json", visualCompareDomSnapshotArtifact({
+      screenshot: files.sourceScreenshot,
+      finalUrl: finalSourceUrl ?? sourceDomSnapshot.url,
+      viewport,
+      maxElements: maxExplanationCandidates,
+      snapshot: sourceDomSnapshot,
+    }))
+    await artifactSession.writeJson("candidateDomSnapshot", "candidate-dom-snapshot.json", visualCompareDomSnapshotArtifact({
+      screenshot: files.candidateScreenshot,
+      finalUrl: finalCandidateUrl ?? candidateDomSnapshot.url,
+      viewport,
+      maxElements: maxExplanationCandidates,
+      snapshot: candidateDomSnapshot,
+    }))
+  }
   await artifactSession.writeJson("visualDiff", "visual-diff.json", summaryWithBlocksEngineVisualParity)
   if (explanation) {
     await artifactSession.writeJson("visualExplanation", "visual-explanation.json", explanation)
@@ -816,6 +836,8 @@ function visualCompareMatrixArtifact(
   const diffScreenshots = entries.map((entry) => entry.artifact.files.diffScreenshot).filter((file): file is string => typeof file === "string")
   const visualDiffs = entries.map((entry) => entry.artifact.files.visualDiff).filter((file): file is string => typeof file === "string")
   const visualExplanations = entries.map((entry) => entry.artifact.files.visualExplanation).filter((file): file is string => typeof file === "string")
+  const sourceDomSnapshots = entries.map((entry) => entry.artifact.files.sourceDomSnapshot).filter((file): file is string => typeof file === "string")
+  const candidateDomSnapshots = entries.map((entry) => entry.artifact.files.candidateDomSnapshot).filter((file): file is string => typeof file === "string")
   const firstArtifact = entries[0]?.artifact
   const captureDiagnostics = visualCompareMatrixCompactCaptureDiagnostics(matrixSummary)
   return {
@@ -829,6 +851,8 @@ function visualCompareMatrixArtifact(
       visualDiff: visualDiffs,
       sourceScreenshot: sourceScreenshots,
       candidateScreenshot: candidateScreenshots,
+      ...(sourceDomSnapshots.length > 0 ? { sourceDomSnapshot: sourceDomSnapshots } : {}),
+      ...(candidateDomSnapshots.length > 0 ? { candidateDomSnapshot: candidateDomSnapshots } : {}),
       diffScreenshot: diffScreenshots,
       ...(visualExplanations.length > 0 ? { visualExplanation: visualExplanations } : {}),
     },
@@ -1588,6 +1612,30 @@ async function readVisualCompareDomSnapshotArtifact(requestedPath: string, artif
   const parsed = JSON.parse(await readFile(path, "utf8")) as unknown
   const artifact = normalizeBrowserDomSnapshotArtifact(parsed, requestedPath, "Visual compare DOM snapshot")
   return artifact
+}
+
+function visualCompareDomSnapshotArtifact(input: {
+  screenshot: string
+  finalUrl: string
+  viewport: BrowserProbeViewport | null
+  maxElements: number
+  snapshot: VisualCompareDomSnapshot
+}): VisualCompareDomSnapshotArtifact {
+  return {
+    schema: "wp-codebox/browser-dom-snapshot/v1",
+    command: "wordpress.visual-compare",
+    screenshot: input.screenshot,
+    finalUrl: input.finalUrl,
+    viewport: input.viewport,
+    capturedAt: now(),
+    limits: { maxElements: input.maxElements },
+    summary: {
+      elementCount: input.snapshot.elementCount,
+      capturedElements: input.snapshot.capturedElements.length,
+      truncated: input.snapshot.truncated,
+    },
+    snapshot: input.snapshot,
+  }
 }
 
 async function resolveVisualCompareArtifactPath(requestedPath: string, artifactRoot: string, label: string): Promise<string> {

--- a/tests/browser-artifact-session.test.ts
+++ b/tests/browser-artifact-session.test.ts
@@ -59,6 +59,8 @@ assert.deepEqual(files.get("files/browser/screenshot.png")?.redaction, { policy:
 const visualSession = new BrowserArtifactSession(artifactRoot, "files/browser/visual-compare/mobile", { source: "wordpress.visual-compare", operation: "visual-compare" })
 await visualSession.writeJson("visualDiff", "visual-diff.json", { schema: "wp-codebox/visual-compare/v1", status: "different" })
 await visualSession.writeBuffer("sourceScreenshot", "source.png", Buffer.from([3, 4, 5]))
+await visualSession.writeJson("sourceDomSnapshot", "source-dom-snapshot.json", { schema: "wp-codebox/browser-dom-snapshot/v1" })
+await visualSession.writeJson("candidateDomSnapshot", "candidate-dom-snapshot.json", { schema: "wp-codebox/browser-dom-snapshot/v1" })
 
 assert.equal(visualSession.path("/tmp/source.png"), "files/browser/visual-compare/mobile/source.png")
 const visualFiles = new Map(visualSession.writer.artifacts.files().map((file) => [file.path, file]))
@@ -66,6 +68,10 @@ assert.equal(visualFiles.get("files/browser/visual-compare/mobile/visual-diff.js
 assert.equal(visualFiles.get("files/browser/visual-compare/mobile/visual-diff.json")?.redaction?.policy, "required")
 assert.equal(visualFiles.get("files/browser/visual-compare/mobile/source.png")?.kind, "browser-visual-source-screenshot")
 assert.deepEqual(visualFiles.get("files/browser/visual-compare/mobile/source.png")?.redaction, { policy: "none", sensitive: false })
+assert.equal(visualFiles.get("files/browser/visual-compare/mobile/source-dom-snapshot.json")?.kind, "browser-visual-source-dom-snapshot")
+assert.equal(visualFiles.get("files/browser/visual-compare/mobile/source-dom-snapshot.json")?.contentType, "application/json")
+assert.equal(visualFiles.get("files/browser/visual-compare/mobile/source-dom-snapshot.json")?.redaction?.policy, "required")
+assert.equal(visualFiles.get("files/browser/visual-compare/mobile/candidate-dom-snapshot.json")?.kind, "browser-visual-candidate-dom-snapshot")
 
 const review = browserReviewSummary([{
   artifactType: "probe",

--- a/tests/browser-visual-compare-dom-snapshots.test.ts
+++ b/tests/browser-visual-compare-dom-snapshots.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict"
+import { once } from "node:events"
+import { readFile, writeFile } from "node:fs/promises"
+import { createServer } from "node:http"
+import { join } from "node:path"
+
+import { PNG } from "pngjs"
+
+import { runVisualCompareCommand } from "../packages/runtime-playground/dist/browser-visual-compare.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+const snapshot = (url: string, title: string) => ({
+  url,
+  title,
+  elementCount: 1,
+  capturedElements: [{ path: "main", tag: "main", text: title, attributes: {}, boundingBox: { x: 0, y: 0, width: 1, height: 1 }, styles: { display: "block" } }],
+  truncated: false,
+})
+
+const domSnapshotArtifact = (url: string, title: string) => ({
+  schema: "wp-codebox/browser-dom-snapshot/v1" as const,
+  command: "wordpress.browser-actions" as const,
+  screenshot: "input.png",
+  finalUrl: url,
+  viewport: null,
+  capturedAt: "2026-01-01T00:00:00.000Z",
+  limits: { maxElements: 1 },
+  summary: { elementCount: 1, capturedElements: 1, truncated: false },
+  snapshot: snapshot(url, title),
+})
+
+async function writePng(path: string): Promise<void> {
+  const png = new PNG({ width: 1, height: 1 })
+  png.data.set([255, 255, 255, 255])
+  await writeFile(path, PNG.sync.write(png))
+}
+
+async function visualCompare(artifactRoot: string, args: string[]) {
+  return runVisualCompareCommand({
+    artifactRoot,
+    server: {
+      serverUrl: "http://127.0.0.1:1",
+      playground: { run: async () => ({ text: "" }) },
+      async [Symbol.asyncDispose]() {},
+    },
+    spec: { command: "wordpress.visual-compare", args },
+  })
+}
+
+await withTempDir("wp-codebox-visual-dom-snapshots-", async (artifactRoot) => {
+  const sourceScreenshot = join(artifactRoot, "input-source.png")
+  const candidateScreenshot = join(artifactRoot, "input-candidate.png")
+  const sourceSidecar = join(artifactRoot, "source-sidecar.json")
+  const candidateSidecar = join(artifactRoot, "candidate-sidecar.json")
+  await Promise.all([writePng(sourceScreenshot), writePng(candidateScreenshot)])
+  await writeFile(sourceSidecar, JSON.stringify(domSnapshotArtifact("https://source.example.test/", "Source")))
+  await writeFile(candidateSidecar, JSON.stringify(domSnapshotArtifact("https://candidate.example.test/", "Candidate")))
+
+  const supplied = await visualCompare(artifactRoot, [
+    `source-screenshot=${sourceScreenshot}`,
+    `candidate-screenshot=${candidateScreenshot}`,
+    `source-dom-snapshot=${sourceSidecar}`,
+    `candidate-dom-snapshot=${candidateSidecar}`,
+  ])
+  const suppliedSummary = JSON.parse(supplied.output)
+  assert.equal(suppliedSummary.schema, "wp-codebox/visual-compare/v1")
+  assert.equal(suppliedSummary.files.sourceDomSnapshot, "files/browser/visual-compare/source-dom-snapshot.json")
+  assert.equal(suppliedSummary.files.candidateDomSnapshot, "files/browser/visual-compare/candidate-dom-snapshot.json")
+  const persistedSource = JSON.parse(await readFile(join(artifactRoot, suppliedSummary.files.sourceDomSnapshot), "utf8"))
+  const persistedCandidate = JSON.parse(await readFile(join(artifactRoot, suppliedSummary.files.candidateDomSnapshot), "utf8"))
+  assert.equal(persistedSource.schema, "wp-codebox/browser-dom-snapshot/v1")
+  assert.equal(persistedSource.command, "wordpress.visual-compare")
+  assert.equal(persistedSource.screenshot, "files/browser/visual-compare/source.png")
+  assert.deepEqual(persistedSource.snapshot, snapshot("https://source.example.test/", "Source"))
+  assert.equal(persistedCandidate.schema, "wp-codebox/browser-dom-snapshot/v1")
+  assert.equal(persistedCandidate.screenshot, "files/browser/visual-compare/candidate.png")
+  assert.equal(persistedCandidate.finalUrl, "https://candidate.example.test/")
+
+  await withTempDir("wp-codebox-visual-dom-snapshots-screenshot-only-", async (screenshotOnlyRoot) => {
+    const screenshotOnly = await visualCompare(screenshotOnlyRoot, [`source-screenshot=${sourceScreenshot}`, `candidate-screenshot=${candidateScreenshot}`])
+    const screenshotOnlySummary = JSON.parse(screenshotOnly.output)
+    assert.equal("sourceDomSnapshot" in screenshotOnlySummary.files, false)
+    assert.equal("candidateDomSnapshot" in screenshotOnlySummary.files, false)
+  })
+})
+
+const page = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "text/html" })
+  response.end("<!doctype html><title>URL snapshot</title><main>URL snapshot</main>")
+})
+page.listen(0, "127.0.0.1")
+await once(page, "listening")
+try {
+  const address = page.address()
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not expose a TCP address")
+  }
+  await withTempDir("wp-codebox-visual-dom-url-capture-", async (artifactRoot) => {
+    const url = `http://127.0.0.1:${address.port}/`
+    const result = await visualCompare(artifactRoot, [`source-url=${url}`, `candidate-url=${url}`])
+    const summary = JSON.parse(result.output)
+    const source = JSON.parse(await readFile(join(artifactRoot, summary.files.sourceDomSnapshot), "utf8"))
+    const candidate = JSON.parse(await readFile(join(artifactRoot, summary.files.candidateDomSnapshot), "utf8"))
+    assert.equal(source.schema, "wp-codebox/browser-dom-snapshot/v1")
+    assert.equal(source.finalUrl, url)
+    assert.equal(source.snapshot.title, "URL snapshot")
+    assert.equal(candidate.snapshot.url, url)
+  })
+} finally {
+  page.close()
+}
+
+console.log("browser visual compare DOM snapshots passed")


### PR DESCRIPTION
## Summary

- Persist the source and candidate DOM snapshots already captured by `wordpress.visual-compare`.
- Expose stable `sourceDomSnapshot` and `candidateDomSnapshot` file references in visual-compare artifacts and matrices.
- Register both JSON files in the browser artifact manifest while preserving screenshot-only behavior.

Fixes #1748.

## How to test

1. Run `npm ci` from the repository root.
2. Run `npm run test:browser-visual-compare-dom-snapshots`.
3. Run `npm run test:browser-artifact-session`.
4. Run `npm run test:browser-visual-compare-capture-reliability`.
5. Confirm URL comparisons and supplied DOM-sidecar comparisons expose `files.sourceDomSnapshot` and `files.candidateDomSnapshot`, while screenshot-only comparisons omit them.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Implementing the artifact contract, writing focused tests, and reviewing compatibility with the existing visual-compare schemas.
