### PR TITLE
Fix runtime backend boundary enforcement

### DIFF
--- a/tests/production-boundary-enforcement.test.ts
+++ b/tests/production-boundary-enforcement.test.ts
@@ -39,6 +39,10 @@ const forbiddenPublicExportTargets = [
 const forbiddenPublicImportSpecifiers = [
   /@wp-playground\//,
 ]
+const runtimeBackendPackages = new Set([
+  "@automattic/wp-codebox-playground",
+  "@automattic/wp-codebox-runtime-cloudflare",
+])
 const forbiddenRuntimeCoreBackendSpecifiers = [
   /@automattic\/wp-codebox-playground(?:\/|$)/,
   /@wp-playground\//,
@@ -88,7 +92,7 @@ for (const manifest of await packageManifests(packagesDir)) {
   }
 
   for (const dependency of Object.keys(source.dependencies ?? {})) {
-    if (source.name !== "@automattic/wp-codebox-playground" && forbiddenPublicImportSpecifiers.some((forbidden) => forbidden.test(dependency))) {
+    if (!runtimeBackendPackages.has(source.name ?? "") && forbiddenPublicImportSpecifiers.some((forbidden) => forbidden.test(dependency))) {
       violations.push(`${rel} depends on backend-internal package ${dependency}`)
     }
   }


### PR DESCRIPTION
## Summary
- identify Codebox runtime backend packages explicitly in production-boundary enforcement
- allow declared backend packages to depend on backend-internal WordPress runtime packages
- keep the restriction intact for public/core/non-backend packages

## Why
The Cloudflare runtime is a Codebox backend, but the boundary test exempted only the Playground backend. Once `@automattic/wp-codebox-runtime-cloudflare` added its required `@wp-playground/wordpress` dependency, `main` became red and all unrelated PRs inherited the failure.

Main failure evidence: https://github.com/Automattic/wp-codebox/actions/runs/29646139662

## How to test
1. Run `npm install` from a fresh checkout.
2. Run `npm run test:production-boundary-enforcement`.
3. Run `npm run build`.

## Compatibility
No production runtime behavior changes. This corrects the architecture test to distinguish runtime backend packages from public/core packages.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the pre-existing main-branch CI failure, implemented the owning-layer boundary correction, verified it, and prepared the PR under Chris Huber's direction.