### PR TITLE
Normalize root extra-plugin source subpaths

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1573,6 +1573,10 @@ function recipeExtraPluginSourceRootContainsSource(plugin: WorkspaceRecipeExtraP
 }
 
 export function normalizeRecipeExtraPluginSourceSubpath(value: string): string {
+  const rootMarker = value.trim().replace(/\\/g, "/").replace(/\/+$/, "")
+  if (rootMarker === ".") {
+    return ""
+  }
   const normalized = normalizeReviewerSafePath(value)
   if (!normalized || normalized === "." || normalized.startsWith("../") || normalized.includes("/../") || isAbsolute(normalized)) {
     throw new Error(`Recipe extra_plugins sourceSubdir/sourceSubpath must be a safe relative directory: ${value}`)

--- a/tests/recipe-extra-plugin-nested-source.test.ts
+++ b/tests/recipe-extra-plugin-nested-source.test.ts
@@ -70,6 +70,34 @@ await withTempDir("wp-codebox-nested-extra-plugin-source-path-", async (recipeDi
   assert.equal((await stat(join(plugin.source, "example.php"))).isFile(), true)
 })
 
+await withTempDir("wp-codebox-extra-plugin-root-source-path-", async (recipeDirectory) => {
+  const pluginRoot = join(recipeDirectory, "example-plugin")
+  await mkdir(pluginRoot, { recursive: true })
+  await writeFile(join(pluginRoot, "example-plugin.php"), "<?php\n/* Plugin Name: Example Plugin */\n")
+
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: {
+      extra_plugins: [{
+        sourcePath: "example-plugin",
+        sourceSubpath: ".",
+        mountSlug: "example-plugin",
+        pluginFile: "example-plugin/example-plugin.php",
+      }],
+    },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  }
+
+  assertWorkspaceRecipeJsonSchema(recipe)
+  assert.deepEqual(await validateWorkspaceRecipeSemantics(recipe, join(recipeDirectory, "recipe.json")), [])
+
+  const [plugin] = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+  assert.ok(plugin)
+  assert.equal(plugin.slug, "example-plugin")
+  assert.equal(plugin.metadata?.sourceSubpath, undefined)
+  assert.equal((await stat(join(plugin.source, "example-plugin.php"))).isFile(), true)
+})
+
 await withTempDir("wp-codebox-nested-extra-plugin-invalid-", async (recipeDirectory) => {
   const repo = join(recipeDirectory, "repo")
   await mkdir(join(repo, "plugins", "nested-plugin"), { recursive: true })
@@ -85,6 +113,11 @@ await withTempDir("wp-codebox-nested-extra-plugin-invalid-", async (recipeDirect
     {
       name: "path traversal sourceSubdir",
       plugin: { sourcePath: "repo", sourceSubdir: "../outside", mountSlug: "nested-plugin", pluginFile: "nested-plugin/nested-plugin.php" },
+      issue: "invalid-source-subdir",
+    },
+    {
+      name: "embedded current-directory sourceSubdir",
+      plugin: { sourcePath: "repo", sourceSubdir: "./plugins/nested-plugin", mountSlug: "nested-plugin", pluginFile: "nested-plugin/nested-plugin.php" },
       issue: "invalid-source-subdir",
     },
     {


### PR DESCRIPTION
## Summary
- canonicalize an explicit `.` extra-plugin source subpath to the existing empty root-subpath representation
- continue rejecting embedded current-directory segments and parent traversal
- cover semantic validation and real extra-plugin source preparation from a plugin-root checkout

## Context
A strict Gutenberg stateful fuzz campaign generated an extra-plugin recipe where `sourcePath` already identified the plugin root and `sourceSubpath` was `.`. WP Codebox rejected that root marker as `invalid-source-subdir` before runtime creation.

An explicit `.` means the source root itself. Canonicalizing it to the existing empty representation avoids requiring every recipe producer to special-case WP Codebox while preserving reviewer-safe nested path validation.

Related tracker: https://github.com/chubes4/homeboy-rigs/issues/683

## Compatibility impact
This broadens accepted recipe input: root-level `sourceSubpath: "."` and equivalent trailing separators now behave like an omitted subpath. Embedded dot segments such as `./plugins/example` and parent traversal remain invalid. Existing valid recipes are unchanged.

## How to test
1. Run `npm ci --ignore-scripts`.
2. Run `npm run build`.
3. Run `npm exec -- tsx tests/recipe-extra-plugin-nested-source.test.ts`.
4. Run `npm run test:recipe-source-packages`.

## Verification
- Build passed.
- Root-subpath semantic validation and source preparation test passed.
- Existing recipe source-package suite passed.
- `npm run check` passed production-boundary enforcement, build, and preceding smoke commands, then stopped on the current-main command-registry mismatch: `wordpress.collect-workload-result outputShape should mention outputSchema id`. This change does not touch that registry.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression coverage, and verification.