### PR TITLE
Preserve browser runtime versions during post-runtime composition

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php
@@ -56,6 +56,11 @@ private static function browser_blueprint_with_post_runtime( array $blueprint, a
 	$post_steps = is_array( $post_runtime_blueprint['steps'] ?? null ) ? $post_runtime_blueprint['steps'] : array();
 	$merged     = array_merge( $blueprint, $post_runtime_blueprint );
 	$merged['steps'] = array_values( array_merge( $steps, $post_steps ) );
+	if ( array_key_exists( 'preferredVersions', $blueprint ) ) {
+		$merged['preferredVersions'] = $blueprint['preferredVersions'];
+	} else {
+		unset( $merged['preferredVersions'] );
+	}
 
 	if ( isset( $blueprint['features'] ) && isset( $post_runtime_blueprint['features'] ) && is_array( $blueprint['features'] ) && is_array( $post_runtime_blueprint['features'] ) ) {
 		$merged['features'] = array_merge( $blueprint['features'], $post_runtime_blueprint['features'] );

--- a/scripts/php-browser-post-runtime-blueprint-smoke.php
+++ b/scripts/php-browser-post-runtime-blueprint-smoke.php
@@ -15,7 +15,7 @@ final class WP_Codebox_Post_Runtime_Blueprint_Smoke {
 }
 
 $runtime_blueprint = array(
-	'preferredVersions' => array( 'php' => '8.3' ),
+	'preferredVersions' => array( 'wp' => '7.0', 'php' => '8.4' ),
 	'features'          => array( 'networking' => false ),
 	'steps'             => array(
 		array( 'step' => 'login' ),
@@ -23,8 +23,9 @@ $runtime_blueprint = array(
 	),
 );
 $post_runtime = array(
-	'features' => array( 'networking' => true ),
-	'steps'    => array( array( 'step' => 'runPHP', 'code' => '<?php import_site();' ) ),
+	'preferredVersions' => array( 'wp' => 'latest', 'php' => '8.2' ),
+	'features'          => array( 'networking' => true ),
+	'steps'             => array( array( 'step' => 'runPHP', 'code' => '<?php import_site();' ) ),
 );
 
 $merged = WP_Codebox_Post_Runtime_Blueprint_Smoke::merge( $runtime_blueprint, $post_runtime );
@@ -32,6 +33,10 @@ $steps  = array_column( $merged['steps'] ?? array(), 'step' );
 
 if ( array( 'login', 'installPlugin', 'runPHP' ) !== $steps ) {
 	fwrite( STDERR, 'Post-runtime blueprint steps were not appended after runtime materialization.' . PHP_EOL );
+	exit( 1 );
+}
+if ( array( 'wp' => '7.0', 'php' => '8.4' ) !== ( $merged['preferredVersions'] ?? null ) ) {
+	fwrite( STDERR, 'Post-runtime blueprint preferredVersions overwrote the runtime selection.' . PHP_EOL );
 	exit( 1 );
 }
 if ( true !== ( $merged['features']['networking'] ?? null ) ) {


### PR DESCRIPTION
## Summary
Keep runtime-selected WordPress and PHP versions authoritative when callers append post-runtime browser blueprint steps.

## What changed
- Preserve the runtime-materialized preferredVersions instead of allowing post-runtime import blueprints to replace them.
- Add regression coverage for WordPress 7.0 and PHP 8.4 surviving conflicting latest and PHP 8.2 post-runtime values.

## How to test
1. Run `php scripts/php-browser-post-runtime-blueprint-smoke.php`; expect prints OK and exits 0.

## Compatibility
No public API removal. Existing post-runtime step ordering and feature merge behavior are preserved; post-runtime callers can no longer replace runtime-owned preferredVersions.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1798
- post-runtime-blueprint-smoke: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the production runtime-version override and drafted the implementation and regression coverage; Chris reviews and owns the change.

## Source relationships
- Closes Automattic/wp-codebox#1798
