### PR TITLE
Exclude Codebox control files from publication snapshots

### DIFF
--- a/packages/runtime-core/src/runner-workspace-apply.ts
+++ b/packages/runtime-core/src/runner-workspace-apply.ts
@@ -236,7 +236,9 @@ function validatePatchPaths(patch: string, changed: RunnerWorkspaceChangedFile[]
 async function snapshotWorkspace(root: string): Promise<RunnerWorkspacePublicationFile[]> {
   const output: RunnerWorkspacePublicationFile[] = []
   const { stdout } = await execFileAsync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], { cwd: root, maxBuffer: MAX_PATCH_BYTES })
-  const paths = stdout.split("\0").filter(Boolean).sort((left, right) => left.localeCompare(right))
+  const paths = stdout.split("\0")
+    .filter((path) => path && path !== ".codebox" && !path.startsWith(".codebox/"))
+    .sort((left, right) => left.localeCompare(right))
   for (const path of paths) {
     const absolute = resolve(root, path)
     if (!pathIsWithinRoot(absolute, root)) throw new Error(`Runner workspace contains a denied path: ${path}`)

--- a/tests/runner-workspace-apply.test.ts
+++ b/tests/runner-workspace-apply.test.ts
@@ -132,6 +132,24 @@ const files = [{ path: "/workspace/README.md", relativePath: "README.md", status
 
 {
   const input = await fixture(patch, files)
+  const controlDirectory = join(input.workspace, ".codebox")
+  await mkdir(controlDirectory)
+  await writeFile(join(controlDirectory, "request.json"), "before\n")
+  const result = await applyRunnerWorkspacePatch({
+    artifactRoot: input.artifacts,
+    artifactRefs: input.refs,
+    workspaceRoot: input.workspace,
+    writablePaths: ["README.md"],
+    verify: async () => {
+      await writeFile(join(controlDirectory, "request.json"), "after\n")
+      await writeFile(join(controlDirectory, "result.json"), "complete\n")
+    },
+  })
+  await verifyRunnerWorkspaceIntegrity(result.integrity!)
+}
+
+{
+  const input = await fixture(patch, files)
   await symlink(input.artifacts, join(input.workspace, "publishable-link"))
   await assert.rejects(
     () => applyRunnerWorkspacePatch({ artifactRoot: input.artifacts, artifactRefs: input.refs, workspaceRoot: input.workspace, writablePaths: ["README.md"] }),


### PR DESCRIPTION
## Summary
- preserve `.codebox` as an unconditional runtime-control exclusion in Git-aware workspace snapshots
- allow task request/result state to mutate after patch approval without invalidating publishable workspace integrity
- retain checks for every tracked and untracked-nonignored workspace file

Fixes #1847.

## Evidence

WP Codebox `v0.12.25` acceptance run https://github.com/Automattic/build-with-wordpress/actions/runs/29627878516 passed install, build, verify, and drift after the pnpm symlink fix, then failed integrity because the target does not ignore runtime-owned `.codebox` files.

## How to test
1. Run `npm ci`.
2. Run `npm run build`.
3. Run `npm run test:runner-workspace-apply`.
4. Run `npm run test:runner-workspace-publisher`.
5. Confirm the apply test mutates `.codebox/request.json`, adds `.codebox/result.json`, and still passes integrity, while a publishable workspace change and symlink remain rejected.

## Compatibility
- No public API, serialized contract, or extension path changes.
- This restores the pre-#1845 `.codebox` exclusion while retaining #1845 Git-ignore behavior for dependency artifacts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Diagnosed the hosted v0.12.25 regression, drafted the minimal exclusion and deterministic regression coverage, and ran verification with Chris reviewing and owning the change.