### PR TITLE
test: cover default PHPUnit recipe paths

### DIFF
--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -36,6 +36,12 @@ try {
   const builtRecipe = JSON.parse(await readFile(recipePath, "utf8")) as WorkspaceRecipe
   assert.ok(builtRecipe.workflow.steps[0].args?.includes("test-root=/home/example/bin/tests/core"))
   assert.ok(builtRecipe.workflow.steps[0].args?.includes("phpunit-xml=/home/example/bin/tests/core/phpunit.xml"))
+
+  await writeFile(optionsPath, JSON.stringify({ pluginSlug: "example" }))
+  assert.equal(await runRecipeBuildCommand(["phpunit", "--options", optionsPath, "--output", recipePath]), 0)
+  const defaultRecipe = JSON.parse(await readFile(recipePath, "utf8")) as WorkspaceRecipe
+  assert.ok(defaultRecipe.workflow.steps[0].args?.includes("test-root=/wordpress/wp-content/plugins/example/tests"))
+  assert.ok(defaultRecipe.workflow.steps[0].args?.includes("phpunit-xml=/wordpress/wp-content/plugins/example/phpunit.xml.dist"))
 } finally {
   await rm(builderDirectory, { recursive: true, force: true })
 }


### PR DESCRIPTION
## Summary
Cover the default PHPUnit recipe paths at the CLI recipe-build boundary.

## What changed
- Assert that recipe build forwards explicit PHPUnit paths and emits plugin-derived defaults when those paths are omitted.

## How to test
1. Run `npm ci`; expect Dependencies install and the workspace builds successfully..
2. Run `npm run test:runtime-services`; expect The command prints runtime services tests passed..
3. Run `npm run build`; expect TypeScript compilation completes successfully..

## Compatibility
Test-only change. No production behavior or extension contract changes.

## Evidence
- Base unchanged since verification: main remains at 65efc1cee169e67d9403f6eec812bbeeeb2564c8.
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1828
- Verified finalization base: main at 65efc1cee169e67d9403f6eec812bbeeeb2564c8
- diff-check: Passed
- runtime-services: Passed
- typescript-build: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy and OpenCode
- **Model:** openai/gpt-5.6-terra and openai/gpt-5.6-sol
- **Used for:** Diagnosed the missing CLI forwarding coverage, generated and promoted the regression test, repaired the upstream promotion path, and ran deterministic verification; Chris reviews and owns the change.

## Source relationships
- Closes Automattic/wp-codebox#1828
