### PR TITLE
Canonicalize generated agent task mount paths

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -119,7 +119,9 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
   const originalArgs = step.args ?? []
   const resolvedStep = { ...step, args: rewriteRecipeExecutionArgs(step.command, originalArgs, options.inputMountPathMap) }
   const finish = (spec: ExecutionSpec & { args?: string[] }): ResolvedRecipeExecutionSpec => {
-    const resolvedArgs = spec.args ?? []
+    // Commands can generate PHP and serialized payloads after their source args
+    // are resolved, so canonicalize the generated execution spec as well.
+    const resolvedArgs = rewriteInputMountPathArgs(spec.args ?? [], options.inputMountPathMap)
     assertResolvedInputMountPathArgs(resolvedArgs, options.inputMountPathMap, `Recipe command ${step.command}`)
     return {
       ...spec,

--- a/packages/cli/src/input-mount-paths.ts
+++ b/packages/cli/src/input-mount-paths.ts
@@ -19,18 +19,7 @@ export function rewriteInputMountPathArgs(args: readonly string[] = [], mappings
   if (mappings.length === 0) {
     return [...args]
   }
-  return args.map((arg) => {
-    const separator = arg.indexOf("=")
-    if (separator <= 0) {
-      return arg
-    }
-    const value = arg.slice(separator + 1)
-    if (!value.startsWith("/")) {
-      return arg
-    }
-    const rewritten = rewriteInputMountPath(value, mappings)
-    return rewritten === value ? arg : `${arg.slice(0, separator + 1)}${rewritten}`
-  })
+  return args.map((arg) => rewriteInputMountPathReferences(arg, mappings))
 }
 
 export function rewriteInputMountPathJsonArgs(args: readonly string[] = [], names: readonly string[] = [], mappings: readonly InputMountPathMapping[] = []): string[] {
@@ -95,8 +84,14 @@ function rewriteInputMountPathsInJsonValue(value: unknown, mappings: readonly In
   return value
 }
 
-function originalPathReferencePattern(path: string): RegExp {
-  return new RegExp(`${escapeRegExp(path)}(?=$|[\\/\\s'"\\]\\}\\),:;])`)
+function rewriteInputMountPathReferences(value: string, mappings: readonly InputMountPathMapping[]): string {
+  return [...mappings]
+    .sort((a, b) => b.originalTarget.length - a.originalTarget.length)
+    .reduce((rewritten, mapping) => rewritten.replace(originalPathReferencePattern(mapping.originalTarget, "g"), mapping.canonicalTarget), value)
+}
+
+function originalPathReferencePattern(path: string, flags = ""): RegExp {
+  return new RegExp(`${escapeRegExp(path)}(?=$|[\\/\\s'"\\]\\}\\),:;])`, flags)
 }
 
 // Mounts targeting the WordPress install tree (ABSPATH is `/wordpress/` in the

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.js"
 import { applyRecipeRuntimeSetup, assertResolvedInputMountPathArgs, recipeInputMountPathMap, rewriteInputMountPathArgs, type PreparedRecipeRuntimeSetup } from "../packages/cli/src/commands/recipe-runtime-setup.js"
 import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
 import type { ExecutionSpec, Runtime, WorkspaceRecipe } from "../packages/runtime-core/src/public.js"
@@ -201,17 +202,43 @@ assert.throws(
   /still references original input mount target.*\/home\/wpcom\/public_html/s,
 )
 
-await assert.rejects(
-  () => executeRecipeWorkflowStep(workflowRuntime, {
-    phase: "steps",
-    index: 1,
-    step: {
-      command: "wordpress.run-php",
-      args: ["code=require '/home/wpcom/public_html/bin/tests/i18n-tools/bootstrap.php';"],
-    },
-  }, process.cwd(), undefined, undefined, undefined, wpcomPathMap),
-  /still references original input mount target.*\/home\/wpcom\/public_html/s,
-)
+const agentMountPathMap = recipeInputMountPathMap({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    mounts: [{ source: "/workspace/example", target: "/workspace/example", mode: "readonly" }],
+  },
+  workflow: { steps: [] },
+})
+const agentRuntimeTask = {
+  bootstrap: "require '/workspace/example/bootstrap.php';",
+  nested: { source: "/workspace/example/task.json" },
+}
+const rewrittenAgentTaskArg = rewriteInputMountPathArgs([`runtime-task-json=${JSON.stringify(agentRuntimeTask)}`], agentMountPathMap)[0]
+assert.deepEqual(JSON.parse(rewrittenAgentTaskArg.slice("runtime-task-json=".length)), {
+  bootstrap: `require '${agentMountPathMap[0].canonicalTarget}/bootstrap.php';`,
+  nested: { source: `${agentMountPathMap[0].canonicalTarget}/task.json` },
+}, "serialized agent task payloads rewrite embedded input mount references")
+
+const agentSandboxSpec = await recipeExecutionSpec({
+  command: "wp-codebox.agent-sandbox-run",
+  args: [
+    "task=Inspect /workspace/example/task.json",
+    "code=require '/workspace/example/bootstrap.php';",
+    rewrittenAgentTaskArg,
+  ],
+}, process.cwd(), undefined, { inputMountPathMap: agentMountPathMap })
+assert.equal(agentSandboxSpec.args?.some((arg) => arg.includes("/workspace/example")), false, "generated agent sandbox bootstrap uses canonical input mount paths")
+assert.match(agentSandboxSpec.args?.[0] ?? "", new RegExp(agentMountPathMap[0].canonicalTarget.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+
+const embeddedPhpExecution = await executeRecipeWorkflowStep(workflowRuntime, {
+  phase: "steps",
+  index: 1,
+  step: {
+    command: "wordpress.run-php",
+    args: ["code=require '/home/wpcom/public_html/bin/tests/i18n-tools/bootstrap.php';"],
+  },
+}, process.cwd(), undefined, undefined, undefined, wpcomPathMap)
+assert.deepEqual(embeddedPhpExecution.args, [`code=require '${wpcomPathMap[0].canonicalTarget}/bin/tests/i18n-tools/bootstrap.php';`])
 
 executedWorkflowSpecs.length = 0
 const nestedWorkloadExecution = await executeRecipeWorkflowStep(workflowRuntime, {


### PR DESCRIPTION
## Summary
- canonicalize input mount references embedded anywhere in generated command arguments
- reapply canonicalization after recipe commands generate their final execution specs
- preserve the stale-reference safety assertion and add agent-sandbox regression coverage

Fixes #1800.

## How to test
1. Run `npm ci`.
2. Run `npm run test:recipe-runtime-setup-staged-materialization`.
3. Run `npm run test:agent-task-contracts`.
4. Run `npm run build`.
5. Submit a `run-agent-task` request with a read-only mount targeting `/workspace/example`; confirm generated `wp-codebox.agent-sandbox-run` bootstrap arguments use the canonical `/tmp/wp-codebox-inputs/...` target and the run advances past stale-path validation.

## Verification
- Focused staged-materialization contract passes.
- Full agent-task contract suite passes.
- TypeScript build passes.
- A live parent-site request with two read-only mounts advanced through canonicalization, booted WordPress Playground, materialized both mounts, and executed the generated `wordpress.run-php` bootstrap. Its later failure was the expected absence of an `agents/chat` component in that deliberately minimal request, not mount canonicalization.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the live runtime failure, drafted the canonicalization fix and regression tests, and ran deterministic verification; Chris reviewed and owns the change.