### PR TITLE
Handle absent tool observability during upload

### DIFF
--- a/.github/scripts/run-agent-task/prepare-agent-task-upload.mjs
+++ b/.github/scripts/run-agent-task/prepare-agent-task-upload.mjs
@@ -218,7 +218,7 @@ function projectParsed(value) {
     tool_results: results.slice(0, MAX_TRANSCRIPT_EXECUTIONS).map(projectToolCall),
     errors: errors.slice(0, MAX_TRANSCRIPT_EXECUTIONS).flatMap((error) => boundedText(record(error).message ?? error) ? [boundedText(record(error).message ?? error)] : []),
     tool_observability: toolObservability,
-  }).filter(([, item]) => Array.isArray(item) ? item.length > 0 : Object.keys(item).length > 0))
+  }).filter(([, item]) => item !== undefined && (Array.isArray(item) ? item.length > 0 : Object.keys(item).length > 0)))
 }
 
 // This is deliberately limited to the public Agents API summary. Tool payloads

--- a/tests/execute-native-agent-task-playground-e2e.test.ts
+++ b/tests/execute-native-agent-task-playground-e2e.test.ts
@@ -90,6 +90,7 @@ add_filter( 'pre_http_request', static function( $preempt, $args, $url ) {
   assert.equal(exclusions.canonical_transcripts.length, 1, "available canonical evidence is projected once")
   assert.match(exclusions.canonical_transcripts[0].provenance.artifact_path, /^runtime-[a-z0-9-]+\/files\/transcript\.json$/)
   const staged = JSON.stringify(await Promise.all((await readdir(join(workspace, ".codebox", "agent-task-upload"), { recursive: true })).map((path) => readFile(join(workspace, ".codebox", "agent-task-upload", path), "utf8").catch(() => ""))))
+  assert.doesNotMatch(staged, /"tool_observability"/, "absent optional tool observability is omitted during upload staging")
   for (const privateValue of ["wp-codebox-runner-workspace-seed-", workspace, "PRIVATE_WORKSPACE_SENTINEL", "PRIVATE_NPM_SENTINEL", "PRIVATE_NETRC_SENTINEL", "PRIVATE_KEY_SENTINEL"]) assert.doesNotMatch(staged, new RegExp(privateValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
   const stagedInput = JSON.parse(await readFile(join(workspace, ".codebox", "agent-task-upload", ".codebox", "native-agent-task-input.json"), "utf8"))
   assert.deepEqual(stagedInput.task_input.workspaces[0].seed, { kind: "runner-workspace-seed", digest: seedProvenance.digest.sha256, files: 2, bytes: seedProvenance.bytes, excludes: seedProvenance.excludes, excluded: seedProvenance.excluded })


### PR DESCRIPTION
## Summary
Keep optional tool observability absent during reviewer transcript staging.

## What changed
- Guarded the optional projection before array/object emptiness filtering and added native Playground coverage for runs without tool observability.

## How to test
1. Run `npm run test:native-agent-task-playground-e2e`; expect The formerly failing upload path succeeds and omits absent tool observability..
2. Run `npm run build`; expect TypeScript compilation succeeds..
3. Run `npm run test:agent-task-contracts`; expect Agent-task and runtime materialization contracts pass..
4. Run `npm run test:browser-runner-template`; expect Browser runner template contracts pass..

## Compatibility
Bug fix restoring the pre-#1809 behavior for runs that do not expose optional tool observability. Runs with canonical version 1 observability are unchanged.

## Evidence
- CI expected: Agent Task Contracts / contracts
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1810
- agent-task-contracts: Passed
- browser-runner-template: Passed
- build: Passed
- native-playground: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the post-merge CI failure, implemented the null-safe optional projection, added native Playground regression coverage, and verified all affected contracts; Chris reviewed and owns the change.

## Source relationships
- Closes #1810
