### PR TITLE
Forward runtime environment to PHPUnit

### DIFF
--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -134,15 +134,16 @@ function recipeActivePluginMetadata(spec: RuntimeCreateSpec): RecipePluginMetada
   return plugins.filter((plugin) => typeof plugin.pluginFile === "string")
 }
 
-export async function phpCodeFromArgs(args: string[], command = "wordpress.run-php"): Promise<string> {
+export async function phpCodeFromArgs(args: string[], command = "wordpress.run-php", normalize = true): Promise<string> {
   const inlineCode = argValue(args, "code")
   if (inlineCode) {
-    return normalizePhpCode(inlineCode)
+    return normalize ? normalizePhpCode(inlineCode) : inlineCode
   }
 
   const codeFile = argValue(args, "code-file")
   if (codeFile) {
-    return normalizePhpCode(await readFile(resolveCommandPath(codeFile), "utf8"))
+    const code = await readFile(resolveCommandPath(codeFile), "utf8")
+    return normalize ? normalizePhpCode(code) : code
   }
 
   throw new Error(`${command} requires code=<php> or code-file=<path>`)

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1725,6 +1725,7 @@ class PlaygroundRuntime implements Runtime {
       artifactRoot: this.artifactRoot,
       mounts: this.mounts,
       runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options),
+      runtimeSpec: this.spec,
       server,
       spec,
     })

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -895,12 +895,14 @@ export async function runPhpunitCommand({
   artifactRoot,
   mounts,
   runPlaygroundCommand,
+  runtimeSpec,
   server,
   spec,
 }: {
   artifactRoot: string
   mounts: MountSpec[]
   runPlaygroundCommand: RunPlaygroundCommand
+  runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
 }): Promise<string> {
@@ -911,7 +913,7 @@ export async function runPhpunitCommand({
   const autoloadFile = argValue(args, "autoload-file")?.trim() || (bootstrapMode === "project" ? "" : "/wp-codebox-vendor/autoload.php")
   const autoloadFileRole = argValue(args, "autoload-file-role")?.trim() === "harness" ? "harness" : undefined
   const resultFile = PLUGIN_PHPUNIT_RESULT_FILE
-  const code = explicitCode ? await phpCodeFromArgs(args, "wordpress.phpunit") : normalizePhpCode(phpunitRunCode({
+  const code = explicitCode ? await phpCodeFromArgs(args, "wordpress.phpunit", false) : phpunitRunCode({
     pluginSlug,
     cwd: argValue(args, "cwd")?.trim() || `/wordpress/wp-content/plugins/${pluginSlug}`,
     autoloadFile,
@@ -932,13 +934,13 @@ export async function runPhpunitCommand({
     projectBootstrap: argValue(args, "project-bootstrap")?.trim() || "",
     multisite: booleanArg(args, "multisite"),
     resultFile,
-  }))
+  })
   if (!explicitCode && !pluginSlug) {
     throw new Error("wordpress.phpunit requires plugin-slug=<slug> when code/code-file is not provided")
   }
   let response: PlaygroundRunResponse
   try {
-    response = await runPlaygroundCommand("wordpress.phpunit", server, { code })
+    response = await runPlaygroundCommand("wordpress.phpunit", server, { code: bootstrapPhpCode(runtimeSpec, code, args) })
   } catch (error) {
     await persistPluginPhpunitResult(server, resultFile, artifactRoot)
     await persistVfsDiagnosticFileToHost(server, resultFile, `/wordpress/wp-content/plugins/${pluginSlug}/.pg-test-result.txt`, mounts)

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -12,6 +12,9 @@ import { recipeExtraPluginSourceSubpath } from "../packages/cli/src/recipe-sourc
 import { recipeInputMountPathMap, rewriteInputMountPathArgs } from "../packages/cli/src/commands/recipe-runtime-setup.js"
 
 const woocommerceAutoload = "/wordpress/wp-content/plugins/woocommerce/vendor/autoload_packages.php"
+const phpunitRuntimeSpec = {
+  runtimeEnv: { TC_MYSQL_PORT: "3306" },
+} as never
 
 function phpunitRecipeArgs(options: Omit<Parameters<typeof buildWordPressPhpunitRecipe>[0], "pluginSlug">): string[] {
   return buildWordPressPhpunitRecipe({ pluginSlug: "demo-plugin", ...options }).workflow.steps[0].args
@@ -332,6 +335,7 @@ await runPhpunitCommand({
     capturedCanonicalHarnessCode = input.code
     return { text: "ok", exitCode: 0 }
   },
+  runtimeSpec: phpunitRuntimeSpec,
   server: { playground: {} } as never,
   spec: {
     command: "wordpress.phpunit",
@@ -347,6 +351,27 @@ await runPhpunitCommand({
 })
 assert.ok(capturedCanonicalHarnessCode.includes('$autoload_file = "/tmp/wp-codebox-inputs/0-wp-codebox-vendor-73845ca47d2f/autoload.php";'))
 assert.ok(capturedCanonicalHarnessCode.includes('$autoload_file_role = "harness";'))
+assert.ok(capturedCanonicalHarnessCode.includes('putenv("TC_MYSQL_PORT=3306");'), "runtime service environment is passed to the PHP executed by wordpress.phpunit")
+assert.ok(capturedCanonicalHarnessCode.indexOf('putenv("TC_MYSQL_PORT=3306");') < capturedCanonicalHarnessCode.indexOf("require_once '/wordpress/wp-load.php';"), "runtime environment is available to project bootstrap code")
+
+let capturedExplicitCode = ""
+await runPhpunitCommand({
+  artifactRoot: mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-artifacts-")),
+  mounts: [],
+  runPlaygroundCommand: async (_command, _server, input) => {
+    capturedExplicitCode = input.code
+    return { text: "ok", exitCode: 0 }
+  },
+  runtimeSpec: phpunitRuntimeSpec,
+  server: { playground: {} } as never,
+  spec: {
+    command: "wordpress.phpunit",
+    args: ["code=<?php declare(strict_types=1); echo getenv('TC_MYSQL_PORT');", "env-json={\"TC_MYSQL_PORT\":\"3307\"}"],
+  },
+})
+assert.equal((capturedExplicitCode.match(/declare\(strict_types=1\);/g) ?? []).length, 1, "explicit PHP is normalized once at the runtime bootstrap boundary")
+assert.ok(capturedExplicitCode.includes("echo getenv('TC_MYSQL_PORT');"), "explicit PHPUnit code receives the same runtime bootstrap")
+assert.ok(capturedExplicitCode.indexOf('putenv("TC_MYSQL_PORT=3306");') < capturedExplicitCode.lastIndexOf("TC_MYSQL_PORT"), "explicit env-json handling remains after runtime environment bootstrap")
 
 const coreModeCode = corePhpunitRunCode({
   coreRoot: "/wordpress",


### PR DESCRIPTION
## Summary

- pass the runtime creation spec into the Playground PHPUnit command runner
- bootstrap generated and explicit PHPUnit PHP with managed runtime environment values
- prove service environment is installed before project bootstrap while preserving explicit-code normalization

Fixes #1858.

## Source relationship

- **Source:** A real managed-MySQL PHPUnit recipe showed a ready service while project bootstrap observed `TC_MYSQL_PORT=unset`.
- **Change kind:** Generic Playground PHPUnit runtime bootstrap repair.
- **Scope:** `wordpress.phpunit` PHP execution only; it now matches the existing runtime bootstrap contract used by other PHP-backed commands such as `wordpress.bench`.

## How to test

1. Check out this branch on a fresh clone and run `npm ci`.
2. Run `npm run build`.
3. Run `npx tsx tests/phpunit-project-autoload.test.ts`.
4. Run `npm run test:runtime-services`.
5. Run `npm run test:runtime-services-lifecycle`.
6. Confirm all commands pass. The PHPUnit test proves runtime service environment is emitted before project bootstrap and explicit PHP is normalized once.

## Backward compatibility

This fixes missing environment propagation for `wordpress.phpunit`. Existing recipe `env-json` processing and command behavior remain intact; managed runtime values are now available at the runtime bootstrap layer as declared by the recipe service contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Implemented runtime-environment propagation and deterministic coverage; Chris reviews and owns the change.