### PR TITLE
Disable PHPUnit result caching in Playground

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -274,7 +274,7 @@ function ${options.relativeFunctionName}(string $path, string $${options.rootPar
 
 function phpunitArgsPhp(functionName: string, logFunction: string): string {
   return `function ${functionName}(array $argv) {
-    $arguments = array('colors' => 'never', 'testdox' => true, 'verbose' => false, 'extensions' => array());
+    $arguments = array('colors' => 'never', 'testdox' => true, 'verbose' => false, 'cacheResult' => false, 'extensions' => array());
     $args = array_slice($argv, 1);
     for ($i = 0; $i < count($args); $i++) {
         $arg = $args[$i];

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -320,5 +320,6 @@ const managedModeCode = phpunitRunCode({
 })
 
 assert.ok(managedModeCode.includes("configured PHPUnit harness autoload file is not readable"))
+assert.ok(managedModeCode.includes("'cacheResult' => false"))
 
 console.log("phpunit project autoload ok")


### PR DESCRIPTION
Closes #1803

## Summary

- disable PHPUnit result caching in the in-process Playground PHPUnit runner
- preserve readonly plugin source mounts by keeping PHPUnit from writing `.phpunit.result.cache` into the test component

## Tests

1. `npm exec tsx -- tests/phpunit-project-autoload.test.ts`
2. `npm run build`

## Compatibility

WP Codebox PHPUnit recipes no longer create PHPUnit result cache files. Test execution and result reporting are unchanged.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode/openai-gpt-5.6-sol
- **Used for:** Diagnosed the readonly mount regression from a downstream runtime canary, implemented the focused runner default, and added contract coverage; Chris reviews and owns the change.