### PR TITLE
Fix nested mount overlays

### DIFF
--- a/packages/cli/src/input-mount-paths.ts
+++ b/packages/cli/src/input-mount-paths.ts
@@ -9,10 +9,22 @@ export interface InputMountPathMapping {
 }
 
 export function recipeInputMountPathMap(recipe: WorkspaceRecipe): InputMountPathMapping[] {
-  return (recipe.inputs?.mounts ?? []).map((mount, index) => ({
-    originalTarget: normalizeSandboxPath(mount.target),
-    canonicalTarget: canonicalInputMountTarget(mount.target, index),
-  }))
+  return (recipe.inputs?.mounts ?? []).reduce<InputMountPathMapping[]>((mappings, mount, index) => {
+    const originalTarget = normalizeSandboxPath(mount.target)
+    // Later declarations overlay the most-specific earlier target. Declaration
+    // order therefore determines ownership for equal or otherwise ambiguous
+    // overlaps, matching the order mounts are materialized into Playground.
+    const parent = [...mappings]
+      .filter((mapping) => pathHasMappedPrefix(originalTarget, mapping.originalTarget))
+      .sort((a, b) => b.originalTarget.length - a.originalTarget.length)[0]
+    mappings.push({
+      originalTarget,
+      canonicalTarget: parent
+        ? `${parent.canonicalTarget}${originalTarget.slice(parent.originalTarget.length)}`
+        : canonicalInputMountTarget(originalTarget, index),
+    })
+    return mappings
+  }, [])
 }
 
 export function rewriteInputMountPathArgs(args: readonly string[] = [], mappings: readonly InputMountPathMapping[] = []): string[] {

--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -11,6 +11,7 @@ export interface HostMountSnapshot {
   mountIndex: number
   target: string
   files: Record<string, string>
+  excludedPaths?: string[]
 }
 
 export interface VfsMountSnapshot {
@@ -122,12 +123,22 @@ export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliSe
       mountIndex,
       target: mount.target,
       files: await hostFileHashes(mount.source),
+      excludedPaths: nestedMountPaths(mounts, mountIndex, mount.target),
     })
   }
 
   const response = await server.playground.run({ code: vfsMountSnapshotPhp(hostSnapshots) })
   const parsed = JSON.parse(response.text || "{}") as { mounts?: VfsMountSnapshot[] }
   return applyVfsMountSnapshots(mounts, parsed.mounts ?? [])
