### PR TITLE
Report runner workspace integrity changes

### DIFF
--- a/.github/scripts/run-agent-task/execute-native-agent-task.mjs
+++ b/.github/scripts/run-agent-task/execute-native-agent-task.mjs
@@ -696,7 +696,7 @@ if (execution.code === 0 && runtimeRecord.success === true && verificationPassed
     runtimeRecord.metadata = { ...record(runtimeRecord.metadata), runner_workspace_publication: publication }
     runtimeRecord.outputs = { ...record(runtimeRecord.outputs), runner_workspace_publication: publication }
   } catch (error) {
-    downstreamFailure = { stage: "publication", message: bounded(error instanceof Error ? error.message : String(error), MAX_WORKFLOW_OUTPUT_BYTES) }
+    downstreamFailure = { stage: "publication", message: bounded(error instanceof Error ? error.message : String(error), MAX_WORKFLOW_OUTPUT_BYTES), ...(error?.evidence ? { evidence: error.evidence } : {}) }
   }
 }
 if (request.success?.requires_pr === true && workspaceApply.status === "no-op" && !publication) {

--- a/packages/runtime-core/src/runner-workspace-apply.ts
+++ b/packages/runtime-core/src/runner-workspace-apply.ts
@@ -67,6 +67,15 @@ export interface RunnerWorkspaceIntegritySnapshot {
   baseline: RunnerWorkspacePublicationFile[]
 }
 
+export interface RunnerWorkspaceIntegrityFailureEvidence {
+  schema: "wp-codebox/runner-workspace-integrity-failure/v1"
+  added: string[]
+  modified: string[]
+  deleted: string[]
+  total: number
+  truncated: boolean
+}
+
 /**
  * Promotes the canonical sandbox patch artifact into the checked-out workspace.
  * Artifact references are treated as locators only after containment and digest
@@ -157,7 +166,23 @@ export async function runnerWorkspaceIdentity(root: string): Promise<RunnerWorks
 export async function verifyRunnerWorkspaceIntegrity(snapshot: RunnerWorkspaceIntegritySnapshot): Promise<void> {
   const current = await snapshotWorkspace(snapshot.workspaceRoot)
   if (JSON.stringify(current) !== JSON.stringify(snapshot.files)) {
-    throw new Error("Runner workspace changed after approval; refusing publication.")
+    const approved = new Map(snapshot.files.map((file) => [file.path, file]))
+    const actual = new Map(current.map((file) => [file.path, file]))
+    const added = [...actual.keys()].filter((path) => !approved.has(path)).sort()
+    const deleted = [...approved.keys()].filter((path) => !actual.has(path)).sort()
+    const modified = [...approved.keys()].filter((path) => actual.has(path) && JSON.stringify(approved.get(path)) !== JSON.stringify(actual.get(path))).sort()
+    const changed = [...added, ...modified, ...deleted]
+    const limit = 100
+    const error = new Error(`Runner workspace changed after approval; refusing publication. Changed paths: ${changed.slice(0, 10).join(", ")}`) as Error & { evidence?: RunnerWorkspaceIntegrityFailureEvidence }
+    error.evidence = {
+      schema: "wp-codebox/runner-workspace-integrity-failure/v1",
+      added: added.slice(0, limit),
+      modified: modified.slice(0, limit),
+      deleted: deleted.slice(0, limit),
+      total: changed.length,
+      truncated: changed.length > limit,
+    }
+    throw error
   }
 }
 
@@ -235,10 +260,7 @@ function validatePatchPaths(patch: string, changed: RunnerWorkspaceChangedFile[]
 
 async function snapshotWorkspace(root: string): Promise<RunnerWorkspacePublicationFile[]> {
   const output: RunnerWorkspacePublicationFile[] = []
-  const { stdout } = await execFileAsync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], { cwd: root, maxBuffer: MAX_PATCH_BYTES })
-  const paths = stdout.split("\0")
-    .filter((path) => path && path !== ".codebox" && !path.startsWith(".codebox/"))
-    .sort((left, right) => left.localeCompare(right))
+  const paths = await workspaceSnapshotPaths(root)
   for (const path of paths) {
     const absolute = resolve(root, path)
     if (!pathIsWithinRoot(absolute, root)) throw new Error(`Runner workspace contains a denied path: ${path}`)
@@ -255,6 +277,31 @@ async function snapshotWorkspace(root: string): Promise<RunnerWorkspacePublicati
     output.push({ path, mode, content: bytes.toString("base64"), sha256: createHash("sha256").update(bytes).digest("hex"), deleted: false })
   }
   return output
+}
+
+async function workspaceSnapshotPaths(root: string): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], { cwd: root, maxBuffer: MAX_PATCH_BYTES })
+    return stdout.split("\0")
+      .filter((path) => path && path !== ".codebox" && !path.startsWith(".codebox/"))
+      .sort((left, right) => left.localeCompare(right))
+  } catch {
+    const paths: string[] = []
+    async function visit(directory: string): Promise<void> {
+      for (const entry of await readdir(directory, { withFileTypes: true })) {
+        if ([".git", ".codebox", "node_modules", "vendor"].includes(entry.name)) continue
+        const absolute = resolve(directory, entry.name)
+        const path = relative(root, absolute).replaceAll("\\", "/")
+        if (entry.isDirectory()) {
+          await visit(absolute)
+        } else {
+          paths.push(path)
+        }
+      }
+    }
+    await visit(root)
+    return paths.sort((left, right) => left.localeCompare(right))
+  }
 }
 
 function validateAppliedWorkspace(baseline: RunnerWorkspacePublicationFile[], current: RunnerWorkspacePublicationFile[], changed: RunnerWorkspaceChangedFile[]): void {

--- a/tests/runner-workspace-apply.test.ts
+++ b/tests/runner-workspace-apply.test.ts
@@ -108,7 +108,19 @@ const files = [{ path: "/workspace/README.md", relativePath: "README.md", status
   const input = await fixture(patch, files)
   const result = await applyRunnerWorkspacePatch({ artifactRoot: input.artifacts, artifactRefs: input.refs, workspaceRoot: input.workspace, writablePaths: ["README.md"] })
   await writeFile(join(input.workspace, "extra.txt"), "unexpected\n")
-  await assert.rejects(() => verifyRunnerWorkspaceIntegrity(result.integrity!), /changed after approval/)
+  await assert.rejects(
+    () => verifyRunnerWorkspaceIntegrity(result.integrity!),
+    (error: Error & { evidence?: Record<string, any> }) => {
+      assert.match(error.message, /Changed paths: extra.txt/)
+      assert.equal(error.evidence?.schema, "wp-codebox/runner-workspace-integrity-failure/v1")
+      assert.deepEqual(error.evidence?.added, ["extra.txt"])
+      assert.deepEqual(error.evidence?.modified, [])
+      assert.deepEqual(error.evidence?.deleted, [])
+      assert.equal(error.evidence?.total, 1)
+      assert.equal(error.evidence?.truncated, false)
+      return true
+    },
+  )
 }
 
 {


### PR DESCRIPTION
## Summary
- report bounded added, modified, and deleted paths when post-verification integrity differs from the approved workspace
- preserve structured integrity evidence in normalized publication failures
- restore the bounded filesystem snapshot fallback for non-Git runner workspaces

Refs #1847.

## Evidence

WP Codebox `v0.12.26` acceptance run https://github.com/Automattic/build-with-wordpress/actions/runs/29642092608 passes install, build, verify, and drift but reports only an opaque integrity mismatch. A fresh caller reproduction leaves exactly the intended docs change after every verification command, proving the remaining mutation is runtime-side.

## How to test
1. Run `npm ci && npm run build`.
2. Run `npm run test:runner-workspace-apply`.
3. Run `npm run test:native-agent-task-lifecycle`.
4. Run `npm run test:runner-workspace-publisher`.
5. Confirm the integrity test reports `extra.txt` as added with the structured evidence schema, while the lifecycle test still supports a non-Git fixture workspace.

## Compatibility
- No existing public fields are removed or changed. Publication failures gain bounded structured evidence and a more actionable message.
- Non-Git workspaces regain the pre-#1845 bounded filesystem behavior; Git workspaces retain tracked plus untracked-nonignored semantics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Reproduced the caller verification path, drafted bounded integrity evidence and non-Git fallback coverage, and ran verification with Chris reviewing and owning the change.