### PR TITLE
Omit publication error from successful verification

### DIFF
--- a/.github/scripts/run-agent-task/execute-native-agent-task.mjs
+++ b/.github/scripts/run-agent-task/execute-native-agent-task.mjs
@@ -295,11 +295,11 @@ async function verifyPublishedPullRequest(publication, targetRepo, cwd) {
   if (response.code !== 0) return { valid: false, error: "Published pull request could not be resolved through GitHub.", stderr: response.stderr, stderr_truncated: response.stderr_truncated }
   try {
     const pullRequest = JSON.parse(response.stdout)
-    return {
-      valid: pullRequest?.html_url === record(publication).pull_request?.url
-        && string(pullRequest?.base?.repo?.full_name).toLowerCase() === targetRepo.toLowerCase(),
-      error: "Published pull request did not resolve to the target repository.",
-    }
+    const valid = pullRequest?.html_url === record(publication).pull_request?.url
+      && string(pullRequest?.base?.repo?.full_name).toLowerCase() === targetRepo.toLowerCase()
+    return valid
+      ? { valid: true }
+      : { valid: false, error: "Published pull request did not resolve to the target repository." }
   } catch {
     return { valid: false, error: "GitHub pull-request validation did not return JSON." }
   }

--- a/tests/execute-native-agent-task-lifecycle.test.mjs
+++ b/tests/execute-native-agent-task-lifecycle.test.mjs
@@ -17,7 +17,8 @@ async function run(mode = "success") {
   const targetRepo = mode === "canonical-casing" ? "automattic/build-with-wordpress" : "owner/repo"
   const publicationRepo = mode === "canonical-casing"
     ? "Automattic/build-with-wordpress"
-    : mode === "different-repo" ? "other/repo" : targetRepo
+    : targetRepo
+  const resolvedRepo = mode === "different-repo" ? "other/repo" : publicationRepo
   await mkdir(join(workspace, ".codebox"), { recursive: true })
   await writeFile(join(workspace, "README.md"), "OPENAI_API_KEY\nbefore\n")
 
@@ -139,8 +140,8 @@ export async function publishRunnerWorkspace({ testHook }) {
   const gh = join(temp, "gh")
   await writeFile(gh, `#!/usr/bin/env node
 process.stdout.write(JSON.stringify({
-  html_url: ${JSON.stringify(`https://github.com/${publicationRepo}/pull/1`)},
-  base: { repo: { full_name: ${JSON.stringify(publicationRepo)} } },
+  html_url: ${JSON.stringify(`https://github.com/${resolvedRepo}/pull/1`)},
+  base: { repo: { full_name: ${JSON.stringify(resolvedRepo)} } },
 }))
 `)
   await chmod(gh, 0o755)
@@ -189,6 +190,7 @@ assert(!durablePatch.includes("OPENAI_API_KEY"), "durable patch artifacts redact
 assert.match(durablePatch, /\[REDACTED\]/)
 assert.match(success.order, /runtime\nvalidation\nverification\ndrift\npublish\n/)
 assert.equal(success.result.runtime_result.metadata.runner_workspace_publication.pull_request.url, "https://github.com/owner/repo/pull/1")
+assert.deepEqual(success.result.publication_verification, { valid: true })
 assert.equal(success.result.runtime_result.agent_runtime_diagnostics.prepared_paths.workspaces[0].target, "/workspace")
 assert.equal(success.result.runtime_result.agent_runtime_diagnostics.prepared_paths.workspaces[0].mode, "readwrite")
 assert.equal(success.result.runtime_result.agent_runtime_diagnostics.sandbox_workspace.mounts[0].target, "/workspace")
@@ -196,12 +198,15 @@ assert.equal(success.result.runtime_result.agent_runtime_diagnostics.local_execu
 
 const canonicalCasing = await run("canonical-casing")
 assert.equal(canonicalCasing.code, 0, `${canonicalCasing.stderr}\n${JSON.stringify(canonicalCasing.result)}`)
-assert.equal(canonicalCasing.result.publication_verification.valid, true)
+assert.deepEqual(canonicalCasing.result.publication_verification, { valid: true })
 
 const differentRepository = await run("different-repo")
 assert.equal(differentRepository.code, 1)
-assert.equal(differentRepository.result.publication_verification.valid, false)
-assert.match(differentRepository.result.failure.message, /valid canonical pull-request result/)
+assert.deepEqual(differentRepository.result.publication_verification, {
+  valid: false,
+  error: "Published pull request did not resolve to the target repository.",
+})
+assert.equal(differentRepository.result.failure.message, "Published pull request did not resolve to the target repository.")
 
 const failedVerification = await run("verify-fail")
 assert.equal(failedVerification.code, 1)


### PR DESCRIPTION
## Summary

- omit the failure-only `error` field when canonical pull-request verification succeeds
- retain the exact diagnostic when a resolvable pull request belongs to a different repository
- add deterministic lifecycle coverage for both complete result shapes

Closes #1882.

## How to test

1. Run `npm ci`.
2. Run `npm run test:native-agent-task-lifecycle`.
3. Run `node --check .github/scripts/run-agent-task/execute-native-agent-task.mjs`.
4. Run `node --check tests/execute-native-agent-task-lifecycle.test.mjs`.
5. Run `git diff --check origin/main...HEAD`.

The targeted lifecycle gate passed through Homeboy against immutable commit `79cc9c3cae8ed66cb01e18af8db26d4e3120e560`; GitHub CI runs the broader repository contract suite.

## Compatibility

Successful verification results no longer contain a contradictory failure-only `error` field. Failure result shapes, strict URL validation, pull-number/API binding, repository identity checks, workflow interfaces, and extension paths are unchanged. Consumers already key behavior on `valid`; this makes successful evidence internally consistent.

## Source evidence

- Issue: https://github.com/Automattic/wp-codebox/issues/1882
- Downstream reproduction: https://github.com/Automattic/build-with-wordpress/actions/runs/29667594093
- Homeboy control-plane recovery: https://github.com/Extra-Chill/homeboy/pull/9060 and https://github.com/Extra-Chill/homeboy/pull/9067

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol, orchestrated and finalized by Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented the publication-verification result-shape fix, added deterministic lifecycle coverage, and repaired the upstream Homeboy recovery path required to finalize the candidate. Chris reviewed and owns the change.