### PR TITLE
Raise Cloudflare WordPress boot CPU budget

### DIFF
--- a/packages/runtime-cloudflare/README.md
+++ b/packages/runtime-cloudflare/README.md
@@ -2,7 +2,7 @@
 
 This additive integration is the first acceptance gate for [wp-codebox#1838](https://github.com/Automattic/wp-codebox/issues/1838). It compiles the current PHP 8.5 Asyncify Wasm asset for workerd, boots WordPress through Playground with the current SQLite integration release, executes PHP, and returns a Codebox runtime-command-result envelope containing the stable `wp-codebox/cloudflare-runtime-health/v1` health payload.
 
-The Worker owns Cloudflare transport and isolate lifecycle. This gate uses one Playground PHP instance per isolate; Durable Objects will serialize site mutation in a later gate. The response identifies the generic `wordpress-playground` backend and `wordpress` environment; callers do not receive Cloudflare binding or limit details. Runtime snapshots, restore, R2, serialization, and cold restoration are deferred to later gates.
+The Worker owns Cloudflare transport and isolate lifecycle. Full WordPress initialization requires the paid-plan five-minute CPU allowance, declared as `limits.cpu_ms: 300000`; Cloudflare's fixed 128 MB isolate memory limit remains unchanged. This gate uses one Playground PHP instance per isolate; Durable Objects will serialize site mutation in a later gate. The response identifies the generic `wordpress-playground` backend and `wordpress` environment; callers do not receive Cloudflare binding or limit details. Runtime snapshots, restore, R2, serialization, and cold restoration are deferred to later gates.
 
 ## Verification
 

--- a/packages/runtime-cloudflare/wrangler.jsonc
+++ b/packages/runtime-cloudflare/wrangler.jsonc
@@ -3,5 +3,6 @@
   "main": "src/worker.ts",
   "compatibility_date": "2026-07-18",
   "compatibility_flags": ["nodejs_compat"],
+  "limits": { "cpu_ms": 300000 },
   "rules": [{ "type": "CompiledWasm", "globs": ["**/*.wasm"], "fallthrough": false }]
 }

--- a/tests/cloudflare-runtime.test.ts
+++ b/tests/cloudflare-runtime.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
 import test from "node:test"
 import { RUNTIME_COMMAND_RESULT_SCHEMA } from "../packages/runtime-core/src/runtime-contracts.js"
 import { CLOUDFLARE_RUNTIME_HEALTH_MARKER, CLOUDFLARE_RUNTIME_HEALTH_SCHEMA, cloudflareRuntimeHealthResponse } from "../packages/runtime-cloudflare/src/health-envelope.js"
@@ -21,4 +22,9 @@ test("Cloudflare health response preserves the Codebox execution envelope", asyn
   assert.equal(payload.execution.schema, RUNTIME_COMMAND_RESULT_SCHEMA)
   assert.equal(payload.execution.status, "ok")
   assert.deepEqual(payload.execution.json, health)
+})
+
+test("Cloudflare runtime declares the paid-plan WordPress boot CPU budget", async () => {
+  const config = JSON.parse(await readFile(new URL("../packages/runtime-cloudflare/wrangler.jsonc", import.meta.url), "utf8")) as { limits?: { cpu_ms?: number } }
+  assert.equal(config.limits?.cpu_ms, 300_000)
 })


### PR DESCRIPTION
## Summary

- declare Cloudflare's paid-plan five-minute CPU allowance for the WordPress boot gate
- preserve the fixed 128 MB isolate memory limit
- add deterministic coverage for the deployment limit and document why it is required

Follow-up to #1856 and #1838.

## Remote evidence

The merged Worker deployed successfully at https://wp-codebox-cloudflare-runtime.chubes.workers.dev with a 17 ms startup time and a 21,313.72 KiB / 7,950.82 KiB gzip bundle. Real requests then returned Cloudflare error 1102, which Cloudflare documents as resource exhaustion. The paid Workers default is 30 seconds of CPU per request; the supported maximum is five minutes via `limits.cpu_ms: 300000`. Memory remains fixed at 128 MB.

Cloudflare reference: https://developers.cloudflare.com/workers/platform/limits/#cpu-time

## How to test

1. Check out this branch from a fresh clone and run `npm ci`.
2. Run `npm run build`.
3. Run `npm run test:cloudflare-runtime`; expect both envelope and CPU-budget tests to pass.
4. Run `npm run cloudflare:local-gate`; expect two HTTP 200 health envelopes and automatic cleanup.
5. Run `npm run cloudflare:dry-run`; expect the reviewed bundle size and no resource mutation.
6. Run `git diff --check`.

## Compatibility

This changes only the deployed Cloudflare Worker's CPU allowance. WP Codebox runtime contracts, extension paths, local workerd behavior, and Cloudflare's 128 MB memory limit are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `gpt-5.6-sol`
- **Used for:** Diagnosed the remote Cloudflare 1102 response, added the explicit deployment limit and regression coverage, and verified the follow-up with Chris; Chris reviews and owns the change.
