### PR TITLE
Capture declared verification command artifacts

### DIFF
--- a/.github/scripts/run-agent-task/artifact-upload-policy.mjs
+++ b/.github/scripts/run-agent-task/artifact-upload-policy.mjs
@@ -1,0 +1,52 @@
+import { isAbsolute } from "node:path"
+
+const SOURCE_TREE = /(^|\/)(prepared-plugins|prepared-source-packages|source-package[^/]*)(\/|$)/i
+const SOURCE_FILE = /\.(?:php|phtml|js|mjs|cjs|jsx|ts|tsx)$/i
+const PHP_OPENING_TAG = /<\?(?:php|=)(?:\s|$)/i
+const PHP_DECLARATION = /\b(?:namespace\s+\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*|(?:abstract\s+|final\s+|readonly\s+)*(?:class|interface|trait|enum)\s+[A-Za-z_]\w*|function\s+&?\s*[A-Za-z_]\w*\s*\()/i
+const WORDPRESS_PLUGIN_HEADER = /\/\*[\s\S]{0,200}?\bPlugin Name\s*:/i
+
+export function artifactSourcePathCategory(path) {
+  if (SOURCE_TREE.test(path)) return "source-tree"
+  if (SOURCE_FILE.test(path)) return "source-file"
+  return ""
+}
+
+// Diagnostics commonly name runtime classes. Reject only PHP-shaped source, even
+// when a source file has been disguised with a reviewer-safe extension.
+export function containsRuntimeSourceContent(text) {
+  const hasPhpTag = PHP_OPENING_TAG.test(text)
+  const hasDeclaration = PHP_DECLARATION.test(text)
+  return (hasPhpTag && hasDeclaration) || (WORDPRESS_PLUGIN_HEADER.test(text) && (hasPhpTag || hasDeclaration))
+}
+
+export function assertNoSeedSnapshotPaths(text) {
+  if (/wp-codebox-runner-workspace-seed-/i.test(text)) throw new Error("Temporary runner workspace seed paths must never be persisted in artifact uploads.")
+  try {
+    const visit = (value) => {
+      if (Array.isArray(value)) return value.forEach(visit)
+      const entry = value && typeof value === "object" && !Array.isArray(value) ? value : {}
+      if (entry.seed && typeof entry.seed === "object" && !Array.isArray(entry.seed) && isAbsolute(entry.seed.source)) throw new Error("Absolute runner workspace seed paths must never be persisted in artifact uploads.")
+      Object.values(entry).forEach(visit)
+    }
+    visit(JSON.parse(text))
+  } catch (error) {
+    if (error instanceof Error && /seed paths/.test(error.message)) throw error
+  }
+}
+
+export function sanitizeSeedSnapshotJson(text) {
+  try {
+    const compact = (value, key = "") => {
+      if (typeof value === "string") return value.replace(/\/?[^\s"']*wp-codebox-runner-workspace-seed-[^\s"']*/gi, "[runner-workspace-seed]")
+      if (Array.isArray(value)) return value.map((entry) => compact(entry))
+      if (!value || typeof value !== "object") return value
+      const entry = value
+      if (key === "seed" && typeof entry.source === "string") return { kind: "runner-workspace-seed" }
+      return Object.fromEntries(Object.entries(entry).map(([childKey, item]) => [childKey, compact(item, childKey)]))
+    }
+    return `${JSON.stringify(compact(JSON.parse(text)), null, 2)}\n`
+  } catch {
+    return text
+  }
+}

--- a/.github/scripts/run-agent-task/build-codebox-task-request.mjs
+++ b/.github/scripts/run-agent-task/build-codebox-task-request.mjs
@@ -59,7 +59,24 @@ function commandList(name) {
     if (entry.description !== undefined && (typeof entry.description !== "string" || !entry.description.trim())) {
       throw new Error(`${name}[${index}].description must be a non-empty string when provided.`)
     }
-    return { command: entry.command.trim(), description: typeof entry.description === "string" ? entry.description.trim() : entry.command.trim() }
+    let artifact
+    if (entry.artifact !== undefined) {
+      if (!entry.artifact || typeof entry.artifact !== "object" || Array.isArray(entry.artifact)) {
+        throw new Error(`${name}[${index}].artifact must be an object with non-empty name, type, and path strings.`)
+      }
+      artifact = Object.fromEntries(["name", "type", "path"].map((key) => {
+        const value = entry.artifact[key]
+        if (typeof value !== "string" || !value.trim()) {
+          throw new Error(`${name}[${index}].artifact.${key} must be a non-empty string.`)
+        }
+        return [key, value.trim()]
+      }))
+    }
+    return {
+      command: entry.command.trim(),
+      description: typeof entry.description === "string" ? entry.description.trim() : entry.command.trim(),
+      ...(artifact ? { artifact } : {}),
+    }
   })
 }
 

--- a/.github/scripts/run-agent-task/execute-native-agent-task.mjs
+++ b/.github/scripts/run-agent-task/execute-native-agent-task.mjs
@@ -1,5 +1,5 @@
-import { rmSync } from "node:fs"
-import { appendFile, lstat, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises"
+import { constants, rmSync } from "node:fs"
+import { appendFile, lstat, mkdir, open, readFile, realpath, rm, writeFile } from "node:fs/promises"
 import { isUtf8 } from "node:buffer"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -7,10 +7,11 @@ import { spawn } from "node:child_process"
 import { createHash } from "node:crypto"
 import { canonicalExternalNativeAgentIdentity, materializeExternalNativePackage, materializeRuntimeSources, normalizeExternalPackageSource, normalizeRuntimeSources, parseExternalPackageSourcePolicy, sha256BytesV1, validateRuntimeSourceModel } from "./materialize-external-native-package.mjs"
 import { readNativeResult } from "./native-result-file.mjs"
-import { assertNoRuntimeSourcePaths, sanitizeRuntimeSourceJson, sanitizeRuntimeSourceText, sanitizeRuntimeSourceValue } from "./runtime-source-sanitizer.mjs"
+import { assertNoRuntimeSourcePaths, sanitizeArtifactUploadText, sanitizeRuntimeSourceJson, sanitizeRuntimeSourceText, sanitizeRuntimeSourceValue } from "./runtime-source-sanitizer.mjs"
 import { publishRunnerWorkspace } from "./runner-workspace-publisher.mjs"
 import { createRunnerWorkspaceSeedSnapshot, RUNNER_WORKSPACE_SEED_EXCLUDES } from "./runner-workspace-seed-snapshot.mjs"
 import { createTrustedArtifactApplyChannel, trustedArtifactApplyRefs } from "./trusted-artifact-snapshot.mjs"
+import { artifactSourcePathCategory, assertNoSeedSnapshotPaths, containsRuntimeSourceContent, sanitizeSeedSnapshotJson } from "./artifact-upload-policy.mjs"
 
 const requestPath = process.env.AGENT_TASK_REQUEST_PATH || ".codebox/agent-task-request.json"
 const workspace = resolve(process.env.AGENT_TASK_WORKSPACE || process.cwd())
@@ -19,6 +20,7 @@ const codeboxCliPath = process.env.WP_CODEBOX_CLI_PATH || join(codeboxRoot, "pac
 const outputPath = process.env.GITHUB_OUTPUT
 const MAX_CAPTURE_BYTES = 32768
 const MAX_WORKFLOW_OUTPUT_BYTES = 8192
+const MAX_COMMAND_ARTIFACT_BYTES = 4 * 1024 * 1024
 const secretValues = ["OPENAI_API_KEY", "MODEL_PROVIDER_SECRET_1", "MODEL_PROVIDER_SECRET_2", "MODEL_PROVIDER_SECRET_3", "MODEL_PROVIDER_SECRET_4", "MODEL_PROVIDER_SECRET_5", "GITHUB_TOKEN", "GH_TOKEN", "ACCESS_TOKEN", "EXTERNAL_PACKAGE_SOURCE_POLICY"].map((name) => process.env[name]).filter(Boolean)
 let privateRuntimeSourceRoot = ""
 let privateRuntimeSourceRootForSanitization = ""
@@ -254,7 +256,16 @@ function commandEntries(value, name) {
     if (!command) throw new Error(`${name}[${index}].command must be a non-empty string.`)
     const description = check.description === undefined ? command : string(check.description)
     if (!description) throw new Error(`${name}[${index}].description must be a non-empty string when provided.`)
-    return { command, description }
+    let artifact
+    if (check.artifact !== undefined) {
+      const output = record(check.artifact)
+      artifact = Object.fromEntries(["name", "type", "path"].map((key) => {
+        const value = string(output[key])
+        if (!value) throw new Error(`${name}[${index}].artifact.${key} must be a non-empty string.`)
+        return [key, value]
+      }))
+    }
+    return { command, description, ...(artifact ? { artifact } : {}) }
   })
 }
 
@@ -337,6 +348,151 @@ function requiredArtifacts(declarations) {
     const name = string(artifact.name)
     return artifact.required === true && artifact.direction !== "input" && name ? [name] : []
   })))
