### PR TITLE
Declare plugin archive release coverage

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,18 @@
     "nodejs": {}
   },
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
+  "release": {
+    "package_coverage": [
+      {
+        "artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
+        "artifact_match": "exact",
+        "source_roots": [
+          "packages/wordpress-plugin"
+        ],
+        "archive_root": "wp-codebox"
+      }
+    ]
+  },
   "version_targets": [
     {
       "file": "package.json",
@@ -45,6 +57,7 @@
     ],
     "test": [
       "npm run smoke -- --group package",
+      "npm run test:release-package-coverage",
       "npm run release:package"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "prepare": "npm run build",
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
+    "test:release-package-coverage": "tsx tests/release-package-coverage.test.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wp-codebox:source": "node bin/wp-codebox-source.mjs",
     "generate:browser-fanout-aggregation-runtime": "tsx scripts/generate-browser-fanout-aggregation-runtime.ts",

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repositoryRoot = resolve(import.meta.dirname, "..")
+const pluginRoot = "packages/wordpress-plugin"
+const pluginArtifact = "packages/wordpress-plugin/dist/wp-codebox.zip"
+
+const homeboy = JSON.parse(await readFile(resolve(repositoryRoot, "homeboy.json"), "utf8"))
+assert.deepEqual(homeboy.release?.package_coverage, [{
+  artifact: pluginArtifact,
+  artifact_match: "exact",
+  source_roots: [pluginRoot],
+  archive_root: "wp-codebox",
+}])
+
+const { stdout } = await execFileAsync("npm", ["run", "release:package"], {
+  cwd: repositoryRoot,
+  maxBuffer: 1024 * 1024 * 20,
+})
+const artifacts = JSON.parse(stdout.trim().split("\n").at(-1) ?? "[]")
+assert.equal(artifacts.length, 2, "release package emitted unexpected artifacts")
+assert.deepEqual(artifacts.filter((artifact: { type: string }) => artifact.type === "wordpress-plugin-zip"), [
+  { path: pluginArtifact, type: "wordpress-plugin-zip" },
+])
+const cliArtifacts = artifacts.filter((artifact: { type: string }) => artifact.type === "node-cli-tarball")
+assert.equal(cliArtifacts.length, 1, "release package must emit exactly one CLI tarball")
+const cliArtifact = cliArtifacts[0] as { path: string, platform: string }
+assert.match(cliArtifact.path, /^dist\/wp-codebox-cli-[^/]+\.tar\.gz$/)
+assert.match(cliArtifact.platform, /^[a-z0-9]+-[a-z0-9]+$/)
+assert.equal(cliArtifact.path, `dist/wp-codebox-cli-${cliArtifact.platform}.tar.gz`)
+
+const { stdout: tracked } = await execFileAsync("git", ["ls-files", "-z", "--", `${pluginRoot}/**`], { cwd: repositoryRoot })
+const mappedFiles = tracked
+  .split("\0")
+  .filter(Boolean)
+  .filter((path) => /\.(php|inc|phtml|js|mjs|cjs|css|json)$/.test(path))
+  .filter((path) => !path.endsWith("/package.json"))
+  .map((path) => `wp-codebox/${path.slice(pluginRoot.length + 1)}`)
+assert.ok(mappedFiles.length > 0, "plugin source root has no mapped tracked runtime files")
+
+const { stdout: zipEntries } = await execFileAsync("unzip", ["-Z1", pluginArtifact], {
+  cwd: repositoryRoot,
+  maxBuffer: 1024 * 1024 * 20,
+})
+const archiveEntries = new Set(zipEntries.trim().split("\n"))
+for (const path of mappedFiles) {
+  assert.ok(archiveEntries.has(path), `${pluginArtifact} is missing mapped tracked file ${path}`)
+}
+
+assert.equal(archiveEntries.has("wp-codebox/package.json"), false, "package metadata is intentionally excluded from the plugin archive")
+
+const { stdout: tarEntries } = await execFileAsync("tar", ["-tzf", cliArtifact.path], {
+  cwd: repositoryRoot,
+  maxBuffer: 1024 * 1024 * 20,
+})
+assert.ok(tarEntries.split("\n").some((path) => path === "wp-codebox-cli/"), "CLI tarball root changed")
+
+console.log("release package coverage passed")


### PR DESCRIPTION
## Summary
Declare the transformed WordPress plugin ZIP layout so Homeboy can validate release completeness without bypasses.

## What changed
- Mapped packages/wordpress-plugin into the wp-codebox archive root for the exact generated plugin ZIP artifact.
- Added a portable executable release-package contract that builds both artifacts, validates every mapped tracked plugin runtime file, and preserves the manifest-derived CLI tarball layout.

## How to test
1. Run `npm run test:release-package-coverage`; expect The real release package builder emits exactly one plugin ZIP and one platform-derived CLI tarball; every mapped tracked plugin runtime file exists in the ZIP..
2. Run `npm run smoke -- --group package`; expect Package smoke checks pass; the Docker-dependent MySQL integration is skipped when Docker is unavailable..
3. Run `npm run build`; expect All TypeScript packages build successfully..
4. Run `git diff --check`; expect The patch contains no whitespace errors..

## Compatibility
Configuration and test-only change. No runtime or public API behavior, plugin extension path, ZIP layout, CLI artifact layout, or existing release output is changed. The declaration enables fail-closed validation through Homeboy #8499.

## Evidence
- CI expected: contracts
- CI expected: workflow-lint
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1829
- build: Passed
- package-smoke: Passed
- release-package-coverage: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding and review subagents
- **Model:** openai/gpt-5.6-sol
- **Used for:** Added and independently reviewed the generic release package coverage declaration and executable package-layout contract; Chris reviews and owns the change.

## Source relationships
- Closes Automattic/wp-codebox#1829
