### PR TITLE
Ignore Git-excluded files during workspace publication

### DIFF
--- a/packages/runtime-core/src/runner-workspace-apply.ts
+++ b/packages/runtime-core/src/runner-workspace-apply.ts
@@ -235,25 +235,24 @@ function validatePatchPaths(patch: string, changed: RunnerWorkspaceChangedFile[]
 
 async function snapshotWorkspace(root: string): Promise<RunnerWorkspacePublicationFile[]> {
   const output: RunnerWorkspacePublicationFile[] = []
-  async function visit(directory: string): Promise<void> {
-    for (const entry of await readdir(directory, { withFileTypes: true })) {
-      if (entry.name === ".git" || entry.name === ".codebox") continue
-      const absolute = resolve(directory, entry.name)
-      const path = relative(root, absolute).replaceAll("\\", "/")
-      const stat = await lstat(absolute)
-      if (stat.isSymbolicLink()) throw new Error(`Runner workspace contains an unsupported path type: ${path}`)
-      if (stat.isDirectory()) {
-        await visit(absolute)
-        continue
-      }
-      if (!stat.isFile()) throw new Error(`Runner workspace contains an unsupported path type: ${path}`)
-      const mode = (stat.mode & 0o111) ? "100755" : "100644"
-      const bytes = await readFile(absolute)
-      output.push({ path, mode, content: bytes.toString("base64"), sha256: createHash("sha256").update(bytes).digest("hex"), deleted: false })
+  const { stdout } = await execFileAsync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], { cwd: root, maxBuffer: MAX_PATCH_BYTES })
+  const paths = stdout.split("\0").filter(Boolean).sort((left, right) => left.localeCompare(right))
+  for (const path of paths) {
+    const absolute = resolve(root, path)
+    if (!pathIsWithinRoot(absolute, root)) throw new Error(`Runner workspace contains a denied path: ${path}`)
+    let stat
+    try {
+      stat = await lstat(absolute)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue
+      throw error
     }
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`Runner workspace contains an unsupported path type: ${path}`)
+    const mode = (stat.mode & 0o111) ? "100755" : "100644"
+    const bytes = await readFile(absolute)
+    output.push({ path, mode, content: bytes.toString("base64"), sha256: createHash("sha256").update(bytes).digest("hex"), deleted: false })
   }
-  await visit(root)
-  return output.sort((a, b) => a.path.localeCompare(b.path))
+  return output
 }
 
 function validateAppliedWorkspace(baseline: RunnerWorkspacePublicationFile[], current: RunnerWorkspacePublicationFile[], changed: RunnerWorkspaceChangedFile[]): void {

--- a/tests/runner-workspace-apply.test.ts
+++ b/tests/runner-workspace-apply.test.ts
@@ -113,6 +113,34 @@ const files = [{ path: "/workspace/README.md", relativePath: "README.md", status
 
 {
   const input = await fixture(patch, files)
+  await writeFile(join(input.workspace, ".gitignore"), "node_modules/\n")
+  await exec("git", ["add", ".gitignore"], { cwd: input.workspace })
+  await exec("git", ["commit", "--quiet", "-m", "ignore dependencies"], { cwd: input.workspace })
+  const result = await applyRunnerWorkspacePatch({
+    artifactRoot: input.artifacts,
+    artifactRefs: input.refs,
+    workspaceRoot: input.workspace,
+    writablePaths: ["README.md"],
+    verify: async () => {
+      const packageLinks = join(input.workspace, "node_modules", ".pnpm", "hono", "node_modules")
+      await mkdir(packageLinks, { recursive: true })
+      await symlink(input.artifacts, join(packageLinks, "hono"))
+    },
+  })
+  await verifyRunnerWorkspaceIntegrity(result.integrity!)
+}
+
+{
+  const input = await fixture(patch, files)
+  await symlink(input.artifacts, join(input.workspace, "publishable-link"))
+  await assert.rejects(
+    () => applyRunnerWorkspacePatch({ artifactRoot: input.artifacts, artifactRefs: input.refs, workspaceRoot: input.workspace, writablePaths: ["README.md"] }),
+    /unsupported path type: publishable-link/,
+  )
+}
+
+{
+  const input = await fixture(patch, files)
   await assert.rejects(() => applyRunnerWorkspacePatch({ artifactRoot: input.artifacts, artifactRefs: input.refs, workspaceRoot: input.workspace, writablePaths: ["src/**"] }), /outside writable_paths/)
   assert.equal(await readFile(join(input.workspace, "README.md"), "utf8"), "before\n")
 }


### PR DESCRIPTION
## Summary
- snapshot runner workspaces from Git tracked and untracked-nonignored files instead of recursively traversing ignored dependency trees
- preserve fail-closed rejection for tracked or publishable symlinks and unsupported file types
- cover pnpm-style ignored package links through the post-verification integrity check

Fixes #1844.

## Evidence

The Build with WordPress acceptance run passed dependency installation, build, verification, and drift checks, then failed publication on an ignored pnpm symlink: https://github.com/Automattic/build-with-wordpress/actions/runs/29624869237

## How to test
1. Run `npm ci`.
2. Run `npm run build`.
3. Run `npm run test:runner-workspace-apply`.
4. Run `npm run test:runner-workspace-publisher`.
5. Confirm the apply test accepts verification-created symlinks below an ignored `node_modules/` tree and still rejects a nonignored workspace symlink.

## Compatibility
- No public API, extension path, or serialized contract changes.
- Publication now follows standard Git ignore semantics for untracked files; tracked files remain included even when an ignore rule matches them.

## Testing caveat

`npm run check` reached the existing `command-registry-smoke` and failed with `wordpress.collect-workload-result outputShape should mention outputSchema id`. This change does not touch command registry code. The targeted tests and TypeScript build pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Diagnosed the hosted publication failure, drafted the Git-aware snapshot implementation and regression tests, and ran verification with Chris reviewing and owning the change.