+}
+
+function commandArtifactFailure(code, message, declaration) {
+  const error = new Error(message)
+  error.code = `wp-codebox.agent-task.command-artifact-${code}`
+  error.artifact = declaration
+  return error
+}
+
+function commandArtifactError(error, declaration) {
+  return {
+    code: typeof error?.code === "string" ? error.code : "wp-codebox.agent-task.command-artifact-validation",
+    message: bounded(error instanceof Error ? error.message : String(error), MAX_WORKFLOW_OUTPUT_BYTES),
+    ...declaration,
+  }
+}
+
+function safeCommandArtifactPath(value) {
+  const path = string(value).replaceAll("\\", "/").replace(/^\.\//, "")
+  if (!path || isAbsolute(path) || /^[A-Za-z]:\//.test(path) || path.split("/").some((part) => !part || part === "." || part === "..")) return ""
+  return path
+}
+
+function commandArtifactAuthorization(declaration, artifactDeclarations) {
+  const outputs = (Array.isArray(artifactDeclarations) ? artifactDeclarations : []).map(record).filter((entry) => entry.direction !== "input")
+  const match = outputs.find((entry) => string(entry.name) === declaration.name && string(entry.type) === declaration.type)
+  if (match) return match
+  const mismatch = outputs.some((entry) => string(entry.name) === declaration.name || string(entry.type) === declaration.type)
+  throw commandArtifactFailure(mismatch ? "mismatch" : "undeclared", mismatch
+    ? `Command artifact ${declaration.name} (${declaration.type}) does not match its request artifact declaration.`
+    : `Command artifact ${declaration.name} (${declaration.type}) is not declared by the request.`, declaration)
+}
+
+async function readBoundedFile(handle, limit) {
+  const bytes = Buffer.alloc(limit + 1)
+  let offset = 0
+  while (offset < bytes.length) {
+    const { bytesRead } = await handle.read(bytes, offset, bytes.length - offset, offset)
+    if (bytesRead === 0) break
+    offset += bytesRead
+  }
+  return bytes.subarray(0, offset)
+}
+
+async function commandArtifactReference(declaration, artifactDeclarations, artifactsPath, kind) {
+  const authorized = commandArtifactAuthorization(declaration, artifactDeclarations)
+  const path = safeCommandArtifactPath(declaration.path)
+  if (!path) throw commandArtifactFailure("path", "Command artifact path must be artifact-relative and must not contain traversal.", declaration)
+  if (artifactSourcePathCategory(path)) throw commandArtifactFailure("forbidden", `Command artifact ${path} is a source path that cannot be uploaded.`, declaration)
+
+  const rootMetadata = await lstat(artifactsPath)
+  if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()) throw commandArtifactFailure("symlink", "Command artifact root must be a regular directory and must not be a symlink.", declaration)
+  const canonicalRoot = await realpath(artifactsPath)
+  const source = resolve(artifactsPath, path)
+  if (!underRoot(artifactsPath, source)) throw commandArtifactFailure("path", "Command artifact path escapes the artifact root.", declaration)
+  let current = artifactsPath
+  let finalMetadata
+  for (const part of path.split("/")) {
+    current = join(current, part)
+    let metadata
+    try {
+      metadata = await lstat(current)
+    } catch (error) {
+      if (error?.code === "ENOENT") throw commandArtifactFailure("missing", `Command artifact ${path} was not created.`, declaration)
+      throw error
+    }
+    if (metadata.isSymbolicLink()) throw commandArtifactFailure("symlink", `Command artifact ${path} must not traverse symlinks.`, declaration)
+    finalMetadata = metadata
+  }
+  if (!finalMetadata?.isFile()) throw commandArtifactFailure("not-regular", `Command artifact ${path} must be a regular file.`, declaration)
+  if (finalMetadata.size > MAX_COMMAND_ARTIFACT_BYTES) throw commandArtifactFailure("too-large", `Command artifact ${path} exceeds the ${MAX_COMMAND_ARTIFACT_BYTES}-byte limit.`, declaration)
+  const canonicalSource = await realpath(source)
+  if (!underRoot(canonicalRoot, canonicalSource)) throw commandArtifactFailure("symlink", `Command artifact ${path} must not traverse symlinks.`, declaration)
+
+  const handle = await open(source, constants.O_RDONLY | constants.O_NOFOLLOW).catch((error) => {
+    if (error?.code === "ELOOP") throw commandArtifactFailure("symlink", `Command artifact ${path} must not be a symlink.`, declaration)
+    if (error?.code === "ENOENT") throw commandArtifactFailure("missing", `Command artifact ${path} was not created.`, declaration)
+    throw error
+  })
+  let bytes
+  try {
+    const metadata = await handle.stat()
+    const pathMetadata = await lstat(source)
+    const canonicalOpenedSource = await realpath(source)
+    if (metadata.dev !== pathMetadata.dev || metadata.ino !== pathMetadata.ino || !underRoot(canonicalRoot, canonicalOpenedSource)) {
+      throw commandArtifactFailure("symlink", `Command artifact ${path} changed while it was being validated.`, declaration)
+    }
+    if (!metadata.isFile()) throw commandArtifactFailure("not-regular", `Command artifact ${path} must be a regular file.`, declaration)
+    if (metadata.size > MAX_COMMAND_ARTIFACT_BYTES) throw commandArtifactFailure("too-large", `Command artifact ${path} exceeds the ${MAX_COMMAND_ARTIFACT_BYTES}-byte limit.`, declaration)
+    bytes = await readBoundedFile(handle, MAX_COMMAND_ARTIFACT_BYTES)
+    if (bytes.length > MAX_COMMAND_ARTIFACT_BYTES) throw commandArtifactFailure("too-large", `Command artifact ${path} exceeds the ${MAX_COMMAND_ARTIFACT_BYTES}-byte limit.`, declaration)
+    if (bytes.includes(0) || !isUtf8(bytes)) throw commandArtifactFailure("malformed", `Command artifact ${path} must be a UTF-8 text file without NUL bytes.`, declaration)
+
+    const sanitizationRoots = [...(Array.isArray(privateRuntimeSourceRootForSanitization) ? privateRuntimeSourceRootForSanitization : [privateRuntimeSourceRootForSanitization]), workspace].filter(Boolean)
+    const sanitized = sanitizeSeedSnapshotJson(sanitizeArtifactUploadText(bytes.toString("utf8"), sanitizationRoots, secretValues))
+    assertNoRuntimeSourcePaths(sanitized, sanitizationRoots)
+    assertNoSeedSnapshotPaths(sanitized)
+    if (containsRuntimeSourceContent(sanitized)) throw commandArtifactFailure("forbidden", `Command artifact ${path} contains source content that cannot be uploaded.`, declaration)
+    const sanitizedBytes = Buffer.from(sanitized)
+    if (sanitizedBytes.length > MAX_COMMAND_ARTIFACT_BYTES) throw commandArtifactFailure("too-large", `Command artifact ${path} exceeds the ${MAX_COMMAND_ARTIFACT_BYTES}-byte limit after sanitization.`, declaration)
+    return {
+      schema: "wp-codebox/typed-artifact/v1",
+      name: declaration.name,
+      type: declaration.type,
+      metadata: {},
+      provenance: { direction: "output", source: `runner-${kind}-command` },
+      artifact: {
+        path,
+        kind: "typed-artifact",
+        contentType: string(authorized.contentType ?? authorized.content_type) || (path.endsWith(".json") ? "application/json" : "text/plain"),
+        sha256: createHash("sha256").update(sanitizedBytes).digest("hex"),
+      },
+    }
+  } finally {
+    await handle.close()
+  }
+}
+
+async function verificationRecord(kind, check, artifactsPath, artifactDeclarations) {
+  const checkResult = await command("bash", ["-lc", check.command], workspace)
+  const result = { kind, command: check.command, description: check.description, success: checkResult.code === 0, exit_code: checkResult.code, stdout: checkResult.stdout, stderr: checkResult.stderr, stdout_truncated: checkResult.stdout_truncated, stderr_truncated: checkResult.stderr_truncated }
+  if (checkResult.code !== 0 || !check.artifact) return result
+  try {
+    return { ...result, artifact: await commandArtifactReference(check.artifact, artifactDeclarations, artifactsPath, kind) }
+  } catch (error) {
+    return { ...result, success: false, artifact_error: commandArtifactError(error, check.artifact) }
+  }
+}
+
+async function finalizeCommandArtifacts(verification, artifactsPath, artifactDeclarations) {
+  for (const check of verification.filter((entry) => entry.artifact)) {
+    const accepted = check.artifact
+    const declaration = { name: accepted.name, type: accepted.type, path: accepted.artifact.path }
+    try {
+      const current = await commandArtifactReference(declaration, artifactDeclarations, artifactsPath, check.kind)
+      if (current.artifact.sha256 !== accepted.artifact.sha256) {
+        throw commandArtifactFailure("changed", `Command artifact ${declaration.path} changed after it was validated.`, declaration)
+      }
+      check.artifact = current
+    } catch (error) {
+      delete check.artifact
+      check.success = false
+      check.artifact_error = commandArtifactError(error, declaration)
+    }
+  }
 }
 
 async function testRuntimeFixtures(externalPackageSource) {
@@ -668,18 +824,18 @@ if (execution.code === 0 && request.run_agent && !request.dry_run && !downstream
     verification.push({ kind: "validation_dependencies", command: validationDependencies, description: "Install validation dependencies", success: checkResult.code === 0, exit_code: checkResult.code, stdout: checkResult.stdout, stderr: checkResult.stderr, stdout_truncated: checkResult.stdout_truncated, stderr_truncated: checkResult.stderr_truncated })
   }
   for (const check of verificationCommands) {
-    const checkResult = await command("bash", ["-lc", check.command], workspace)
-    verification.push({ kind: "verification", ...check, success: checkResult.code === 0, exit_code: checkResult.code, stdout: checkResult.stdout, stderr: checkResult.stderr, stdout_truncated: checkResult.stdout_truncated, stderr_truncated: checkResult.stderr_truncated })
+    verification.push(await verificationRecord("verification", check, artifactsPath, request.artifacts?.declarations))
   }
   for (const check of driftChecks) {
-    const checkResult = await command("bash", ["-lc", check.command], workspace)
-    verification.push({ kind: "drift", ...check, success: checkResult.code === 0, exit_code: checkResult.code, stdout: checkResult.stdout, stderr: checkResult.stderr, stdout_truncated: checkResult.stdout_truncated, stderr_truncated: checkResult.stderr_truncated })
+    verification.push(await verificationRecord("drift", check, artifactsPath, request.artifacts?.declarations))
   }
+  await finalizeCommandArtifacts(verification, artifactsPath, request.artifacts?.declarations)
 }
 
 const verificationPassed = verification.every((check) => check.success)
 if (!verificationPassed) {
-  downstreamFailure ??= { stage: "verification", message: "Runner workspace verification did not pass." }
+  const artifactError = verification.find((check) => check.artifact_error)?.artifact_error
+  downstreamFailure ??= { stage: "verification", message: artifactError?.message || "Runner workspace verification did not pass.", ...(artifactError ? { artifact_error: artifactError } : {}) }
 }
 const runtimeRecord = record(runtimeResult)
 const agentResult = record(runtimeRecord.agent_task_run_result)

--- a/.github/scripts/run-agent-task/prepare-agent-task-upload.mjs
+++ b/.github/scripts/run-agent-task/prepare-agent-task-upload.mjs
@@ -3,7 +3,8 @@ import { lstat, mkdir, open, readdir, readFile, realpath, rm, writeFile } from "
 import { isUtf8 } from "node:buffer"
 import { createHash } from "node:crypto"
 import { isAbsolute, join, relative, resolve } from "node:path"
-import { assertNoRuntimeSourcePaths, sanitizeRuntimeSourceJson } from "./runtime-source-sanitizer.mjs"
+import { assertNoRuntimeSourcePaths, sanitizeArtifactUploadText, sanitizeRuntimeSourceJson } from "./runtime-source-sanitizer.mjs"
+import { artifactSourcePathCategory, assertNoSeedSnapshotPaths, containsRuntimeSourceContent, sanitizeSeedSnapshotJson } from "./artifact-upload-policy.mjs"
 
 const MAX_UPLOAD_FILE_BYTES = 4 * 1024 * 1024
 const MAX_TRANSCRIPT_EXECUTIONS = 64
@@ -20,27 +21,12 @@ const runtimeSourceRoot = process.env.WP_CODEBOX_RUNTIME_SOURCE_ROOT ? resolve(p
 const runtimeSourcePrefix = process.env.WP_CODEBOX_RUNTIME_SOURCE_PREFIX ? resolve(process.env.WP_CODEBOX_RUNTIME_SOURCE_PREFIX) : ""
 const runtimeSourceRoots = [runtimeSourceRoot, runtimeSourcePrefix].filter(Boolean)
 const privateUploadRoots = [...runtimeSourceRoots, workspace]
-const SOURCE_TREE = /(^|\/)(prepared-plugins|prepared-source-packages|source-package[^/]*)(\/|$)/i
-const SOURCE_FILE = /\.(?:php|phtml|js|mjs|cjs|jsx|ts|tsx)$/i
-const PHP_OPENING_TAG = /<\?(?:php|=)(?:\s|$)/i
-const PHP_DECLARATION = /\b(?:namespace\s+\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*|(?:abstract\s+|final\s+|readonly\s+)*(?:class|interface|trait|enum)\s+[A-Za-z_]\w*|function\s+&?\s*[A-Za-z_]\w*\s*\()/i
-const WORDPRESS_PLUGIN_HEADER = /\/\*[\s\S]{0,200}?\bPlugin Name\s*:/i
-
-// Diagnostics commonly name runtime classes. Reject only PHP-shaped source, even
-// when a source file has been disguised with a reviewer-safe extension.
-function containsRuntimeSourceContent(text) {
-  const hasPhpTag = PHP_OPENING_TAG.test(text)
-  const hasDeclaration = PHP_DECLARATION.test(text)
-  return (hasPhpTag && hasDeclaration) || (WORDPRESS_PLUGIN_HEADER.test(text) && (hasPhpTag || hasDeclaration))
-}
-
 function redact(value) {
   return secretValues.reduce((output, secret) => output.split(secret).join("[REDACTED]"), value)
 }
 
 function sanitizeText(text) {
-  return sanitizeRuntimeSourceJson(text, privateUploadRoots)
-    .replace(/\/(?:Users|home|private|var|tmp|opt|Volumes)\/[^\s"'\\]+/g, "[host-path]")
+  return sanitizeArtifactUploadText(text, privateUploadRoots, secretValues)
 }
 
 function compactNativeInput(text) {
@@ -74,38 +60,6 @@ function compactNativeInput(text) {
   }
 }
 
-function assertNoSeedSnapshotPaths(text) {
-  if (/wp-codebox-runner-workspace-seed-/i.test(text)) throw new Error("Temporary runner workspace seed paths must never be persisted in artifact uploads.")
-  try {
-    const visit = (value) => {
-      if (Array.isArray(value)) return value.forEach(visit)
-      const entry = record(value)
-      if (!Object.keys(entry).length) return
-      if (record(entry.seed).source && isAbsolute(record(entry.seed).source)) throw new Error("Absolute runner workspace seed paths must never be persisted in artifact uploads.")
-      Object.values(entry).forEach(visit)
-    }
-    visit(JSON.parse(text))
-  } catch (error) {
-    if (error instanceof Error && /seed paths/.test(error.message)) throw error
-  }
-}
-
-function sanitizeSeedSnapshotJson(text) {
-  try {
-    const compact = (value, key = "") => {
-      if (typeof value === "string") return value.replace(/\/?[^\s"']*wp-codebox-runner-workspace-seed-[^\s"']*/gi, "[runner-workspace-seed]")
-      if (Array.isArray(value)) return value.map((entry) => compact(entry))
-      const entry = record(value)
-      if (!Object.keys(entry).length) return value
-      if (key === "seed" && typeof entry.source === "string") return { kind: "runner-workspace-seed" }
-      return Object.fromEntries(Object.entries(entry).map(([childKey, item]) => [childKey, compact(item, childKey)]))
-    }
-    return `${JSON.stringify(compact(JSON.parse(text)), null, 2)}\n`
-  } catch {
-    return text
-  }
-}
-
 function isPrivateRuntimePath(value) {
   if (!runtimeSourceRoots.length || typeof value !== "string") return false
   const path = resolve(value)
@@ -124,9 +78,18 @@ function safeRelativeArtifactPath(value) {
 
 function sourceCategory(path, absolutePath) {
   if (isPrivateRuntimePath(absolutePath)) return "private-runtime"
-  if (SOURCE_TREE.test(path)) return "source-tree"
-  if (SOURCE_FILE.test(path)) return "source-file"
-  return ""
+  return artifactSourcePathCategory(path)
+}
+
+async function readBoundedFile(handle, limit) {
+  const bytes = Buffer.alloc(limit + 1)
+  let offset = 0
+  while (offset < bytes.length) {
+    const { bytesRead } = await handle.read(bytes, offset, bytes.length - offset, offset)
+    if (bytesRead === 0) break
+    offset += bytesRead
+  }
+  return bytes.subarray(0, offset)
 }
 
 async function stageTextFile(source, destination, options = {}) {
@@ -135,9 +98,9 @@ async function stageTextFile(source, destination, options = {}) {
   const handle = await open(source, constants.O_RDONLY | constants.O_NOFOLLOW).catch(() => null)
   if (!handle) return false
   const openedMetadata = await handle.stat()
-  const contents = openedMetadata.isFile() && openedMetadata.size <= MAX_UPLOAD_FILE_BYTES ? await handle.readFile() : null
+  const contents = openedMetadata.isFile() && openedMetadata.size <= MAX_UPLOAD_FILE_BYTES ? await readBoundedFile(handle, MAX_UPLOAD_FILE_BYTES) : null
   await handle.close()
-  if (!contents || contents.includes(0) || !isUtf8(contents)) return false
+  if (!contents || contents.length > MAX_UPLOAD_FILE_BYTES || contents.includes(0) || !isUtf8(contents)) return false
   const sourceText = contents.toString("utf8")
   const sanitized = options.projectWorkflowResult
     ? `${JSON.stringify(projectWorkflowResult(parseJsonOrEmpty(sourceText)), null, 2)}\n`
@@ -200,7 +163,7 @@ function projectWorkflowResult(value) {
   const reviewerEvidence = record(result.reviewer_evidence)
   const verification = Array.isArray(result.verification) ? result.verification.slice(0, MAX_REVIEW_COLLECTION_ENTRIES).map((value) => {
     const check = record(value)
-    return projectReviewValue(Object.fromEntries(["kind", "command", "description", "success", "exit_code", "stdout_truncated", "stderr_truncated"].flatMap((key) => check[key] === undefined ? [] : [[key, check[key]]])))
+    return projectReviewValue(Object.fromEntries(["kind", "command", "description", "success", "exit_code", "stdout_truncated", "stderr_truncated", "artifact", "artifact_error"].flatMap((key) => check[key] === undefined ? [] : [[key, check[key]]])))
   }) : undefined
   return projectReviewValue(Object.fromEntries(Object.entries({
     schema: result.schema,
@@ -419,6 +382,28 @@ function declaredArtifactPaths(result, allowed) {
   return [...paths].sort()
 }
 
+function commandArtifactDigests(result) {
+  const digests = new Map()
+  const visit = (value) => {
+    if (Array.isArray(value)) return value.forEach(visit)
+    const entry = record(value)
+    if (!Object.keys(entry).length) return
+    const provenance = record(entry.provenance)
+    const artifact = record(entry.artifact)
+    const path = safeRelativeArtifactPath(artifact.path)
+    if (entry.schema === "wp-codebox/typed-artifact/v1"
+      && typeof provenance.source === "string"
+      && /^runner-(?:verification|drift)-command$/.test(provenance.source)
+      && path
+      && /^[a-f0-9]{64}$/.test(artifact.sha256)) {
+      digests.set(path, artifact.sha256)
+    }
+    Object.values(entry).forEach(visit)
+  }
+  visit(result)
+  return digests
+}
+
 function workflowOutputArtifacts(result) {
   return Object.entries(record(result.workflow_output_artifacts)).flatMap(([name, value]) => {
     const reference = record(value)
@@ -497,6 +482,7 @@ const request = parseJsonOrEmpty(await readFile(requestPath, "utf8").catch(() =>
 const resultSource = join(workspace, ".codebox", "agent-task-workflow-result.json")
 const result = parseJsonOrEmpty(await readFile(resultSource, "utf8").catch(() => "{}"))
 const declaredPaths = new Set(declaredArtifactPaths(result, declarations(request)))
+const commandArtifactHashes = commandArtifactDigests(result)
 const workflowOutputArtifactsToStage = workflowOutputArtifacts(result)
 
 await rm(uploadPath, { recursive: true, force: true })
@@ -512,7 +498,10 @@ for (const path of declaredPaths) {
     // Keep staging independent of an untrusted alias, including transcripts.
     continue
   }
-  await stageTextFile(source, join(uploadPath, ".codebox", "agent-task-artifacts", path))
+  const expectedDigest = commandArtifactHashes.get(path)
+  const destination = join(uploadPath, ".codebox", "agent-task-artifacts", path)
+  const staged = await stageTextFile(source, destination)
+  if (expectedDigest && (!staged || digest(await readFile(destination)) !== expectedDigest)) throw new Error(`Command artifact ${path} could not be staged without modification.`)
 }
 for (const [path, reference] of workflowOutputArtifactsToStage) {
   const source = resolve(artifactsPath, path)

--- a/.github/scripts/run-agent-task/runtime-source-sanitizer.mjs
+++ b/.github/scripts/run-agent-task/runtime-source-sanitizer.mjs
@@ -46,6 +46,12 @@ export function sanitizeRuntimeSourceJson(text, root) {
   }
 }
 
+export function sanitizeArtifactUploadText(text, roots, secrets = []) {
+  const redacted = secrets.filter(Boolean).reduce((value, secret) => value.split(secret).join("[REDACTED]"), text)
+  return sanitizeRuntimeSourceJson(redacted, roots)
+    .replace(/\/(?:Users|home|private|var|tmp|opt|Volumes)\/[^\s"'\\]+/g, "[host-path]")
+}
+
 export function assertNoRuntimeSourcePaths(value, root, message = "Runtime source paths must never be persisted in workflow results or artifacts.") {
   const serialized = JSON.stringify(value)
   if (runtimeSourceRoots(root).some((sourceRoot) => serialized.includes(sourceRoot))) throw new Error(message)

--- a/contracts/agent-task-workflow-request.fixture.json
+++ b/contracts/agent-task-workflow-request.fixture.json
@@ -27,7 +27,12 @@
   "verification_commands": [
     {
       "command": "npm test",
-      "description": "Run checks"
+      "description": "Run checks",
+      "artifact": {
+        "name": "completion_report",
+        "type": "CompletionReport",
+        "path": "completion-report.json"
+      }
     }
   ],
   "drift_checks": [],
@@ -55,6 +60,12 @@
       {
         "schema": "wp-codebox/artifact-declaration/v1",
         "name": "agent_transcript"
+      },
+      {
+        "name": "completion_report",
+        "type": "CompletionReport",
+        "direction": "output",
+        "contentType": "application/json"
       }
     ],
     "transcript_name": "agent-transcript",

--- a/docs/agent-task-reusable-workflow.md
+++ b/docs/agent-task-reusable-workflow.md
@@ -14,8 +14,9 @@ jobs:
       writable_paths: README.md,docs/**
       runner_workspace: '{"enabled":true,"repo":"Automattic/example-target"}'
       validation_dependencies: npm ci
-      verification_commands: '[{"command":"npm test","description":"Run checks"}]'
+      verification_commands: '[{"command":"npm test","description":"Run checks","artifact":{"name":"test_report","type":"TestReport","path":"test-report.json"}}]'
       drift_checks: '["git diff --exit-code"]'
+      artifact_declarations: '[{"name":"test_report","type":"TestReport","direction":"output","contentType":"application/json"}]'
       success_requires_pr: true
       access_token_repos: Automattic/example-target
       allowed_repos: '["Automattic/example-target"]'
@@ -61,7 +62,7 @@ This release-coherence contract fixes [#1759](https://github.com/Automattic/wp-c
 - `prompt`, `writable_paths`, provider/model, `max_turns`, `time_budget_ms`, callback data, and artifact declarations: native task inputs.
 - `runner_workspace`: JSON runner-workspace publication request owned by the package.
 - `validation_dependencies`: optional shell command that installs validation dependencies in the target workspace.
-- `verification_commands` and `drift_checks`: JSON arrays of non-empty command strings or `{command, description}` objects. Every entry runs and must pass.
+- `verification_commands` and `drift_checks`: JSON arrays of non-empty command strings or `{command, description}` objects. Every entry runs and must pass. An object may declare one output as `artifact: {name, type, path}`. All three artifact fields are required, `path` is relative to `.codebox/agent-task-artifacts`, and the exact name/type pair must also be an output in `artifact_declarations`. After an exit-zero command, the workflow accepts only an existing regular UTF-8 file of at most 4 MiB without path traversal or symlinks. It adds a canonical `wp-codebox/typed-artifact/v1` reference to that verification record so declared-artifact upload staging collects the file. Artifact validation fails that verification before publication; failed commands never accept an artifact. Strings and command/description-only objects retain their existing behavior.
 - `success_requires_pr`: require a successful, published runner-workspace pull request for `target_repo`.
 - `access_token_repos`: comma-separated repositories available to the supplied access token.
 - `allowed_repos`: JSON repository allowlist. It and `access_token_repos` must explicitly include `target_repo`.

--- a/tests/agent-task-reusable-workflow.test.ts
+++ b/tests/agent-task-reusable-workflow.test.ts
@@ -165,7 +165,7 @@ await execFileAsync("node", [new URL("../.github/scripts/run-agent-task/build-co
     MODEL: "gpt-5.5",
     RUNNER_WORKSPACE_CONFIG: '{"enabled":true,"repo":"Automattic/example-target"}',
     VALIDATION_DEPENDENCIES: "",
-    VERIFICATION_COMMANDS: '[{"command":"npm test","description":"Run checks"}]',
+    VERIFICATION_COMMANDS: '[{"command":"npm test","description":"Run checks","artifact":{"name":"completion_report","type":"CompletionReport","path":"completion-report.json"}}]',
     DRIFT_CHECKS: "[]",
     SUCCESS_REQUIRES_PR: "false",
     ACCESS_TOKEN_REPOS: "Automattic/example-target",
@@ -176,7 +176,7 @@ await execFileAsync("node", [new URL("../.github/scripts/run-agent-task/build-co
     TRANSCRIPT_ARTIFACT_NAME: "agent-transcript",
     REPLAY_BUNDLE_ARTIFACT_NAME: "agent-replay",
     EXPECTED_ARTIFACTS: '["agent_transcript"]',
-    ARTIFACT_DECLARATIONS: '[{"schema":"wp-codebox/artifact-declaration/v1","name":"agent_transcript"}]',
+    ARTIFACT_DECLARATIONS: '[{"schema":"wp-codebox/artifact-declaration/v1","name":"agent_transcript"},{"name":"completion_report","type":"CompletionReport","direction":"output","contentType":"application/json"}]',
     CALLBACK_DATA: '{"workload":"example-maintenance"}',
     RUN_AGENT: "false",
     DRY_RUN: "true",
@@ -311,6 +311,21 @@ await assert.rejects(execFileAsync("node", [new URL("../.github/scripts/run-agen
     EXTERNAL_PACKAGE_SOURCE_POLICY: '{"version":1,"repositories":{"automattic/example-agent-packages":["packages/example-agent.agent.json"]}}',
   },
 }), /verification_commands\[0\]\.command/)
+
+const malformedArtifactRequest = { ...request, verification_commands: [{ command: "true", artifact: { name: "report", path: "report.json" } }] }
+await writeFile(requestPath, `${JSON.stringify(malformedArtifactRequest, null, 2)}\n`)
+await assert.rejects(execFileAsync("node", [executeNativeAgentTask], {
+  cwd: tmp,
+  env: {
+    ...process.env,
+    GITHUB_OUTPUT: outputPath,
+    AGENT_TASK_REQUEST_PATH: requestPath,
+    AGENT_TASK_WORKSPACE: tmp,
+    WP_CODEBOX_WORKFLOW_ROOT: new URL("..", import.meta.url).pathname,
+    GITHUB_TOKEN: "test-caller-token",
+    EXTERNAL_PACKAGE_SOURCE_POLICY: '{"version":1,"repositories":{"automattic/example-agent-packages":["packages/example-agent.agent.json"]}}',
+  },
+}), /verification_commands\[0\]\.artifact\.type/)
 
 await writeFile(requestPath, "{\n")
 await assert.rejects(execFileAsync("node", [executeNativeAgentTask], {

--- a/tests/execute-native-agent-task-lifecycle.test.mjs
+++ b/tests/execute-native-agent-task-lifecycle.test.mjs
@@ -22,6 +22,28 @@ async function run(mode = "success") {
   await mkdir(join(workspace, ".codebox"), { recursive: true })
   await writeFile(join(workspace, "README.md"), "OPENAI_API_KEY\nbefore\n")
 
+  const artifactModes = new Set(["artifact-verification", "artifact-drift", "artifact-readonly", "artifact-missing", "artifact-traversal", "artifact-symlink", "artifact-oversized", "artifact-undeclared", "artifact-mismatch", "artifact-command-fail", "artifact-replaced"])
+  const commandArtifact = artifactModes.has(mode) ? {
+    name: "completion_report",
+    type: "CompletionReport",
+    path: mode === "artifact-traversal" ? "../completion-report.json" : "completion-report.json",
+  } : undefined
+  const artifactCommand = mode === "artifact-missing"
+    ? "echo verification >> .codebox/order"
+    : mode === "artifact-traversal"
+      ? `echo verification >> .codebox/order && printf '%s\\n' '{"ok":true}' > .codebox/completion-report.json`
+      : mode === "artifact-symlink"
+        ? `echo verification >> .codebox/order && printf '%s\\n' '{"ok":true}' > .codebox/completion-report-source.json && ln -s ../completion-report-source.json .codebox/agent-task-artifacts/completion-report.json`
+        : mode === "artifact-oversized"
+          ? `echo verification >> .codebox/order && node -e 'require("node:fs").writeFileSync(".codebox/agent-task-artifacts/completion-report.json", Buffer.alloc(4 * 1024 * 1024 + 1, 120))'`
+          : `echo verification >> .codebox/order && printf '%s\\n' '{"ok":true}' > .codebox/agent-task-artifacts/completion-report.json${mode === "artifact-command-fail" ? " && false" : mode === "artifact-readonly" ? " && chmod 444 .codebox/agent-task-artifacts/completion-report.json" : ""}`
+  const verificationCommand = artifactModes.has(mode) && mode !== "artifact-drift" ? artifactCommand : (mode === "verify-fail" ? "false" : "echo verification >> .codebox/order")
+  const driftCommand = mode === "artifact-drift"
+    ? artifactCommand
+    : mode === "artifact-replaced"
+      ? `echo drift >> .codebox/order && printf '%s\\n' '{"ok":false}' > .codebox/agent-task-artifacts/completion-report.json`
+      : "echo drift >> .codebox/order"
+
   const request = {
     schema: "wp-codebox/agent-task-workflow-request/v1",
     model: { provider: "openai", name: "gpt-5" },
@@ -44,9 +66,9 @@ async function run(mode = "success") {
     },
     validation_dependencies: "echo validation >> .codebox/order",
     verification_commands: [
-      { command: mode === "verify-fail" ? "false" : "echo verification >> .codebox/order" },
+      { command: verificationCommand, ...(mode !== "artifact-drift" && commandArtifact ? { artifact: commandArtifact } : {}) },
     ],
-    drift_checks: [{ command: "echo drift >> .codebox/order" }],
+    drift_checks: [{ command: driftCommand, ...(mode === "artifact-drift" && commandArtifact ? { artifact: commandArtifact } : {}) }],
     success: { requires_pr: mode !== "no-op-maintenance" },
     access: {
       caller_repo: targetRepo,
@@ -54,7 +76,12 @@ async function run(mode = "success") {
       access_token_repos: [targetRepo],
     },
     limits: { max_turns: 1, time_budget_ms: 1000 },
-    artifacts: { expected: [], declarations: [] },
+    artifacts: {
+      expected: [],
+      declarations: artifactModes.has(mode) && mode !== "artifact-undeclared"
+        ? [{ name: "completion_report", type: mode === "artifact-mismatch" ? "DifferentReport" : "CompletionReport", direction: "output", contentType: "application/json" }]
+        : [],
+    },
     outputs: {
       projections: {
         pr_url: mode === "no-op-maintenance"
@@ -195,6 +222,69 @@ assert.equal(success.result.runtime_result.agent_runtime_diagnostics.prepared_pa
 assert.equal(success.result.runtime_result.agent_runtime_diagnostics.prepared_paths.workspaces[0].mode, "readwrite")
 assert.equal(success.result.runtime_result.agent_runtime_diagnostics.sandbox_workspace.mounts[0].target, "/workspace")
 assert.equal(success.result.runtime_result.agent_runtime_diagnostics.local_executor_root, "/workspace")
+assert.equal(success.result.verification.some((check) => check.artifact || check.artifact_error), false, "legacy command entries retain their result shape")
+
+for (const mode of ["artifact-verification", "artifact-drift", "artifact-readonly"]) {
+  const artifactSuccess = await run(mode)
+  assert.equal(artifactSuccess.code, 0, `${artifactSuccess.stderr}\n${JSON.stringify(artifactSuccess.result)}`)
+  const artifactCheck = artifactSuccess.result.verification.find((check) => check.artifact)
+  assert.equal(artifactCheck.kind, mode === "artifact-drift" ? "drift" : "verification")
+  assert.deepEqual({ schema: artifactCheck.artifact.schema, name: artifactCheck.artifact.name, type: artifactCheck.artifact.type }, {
+    schema: "wp-codebox/typed-artifact/v1",
+    name: "completion_report",
+    type: "CompletionReport",
+  })
+  assert.equal(artifactCheck.artifact.artifact.path, "completion-report.json")
+  assert.match(artifactCheck.artifact.artifact.sha256, /^[a-f0-9]{64}$/)
+  await execFileAsync(process.execPath, [uploader], {
+    cwd: artifactSuccess.workspace,
+    env: {
+      ...process.env,
+      AGENT_TASK_WORKSPACE: artifactSuccess.workspace,
+      AGENT_TASK_REQUEST_PATH: join(artifactSuccess.workspace, ".codebox", "agent-task-request.json"),
+      AGENT_TASK_UPLOAD_PATH: join(artifactSuccess.workspace, ".codebox", "agent-task-upload"),
+    },
+  })
+  assert.deepEqual(JSON.parse(await readFile(join(artifactSuccess.workspace, ".codebox", "agent-task-upload", ".codebox", "agent-task-artifacts", "completion-report.json"), "utf8")), { ok: true })
+  const uploadedResult = JSON.parse(await readFile(join(artifactSuccess.workspace, ".codebox", "agent-task-upload", ".codebox", "agent-task-workflow-result.json"), "utf8"))
+  assert.equal(uploadedResult.verification.find((check) => check.artifact).artifact.artifact.path, "completion-report.json")
+  if (mode === "artifact-verification") {
+    await writeFile(join(artifactSuccess.workspace, ".codebox", "agent-task-artifacts", "completion-report.json"), '{"tampered":true}\n')
+    await assert.rejects(execFileAsync(process.execPath, [uploader], {
+      cwd: artifactSuccess.workspace,
+      env: {
+        ...process.env,
+        AGENT_TASK_WORKSPACE: artifactSuccess.workspace,
+        AGENT_TASK_REQUEST_PATH: join(artifactSuccess.workspace, ".codebox", "agent-task-request.json"),
+        AGENT_TASK_UPLOAD_PATH: join(artifactSuccess.workspace, ".codebox", "agent-task-upload"),
+      },
+    }), /could not be staged without modification/)
+  }
+}
+
+for (const [mode, code] of [
+  ["artifact-missing", "wp-codebox.agent-task.command-artifact-missing"],
+  ["artifact-traversal", "wp-codebox.agent-task.command-artifact-path"],
+  ["artifact-symlink", "wp-codebox.agent-task.command-artifact-symlink"],
+  ["artifact-oversized", "wp-codebox.agent-task.command-artifact-too-large"],
+  ["artifact-undeclared", "wp-codebox.agent-task.command-artifact-undeclared"],
+  ["artifact-mismatch", "wp-codebox.agent-task.command-artifact-mismatch"],
+  ["artifact-replaced", "wp-codebox.agent-task.command-artifact-changed"],
+]) {
+  const artifactFailure = await run(mode)
+  assert.equal(artifactFailure.code, 1)
+  assert(!artifactFailure.order.includes("publish"), `${mode} must fail before publication`)
+  assert.equal(artifactFailure.result.failure.stage, "verification")
+  assert.equal(artifactFailure.result.failure.artifact_error.code, code)
+  assert.equal(artifactFailure.result.verification.find((check) => check.artifact_error).artifact_error.code, code)
+}
+
+const failedArtifactCommand = await run("artifact-command-fail")
+assert.equal(failedArtifactCommand.code, 1)
+const failedArtifactCheck = failedArtifactCommand.result.verification.find((check) => check.kind === "verification")
+assert.equal(failedArtifactCheck.exit_code, 1)
+assert.equal(failedArtifactCheck.artifact, undefined)
+assert.equal(failedArtifactCheck.artifact_error, undefined, "failed commands do not accept or validate artifacts")
 
 const canonicalCasing = await run("canonical-casing")
 assert.equal(canonicalCasing.code, 0, `${canonicalCasing.stderr}\n${JSON.stringify(canonicalCasing.result)}`)


### PR DESCRIPTION
## Summary
Allow successful verification and drift commands to produce bounded, declared, reviewer-visible artifacts without adding caller-specific semantics to WP Codebox.

## What changed
- Extend verification and drift command entries with optional name, type, and artifact-relative path declarations.
- Validate authorization, containment, symlinks, file type, size, UTF-8, sanitization, and immutable digest before publication.
- Stage accepted artifacts through the existing declared-artifact allowlist and revalidate digests during upload.

## How to test
1. Run `npm run test:native-agent-task-lifecycle`; expect Verification and drift artifact success/failure, ordering, tamper, and upload integration cases pass..
2. Run `npm run test:agent-task-contracts`; expect Reusable workflow, canonical evidence, interface, runtime-source, and request contract suites pass..
3. Run `npm run build`; expect Runtime core, Playground, and CLI TypeScript builds pass..

## Compatibility
Additive reusable-workflow request support. Existing verification and drift entries remain compatible; artifact validation applies only when an artifact is declared.

## Evidence
- Base unchanged since verification: main remains at bc982947ec33c78160125026e16d357b7ece3ea1.
- CI expected: WP Codebox CI
- Durable run execution: PartialFailure
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1887
- Verified finalization base: main at bc982947ec33c78160125026e16d357b7ece3ea1
- gate-1: Passed
- gate-2: Passed
- gate-3: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Designed and implemented generic declared artifacts from verification and drift commands, including containment, sanitization, integrity, upload, and regression coverage; Chris reviewed and owns the change.

## Source relationships
- Closes Automattic/wp-codebox#1887