+}
+
+function nestedMountPaths(mounts: MountSpec[], mountIndex: number, parentTarget: string): string[] {
+  const normalizedParent = parentTarget.replace(/\/+$/, "")
+  return mounts
+    .slice(mountIndex + 1)
+    .map((mount) => mount.target.replace(/\/+$/, ""))
+    .filter((target) => target.startsWith(`${normalizedParent}/`))
+    .map((target) => target.slice(normalizedParent.length + 1))
 }
 
 function mountMaterializesVfsToHost(mount: MountSpec): boolean {
@@ -536,9 +547,9 @@ export function vfsMountSnapshotPhp(hostSnapshots: HostMountSnapshot[]): string 
 $payload = json_decode(${payload}, true);
 $skip = array_fill_keys(${skipList}, true);
 
-function wp_codebox_vfs_mount_files(string $root, array $host_hashes, array $skip): array {
+function wp_codebox_vfs_mount_files(string $root, array $host_hashes, array $skip, array $excluded_paths): array {
     $files = array();
-    $walk = function (string $directory, string $relative_directory) use (&$walk, &$files, $root, $host_hashes, $skip): void {
+    $walk = function (string $directory, string $relative_directory) use (&$walk, &$files, $root, $host_hashes, $skip, $excluded_paths): void {
         if (!is_dir($directory)) {
             return;
         }
@@ -555,6 +566,16 @@ function wp_codebox_vfs_mount_files(string $root, array $host_hashes, array $ski
             }
             $relative_path = '' === $relative_directory ? $entry : $relative_directory . '/' . $entry;
             $path = $directory . '/' . $entry;
+            $excluded = false;
+            foreach ($excluded_paths as $excluded_path) {
+                if ($relative_path === $excluded_path || str_starts_with($relative_path, $excluded_path . '/')) {
+                    $excluded = true;
+                    break;
+                }
+            }
+            if ($excluded) {
+                continue;
+            }
             if (is_dir($path)) {
                 $walk($path, $relative_path);
                 continue;
@@ -594,7 +615,7 @@ foreach (($payload['mounts'] ?? array()) as $mount) {
         'mountIndex' => (int) ($mount['mountIndex'] ?? -1),
         'target' => $target,
         'authoritative' => true,
-        'files' => wp_codebox_vfs_mount_files($target, is_array($mount['files'] ?? null) ? $mount['files'] : array(), $skip),
+        'files' => wp_codebox_vfs_mount_files($target, is_array($mount['files'] ?? null) ? $mount['files'] : array(), $skip, is_array($mount['excludedPaths'] ?? null) ? $mount['excludedPaths'] : array()),
     );
 }
 

--- a/tests/playground-readonly-mounts-integration.test.ts
+++ b/tests/playground-readonly-mounts-integration.test.ts
@@ -1,22 +1,30 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
-import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-readonly-mounts-integration-"))
+const projectSource = join(root, "project")
+const projectConfigSource = join(projectSource, "config.php")
+const overlaySource = join(root, "config-overlay.php")
 const readonlySource = join(root, "readonly.bin")
 const readwriteSource = join(root, "readwrite.bin")
 const recipePath = join(root, "recipe.json")
 const artifactsPath = join(root, "artifacts")
+const originalConfig = "<?php return 'parent';\n"
+const overlayConfig = "<?php return 'overlay';\n"
 const readonlyBytes = Buffer.from([0, 255, 1, 2, 3, 127, 128])
 const overwrittenBytes = Buffer.from([128, 127, 3, 2, 1, 255, 0])
 const stagingDirectoriesBefore = await readonlyStagingDirectories()
 
 try {
+  await mkdir(projectSource)
+  await writeFile(projectConfigSource, originalConfig)
+  await writeFile(overlaySource, overlayConfig)
   await writeFile(readonlySource, readonlyBytes)
   await writeFile(readwriteSource, readonlyBytes)
   await writeFile(recipePath, `${JSON.stringify({
@@ -24,6 +32,8 @@ try {
     runtime: { backend: "wordpress-playground", wp: "6.5", blueprint: { steps: [] } },
     inputs: {
       mounts: [
+        { source: projectSource, target: "/home/project", mode: "readwrite" },
+        { source: overlaySource, target: "/home/project/config.php", mode: "readonly" },
         { source: readonlySource, target: "/wordpress/readonly.bin", mode: "readonly" },
         { source: readwriteSource, target: "/wordpress/readwrite.bin", mode: "readwrite" },
       ],
@@ -31,7 +41,7 @@ try {
     workflow: {
       steps: [{
         command: "wordpress.run-php",
-        args: [`code=$contents = base64_decode('${overwrittenBytes.toString("base64")}'); file_put_contents('/wordpress/readonly.bin', $contents); file_put_contents('/wordpress/readwrite.bin', $contents);`],
+        args: [`code=$config = file_get_contents('/home/project/config.php'); if ($config !== "<?php return 'overlay';\\n") { fwrite(STDERR, $config); exit(1); } $contents = base64_decode('${overwrittenBytes.toString("base64")}'); file_put_contents('/home/project/config.php', "overwritten"); file_put_contents('/home/project/mutated.txt', 'parent mutation'); file_put_contents('/wordpress/readonly.bin', $contents); file_put_contents('/wordpress/readwrite.bin', $contents);`],
       }],
     },
   })}\n`)
@@ -41,6 +51,9 @@ try {
     assert.equal(output.success, true, JSON.stringify(output))
     assert.equal(sha256(await readFile(readonlySource)), sha256(readonlyBytes), "readonly host bytes must survive an actual Playground PHP overwrite")
     assert.deepEqual(await readFile(readwriteSource), overwrittenBytes, "readwrite host bytes must reflect an actual Playground PHP overwrite")
+    assert.equal(await readFile(overlaySource, "utf8"), overlayConfig, "readonly overlay source must survive an actual Playground PHP overwrite")
+    assert.equal(await readFile(projectConfigSource, "utf8"), originalConfig, "the parent writeback must exclude the nested overlay path")
+    assert.equal(await readFile(join(projectSource, "mutated.txt"), "utf8"), "parent mutation", "parent readwrite mutations must still materialize")
     assert.deepEqual(await readonlyStagingDirectories(), stagingDirectoriesBefore, "recipe-run cleanup must remove readonly mount staging")
   }
 } finally {

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -161,6 +161,30 @@ assert.deepEqual(rewriteInputMountPathArgs(["cwd=/home/example/public_html/bin/t
   { originalTarget: "/home/example/public_html/bin/tests", canonicalTarget: "/tmp/wp-codebox-inputs/tests" },
 ]), ["cwd=/tmp/wp-codebox-inputs/tests/foo"])
 
+const nestedInputMountPathMap = recipeInputMountPathMap({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    mounts: [
+      { source: "/workspace/project", target: "/home/project", mode: "readwrite" },
+      { source: "/workspace/config.php", target: "/home/project/config.php", mode: "readonly" },
+    ],
+  },
+  workflow: { steps: [] },
+})
+assert.equal(nestedInputMountPathMap[1].canonicalTarget, `${nestedInputMountPathMap[0].canonicalTarget}/config.php`, "a later nested mount overlays its earlier parent target")
+assert.deepEqual(rewriteInputMountPathArgs(["config=/home/project/config.php"], nestedInputMountPathMap), [`config=${nestedInputMountPathMap[1].canonicalTarget}`], "nested paths rewrite to their effective overlay target")
+const reverseNestedInputMountPathMap = recipeInputMountPathMap({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    mounts: [
+      { source: "/workspace/config.php", target: "/home/project/config.php", mode: "readonly" },
+      { source: "/workspace/project", target: "/home/project", mode: "readwrite" },
+    ],
+  },
+  workflow: { steps: [] },
+})
+assert.match(reverseNestedInputMountPathMap[1].canonicalTarget, /^\/tmp\/wp-codebox-inputs\/1-project-[a-f0-9]{12}$/, "an earlier nested declaration does not alter a later parent target")
+
 const wpcomPathMap = recipeInputMountPathMap({
   schema: "wp-codebox/workspace-recipe/v1",
   inputs: {


### PR DESCRIPTION
## Summary

- compose later nested mounts inside the most-specific earlier canonical parent target
- exclude nested mount ownership from parent read-write VFS materialization
- preserve existing binary read-only/read-write coverage while proving nested file overlays in a real Playground run

Fixes #1851.

## Source relationship

- **Source:** Runtime evidence from a WPCOM PHPUnit recipe using a read-write source-tree mount plus a read-only nested test config.
- **Change kind:** Generic WP Codebox mount-composition repair.
- **Scope:** Mount path canonicalization and Playground parent write-back ownership only; non-overlapping mounts retain their existing behavior.

## How to test

1. Check out this branch on a fresh clone and run `npm ci`.
2. Run `npm run build`.
3. Run `npm run test:playground-readonly-mounts`.
4. Run `npm run test:playground-readonly-mounts-integration`.
5. Run `npx tsx tests/recipe-runtime-setup-staged-materialization.test.ts`.
6. Confirm all commands pass. The integration test verifies byte-exact read-only behavior, normal read-write materialization, nested overlay visibility, nested source immutability, parent exclusion of the nested path, and sibling parent mutation write-back.

## Backward compatibility

This changes behavior only for overlapping mounts: later nested declarations now overlay earlier parent targets in declaration order instead of being staged independently and remaining invisible through the parent path. This is the intended composition contract. Non-overlapping mounts and reverse-order declarations retain independent canonical targets.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Implemented the generic nested-mount composition fix and deterministic integration coverage; Chris reviews and owns the change.