### PR TITLE
Expose recipe fuzz results as typed workload artifacts

### DIFF
--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -395,6 +395,7 @@ function recipeWorkloadArtifactPayloads(execution: ExecutionResult, artifact: st
 
 function collectRecipeArtifactPayloadsFromContainer(container: Record<string, unknown> | undefined, artifact: string, expectedSchema: string | undefined, out: Array<{ name: string; payload: Record<string, unknown> }>): void {
   if (!container) return
+  collectRecipeFuzzSuiteArtifactPayloads(container, artifact, expectedSchema, out)
   const artifacts = isRecord(container.artifacts) ? container.artifacts : undefined
   for (const [name, value] of Object.entries(artifacts ?? {})) {
     if (!artifactNameMatches(name, artifact)) continue
@@ -406,6 +407,22 @@ function collectRecipeArtifactPayloadsFromContainer(container: Record<string, un
   }
   for (const nestedStep of Array.isArray(container.steps) ? container.steps : []) {
     if (isRecord(nestedStep)) collectRecipeArtifactPayloadsFromContainer(nestedStep, artifact, expectedSchema, out)
+  }
+}
+
+function collectRecipeFuzzSuiteArtifactPayloads(result: Record<string, unknown>, artifact: string, expectedSchema: string | undefined, out: Array<{ name: string; payload: Record<string, unknown> }>): void {
+  if (result.schema !== "wp-codebox/fuzz-suite-result/v1" || (expectedSchema && result.schema !== expectedSchema)) return
+  const add = (name: string) => {
+    if (!artifact || artifactNameMatches(name, artifact)) out.push({ name, payload: result })
+  }
+
+  // Keep the normalized result envelope intact; consumers receive real fuzz evidence, not a lossy wrapper.
+  add("wp-codebox-fuzz-suite-result")
+  add("result-envelope")
+  if (Array.isArray(result.cases)) add("case-log")
+  if (isRecord(result.coverageSummary)) add("coverage-summary")
+  if (Array.isArray(result.cases) && result.cases.some((fuzzCase) => isRecord(fuzzCase) && isRecord(fuzzCase.metadata) && isRecord(fuzzCase.metadata.replay))) {
+    add("replay-data")
   }
 }
 

--- a/tests/nested-fuzz-suite-recipe-command.test.ts
+++ b/tests/nested-fuzz-suite-recipe-command.test.ts
@@ -318,4 +318,36 @@ assert.equal(fallbackExecution.exitCode, 0)
 assert.equal(fallbackResult.status, "passed")
 assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php", "wordpress.run-php"])
 
+executed.length = 0
+const collectableFuzzSuiteWorkload: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [{ command: "wordpress.run-workload", args: [`workload-json=${JSON.stringify({
+      schema: "wp-codebox/wordpress-workload-run/v1",
+      steps: [{ command: "wp-codebox/run-fuzz-suite", args: [`input-json=${JSON.stringify(suite)}`] }],
+      after: [
+        { command: "wordpress.collect-workload-result", args: ["artifact=wp-codebox-fuzz-suite-result"] },
+        { command: "wordpress.collect-workload-result", args: ["artifact=case-log"] },
+        { command: "wordpress.collect-workload-result", args: ["artifact=coverage-summary"] },
+        { command: "wordpress.collect-workload-result", args: ["artifact=result-envelope"] },
+        { command: "wordpress.collect-workload-result", args: ["artifact=replay-data"] },
+      ],
+    })}`] }],
+  },
+}
+assertWorkspaceRecipeJsonSchema(collectableFuzzSuiteWorkload, { recipeCommandIds: ["wordpress.run-workload", "wp-codebox/run-fuzz-suite", "wordpress.run-php", "wordpress.collect-workload-result"] })
+const collectableFuzzSuiteExecution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: collectableFuzzSuiteWorkload.workflow.steps[0]! }, process.cwd())
+const collectableFuzzSuiteResult = JSON.parse(collectableFuzzSuiteExecution.stdout)
+assert.equal(collectableFuzzSuiteExecution.exitCode, 0)
+assert.equal(collectableFuzzSuiteResult.steps, 6)
+for (const artifact of ["wp-codebox-fuzz-suite-result", "case-log", "coverage-summary", "result-envelope", "replay-data"]) {
+  const payload = collectableFuzzSuiteResult.artifacts[artifact]
+  assert.equal(payload.schema, "wp-codebox/fuzz-suite-result/v1")
+  assert.equal(payload.status, "passed")
+  assert.equal(payload.cases[0].id, "case-one")
+}
+assert.equal(collectableFuzzSuiteResult.artifacts["coverage-summary"].coverageSummary.executed, 1)
+assert.equal(collectableFuzzSuiteResult.artifacts["replay-data"].cases[0].metadata.replay.caseId, "case-one")
+assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php"])
+
 console.log("nested fuzz suite recipe command ok")


### PR DESCRIPTION
## Summary

Nested recipe-backed fuzz suite results are now discoverable through the existing typed workload artifact collector.

Closes #1879.

## What changed

- Recognize canonical `wp-codebox/fuzz-suite-result/v1` payloads during generic workload artifact discovery.
- Project the same lossless typed envelope under the semantic names for normalized result, result envelope, case log, coverage summary, and replay data when those fields are actually present.
- Preserve fail-closed collection when requested evidence is absent.
- Add nested recipe coverage that executes a suite and successfully collects all five typed outputs.

## How to test

1. Run `npm run build`.
2. Run `npm run test:nested-fuzz-suite-recipe-command`.
3. Run `npm run test:playground-fuzz-suite-public`.
4. Run `npm run test:fuzz-suite-runner`.
5. Run `npm run test:fuzz-run-recipe`.
6. Confirm all commands pass.

## Compatibility

No breaking compatibility impact. Existing workload artifact discovery remains unchanged; nested fuzz suite envelopes gain additional semantic lookup names only when the corresponding real evidence exists.

## Evidence

- Source issue: https://github.com/Automattic/wp-codebox/issues/1879
- Homeboy targeted gate passed against base `2f58c6cd2e4ee4f4af59fdf2a8695ef8f3ffa8d4`.
- GitHub reports no additional status checks configured for this branch.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-terra
- **Used for:** Diagnosed the nested fuzz artifact handoff, drafted the generic projection and deterministic tests, and prepared the PR; Chris reviews and owns the change.