### PR TITLE
Fix project-mode PHPUnit builder autoload default

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -67,6 +67,7 @@ export function normalizeRecipeMounts(mounts: readonly WorkspaceRecipeMount[] = 
 export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptions): WorkspaceRecipe {
   const pluginSlug = requiredPluginSlug(options.pluginSlug, "buildWordPressPhpunitRecipe")
   const pluginTarget = `/wordpress/wp-content/plugins/${pluginSlug}`
+  const autoloadFile = options.autoloadFile ?? (options.bootstrapMode === "project" ? "" : "/wp-codebox-vendor/autoload.php")
 
   return {
     schema: "wp-codebox/workspace-recipe/v1",
@@ -93,8 +94,8 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
           commandJsonArg("changed-tests-json", options.changedTestFiles ?? []),
           commandJsonArg("env-json", options.env ?? {}),
           commandJsonArg("wp-config-defines-json", options.wpConfigDefines ?? {}),
-          commandArg("autoload-file", options.autoloadFile ?? "/wp-codebox-vendor/autoload.php"),
-          commandArg("autoload-file-role", "harness"),
+          commandArg("autoload-file", autoloadFile),
+          commandArg("autoload-file-role", autoloadFile ? "harness" : ""),
           commandArg("project-autoload-file", options.projectAutoloadFile ?? ""),
           commandArg("tests-dir", options.testsDir ?? "/wp-codebox-vendor/wp-phpunit/wp-phpunit"),
           commandArg("test-root", options.testRoot ?? `${pluginTarget}/tests`),

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -13,6 +13,27 @@ import { recipeInputMountPathMap, rewriteInputMountPathArgs } from "../packages/
 
 const woocommerceAutoload = "/wordpress/wp-content/plugins/woocommerce/vendor/autoload_packages.php"
 
+function phpunitRecipeArgs(options: Omit<Parameters<typeof buildWordPressPhpunitRecipe>[0], "pluginSlug">): string[] {
+  return buildWordPressPhpunitRecipe({ pluginSlug: "demo-plugin", ...options }).workflow.steps[0].args
+}
+
+const projectRecipeWithoutAutoload = phpunitRecipeArgs({ bootstrapMode: "project" })
+assert.ok(projectRecipeWithoutAutoload.includes("autoload-file="))
+assert.ok(!projectRecipeWithoutAutoload.some((arg) => arg === "autoload-file-role=harness"), "project mode without an autoload file must not require the harness")
+
+const managedRecipe = phpunitRecipeArgs({})
+assert.ok(managedRecipe.includes("autoload-file=/wp-codebox-vendor/autoload.php"))
+assert.ok(managedRecipe.includes("autoload-file-role=harness"))
+
+const explicitAutoloadRecipe = phpunitRecipeArgs({
+  bootstrapMode: "project",
+  autoloadFile: "/wp-codebox-vendor/autoload.php",
+  projectAutoloadFile: "/workspace/project/vendor/autoload.php",
+})
+assert.ok(explicitAutoloadRecipe.includes("autoload-file=/wp-codebox-vendor/autoload.php"))
+assert.ok(explicitAutoloadRecipe.includes("autoload-file-role=harness"))
+assert.ok(explicitAutoloadRecipe.includes("project-autoload-file=/workspace/project/vendor/autoload.php"))
+
 function extractPhpFunction(source: string, functionName: string): string {
   const start = source.indexOf(`function ${functionName}(`)
   assert.notEqual(start, -1)
@@ -198,15 +219,15 @@ assert.deepEqual(recipe.inputs.mounts?.filter((mount) => mount.target === "/wp-c
 ])
 
 assert.deepEqual(recipe.workflow.steps[0].args.filter((arg) => arg.includes("autoload-file=")), [
-  "autoload-file=/wp-codebox-vendor/autoload.php",
+  "autoload-file=",
   `project-autoload-file=${woocommerceAutoload}`,
 ])
-assert.ok(recipe.workflow.steps[0].args.includes("autoload-file-role=harness"), "modern PHPUnit recipes explicitly preserve harness autoload intent")
+assert.ok(!recipe.workflow.steps[0].args.includes("autoload-file-role=harness"), "project mode without an explicit autoload file preserves project-owned harness setup")
 assert.deepEqual(rewriteInputMountPathArgs(recipe.workflow.steps[0].args, recipeInputMountPathMap(recipe)).filter((arg) => arg.includes("autoload-file=")), [
-  "autoload-file=/tmp/wp-codebox-inputs/0-wp-codebox-vendor-73845ca47d2f/autoload.php",
+  "autoload-file=",
   `project-autoload-file=${woocommerceAutoload}`,
 ])
-assert.ok(rewriteInputMountPathArgs(recipe.workflow.steps[0].args, recipeInputMountPathMap(recipe)).includes("autoload-file-role=harness"), "CLI path canonicalization preserves autoload intent")
+assert.ok(!rewriteInputMountPathArgs(recipe.workflow.steps[0].args, recipeInputMountPathMap(recipe)).includes("autoload-file-role=harness"), "CLI path canonicalization preserves absent harness autoload intent")
 assert.ok(recipe.workflow.steps[0].args.includes("cwd=/home/example/public_html"))
 assert.ok(recipe.workflow.steps[0].args.includes("test-root=/home/example/public_html/bin/tests/phpunit"))
 assert.ok(recipe.workflow.steps[0].args.includes("phpunit-xml=/home/example/public_html/bin/tests/phpunit/phpunit.xml.dist"))


### PR DESCRIPTION
Closes #1835.

## Summary
- let project-mode PHPUnit recipes preserve the runtime default when no harness autoload is supplied
- retain the `/wp-codebox-vendor/autoload.php` default and harness role for managed mode
- preserve explicit harness and project autoload behavior
- cover project, managed, and explicit builder cases deterministically

## How to test
1. Run `npm ci`.
2. Run `npm exec -- tsx tests/phpunit-project-autoload.test.ts`.
3. Run `npm run build`.
4. Build a PHPUnit recipe with `bootstrapMode: "project"` and no `autoloadFile`; confirm the step contains `autoload-file=` and no `autoload-file-role=harness`.
5. Build the same recipe in managed/default mode; confirm it contains `autoload-file=/wp-codebox-vendor/autoload.php` and `autoload-file-role=harness`.

## Compatibility
- Managed/default PHPUnit recipes retain their existing harness behavior.
- Explicit `autoloadFile` and `projectAutoloadFile` inputs retain their existing behavior.
- Project-mode callers that omitted `autoloadFile` no longer require an undeclared `/wp-codebox-vendor` mount, matching the runtime behavior shipped in #1733.

## Verification
- `npm exec -- tsx tests/phpunit-project-autoload.test.ts`: passed (`phpunit project autoload ok`)
- `npm run build`: passed
- `git diff --check`: passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Investigated the builder/runtime mismatch, drafted the implementation and deterministic regression coverage, and verified the candidate; Chris reviewed and owns the change.