### PR TITLE
Prevent stale runner publication branches

### DIFF
--- a/.github/scripts/run-agent-task/runner-workspace-publisher.mjs
+++ b/.github/scripts/run-agent-task/runner-workspace-publisher.mjs
@@ -41,25 +41,33 @@ export async function publishRunnerWorkspace({ request, changedFiles, publicatio
   let head = configuredHead
   let pull = null
   let parent = baseSha
+  let reusedPull = false
   if (existing) {
     const pulls = await openPulls(head)
     pull = pulls.find((candidate) => isExactPull(candidate, head)) || null
+    if (!pull) {
+      head = `${configuredHead}-${baseSha.slice(0, 12)}`
+      if (!/^[A-Za-z0-9._/-]+$/.test(head)) throw new Error("Runner workspace fresh publication branch configuration is invalid.")
+      try {
+        existing = await api("GET", refPath(head))
+      } catch (error) {
+        if (!String(error.message).includes(" 404.")) throw error
+        existing = null
+      }
+      if (existing) {
+        const freshPulls = await openPulls(head)
+        pull = freshPulls.find((candidate) => isExactPull(candidate, head)) || null
+        if (!pull) throw new Error(`Fresh publication branch ${head} already exists without an exact open pull request; choose a new run ID or resolve the branch before publishing.`)
+      }
+    }
     if (pull) {
-      const existingSha = string(existing.object?.sha)
+      const existingSha = string(existing?.object?.sha)
       const comparison = await api("GET", `/compare/${baseSha}...${existingSha}`)
       if (!existingSha || !["ahead", "identical"].includes(string(comparison.status)) || string(comparison.merge_base_commit?.sha) !== baseSha) {
         throw new Error(`Existing publication branch ${head} has an open pull request but does not descend from current base ${base}@${baseSha}; rebase the pull request before publishing again.`)
       }
       parent = existingSha
-    } else {
-      head = `${configuredHead}-${baseSha.slice(0, 12)}`
-      if (!/^[A-Za-z0-9._/-]+$/.test(head)) throw new Error("Runner workspace fresh publication branch configuration is invalid.")
-      try {
-        await api("GET", refPath(head))
-        throw new Error(`Fresh publication branch ${head} already exists; choose a new run ID or resolve its pull request before publishing.`)
-      } catch (error) {
-        if (!String(error.message).includes(" 404.")) throw error
-      }
+      reusedPull = true
     }
   }
   const parentCommit = await api("GET", `/git/commits/${parent}`)
@@ -80,5 +88,5 @@ export async function publishRunnerWorkspace({ request, changedFiles, publicatio
   else await api("POST", "/git/refs", { ref: `refs/heads/${head}`, sha: string(commit.sha) })
   pull ||= await api("POST", "/pulls", { title: string(config.title || request.workload?.label || "Apply agent task changes"), head, base, body: string(config.body || "") })
   if (!isExactPull(pull, head) || !/^https:\/\/github\.com\//.test(string(pull.html_url))) throw new Error("GitHub publication response did not match the requested repository and branches.")
-  return { schema: "wp-codebox/runner-workspace-publication-result/v1", success: true, status: "published", backend: "github-rest", branch: { base, base_sha: baseSha, head, name: head }, commit: { sha: string(commit.sha), parent_sha: parent }, pull_request: { number: pull.number, url: pull.html_url, reused: Boolean(pull && existing && parent !== baseSha), opened: !(existing && parent !== baseSha) } }
+  return { schema: "wp-codebox/runner-workspace-publication-result/v1", success: true, status: "published", backend: "github-rest", branch: { base, base_sha: baseSha, head, name: head }, commit: { sha: string(commit.sha), parent_sha: parent }, pull_request: { number: pull.number, url: pull.html_url, reused: reusedPull, opened: !reusedPull } }
 }

--- a/.github/scripts/run-agent-task/runner-workspace-publisher.mjs
+++ b/.github/scripts/run-agent-task/runner-workspace-publisher.mjs
@@ -13,7 +13,7 @@ export async function publishRunnerWorkspace({ request, changedFiles, publicatio
   const hasConfiguredBase = Boolean(base)
   const prefix = string(config.branch_prefix || "wp-codebox/agent-task/")
   const runId = string(config.run_id || request.workload?.id || "agent-task").replace(/[^A-Za-z0-9._/-]+/g, "-")
-  const head = `${prefix}${runId}`
+  const configuredHead = `${prefix}${runId}`
   const api = async (method, path, body) => {
     const response = await fetchImpl(`https://api.github.com/repos/${targetRepo}${path}`, { method, headers: { Accept: "application/vnd.github+json", Authorization: `Bearer ${token}`, "X-GitHub-Api-Version": "2022-11-28", ...(body ? { "Content-Type": "application/json" } : {}) }, ...(body ? { body: JSON.stringify(body) } : {}) })
     const payload = await response.json().catch(() => ({}))
@@ -21,17 +21,48 @@ export async function publishRunnerWorkspace({ request, changedFiles, publicatio
     return payload
   }
   if (!base) base = string((await api("GET", "")).default_branch)
-  if (!/^[A-Za-z0-9._/-]+$/.test(prefix) || !head.startsWith(prefix) || head.includes("..") || !/^[A-Za-z0-9._/-]+$/.test(base)) {
+  if (!/^[A-Za-z0-9._/-]+$/.test(prefix) || !configuredHead.startsWith(prefix) || configuredHead.includes("..") || !/^[A-Za-z0-9._/-]+$/.test(base)) {
     throw new Error(hasConfiguredBase ? "Runner workspace branch configuration is invalid." : "Runner workspace branch configuration is invalid: repository metadata must provide a valid default branch when base is omitted.")
   }
+  const refPath = (name) => `/git/ref/heads/${name.split("/").map(encodeURIComponent).join("/")}`
+  const openPulls = async (head) => {
+    const pulls = await api("GET", `/pulls?state=open&head=${encodeURIComponent(`${targetRepo.split("/")[0]}:${head}`)}&base=${encodeURIComponent(base)}`)
+    return Array.isArray(pulls) ? pulls : []
+  }
+  const isExactPull = (pull, head) => string(pull?.base?.repo?.full_name).toLowerCase() === targetRepo
+    && string(pull?.head?.repo?.full_name).toLowerCase() === targetRepo
+    && string(pull?.head?.ref) === head
+    && string(pull?.base?.ref) === base
+  const baseRef = await api("GET", refPath(base))
+  const baseSha = string(baseRef.object?.sha)
+  if (!baseSha) throw new Error("Runner workspace publication base branch did not resolve to a commit SHA.")
   let existing = null
-  try { existing = await api("GET", `/git/ref/heads/${head.split("/").map(encodeURIComponent).join("/")}`) } catch (error) { if (!String(error.message).includes(" 404.")) throw error }
-  // Existing PR branches are append-only publication targets. Their current tree
-  // is the base so files from earlier agent turns cannot disappear.
-  const parent = string(existing?.object?.sha)
-  const baseRef = parent ? null : await api("GET", `/git/ref/heads/${encodeURIComponent(base)}`)
-  const baseSha = parent || string(baseRef.object?.sha)
-  const baseCommit = await api("GET", `/git/commits/${baseSha}`)
+  try { existing = await api("GET", refPath(configuredHead)) } catch (error) { if (!String(error.message).includes(" 404.")) throw error }
+  let head = configuredHead
+  let pull = null
+  let parent = baseSha
+  if (existing) {
+    const pulls = await openPulls(head)
+    pull = pulls.find((candidate) => isExactPull(candidate, head)) || null
+    if (pull) {
+      const existingSha = string(existing.object?.sha)
+      const comparison = await api("GET", `/compare/${baseSha}...${existingSha}`)
+      if (!existingSha || !["ahead", "identical"].includes(string(comparison.status)) || string(comparison.merge_base_commit?.sha) !== baseSha) {
+        throw new Error(`Existing publication branch ${head} has an open pull request but does not descend from current base ${base}@${baseSha}; rebase the pull request before publishing again.`)
+      }
+      parent = existingSha
+    } else {
+      head = `${configuredHead}-${baseSha.slice(0, 12)}`
+      if (!/^[A-Za-z0-9._/-]+$/.test(head)) throw new Error("Runner workspace fresh publication branch configuration is invalid.")
+      try {
+        await api("GET", refPath(head))
+        throw new Error(`Fresh publication branch ${head} already exists; choose a new run ID or resolve its pull request before publishing.`)
+      } catch (error) {
+        if (!String(error.message).includes(" 404.")) throw error
+      }
+    }
+  }
+  const parentCommit = await api("GET", `/git/commits/${parent}`)
   const tree = []
   const captured = Array.isArray(publicationFiles) ? publicationFiles : []
   if (!captured.length) throw new Error("Runner workspace publication requires immutable approved file content.")
@@ -43,12 +74,11 @@ export async function publishRunnerWorkspace({ request, changedFiles, publicatio
     const blob = await api("POST", "/git/blobs", { content: changed.content, encoding: "base64" })
     tree.push({ path: relativePath, mode: changed.mode, type: "blob", sha: string(blob.sha) })
   }
-  const nextTree = await api("POST", "/git/trees", { base_tree: string(baseCommit.tree?.sha), tree })
-  const commit = await api("POST", "/git/commits", { message: string(config.commit_message || request.workload?.label || "Apply agent task changes"), tree: string(nextTree.sha), parents: [baseSha] })
-  if (existing) await api("PATCH", `/git/refs/heads/${head.split("/").map(encodeURIComponent).join("/")}`, { sha: string(commit.sha), force: false })
+  const nextTree = await api("POST", "/git/trees", { base_tree: string(parentCommit.tree?.sha), tree })
+  const commit = await api("POST", "/git/commits", { message: string(config.commit_message || request.workload?.label || "Apply agent task changes"), tree: string(nextTree.sha), parents: [parent] })
+  if (pull) await api("PATCH", `/git/refs/heads/${head.split("/").map(encodeURIComponent).join("/")}`, { sha: string(commit.sha), force: false })
   else await api("POST", "/git/refs", { ref: `refs/heads/${head}`, sha: string(commit.sha) })
-  const pulls = await api("GET", `/pulls?state=open&head=${encodeURIComponent(`${targetRepo.split("/")[0]}:${head}`)}&base=${encodeURIComponent(base)}`)
-  const pull = Array.isArray(pulls) && pulls[0] ? pulls[0] : await api("POST", "/pulls", { title: string(config.title || request.workload?.label || "Apply agent task changes"), head, base, body: string(config.body || "") })
-  if (string(pull.base?.repo?.full_name).toLowerCase() !== targetRepo || string(pull.head?.ref) !== head || string(pull.base?.ref) !== base || !/^https:\/\/github\.com\//.test(string(pull.html_url))) throw new Error("GitHub publication response did not match the requested repository and branches.")
-  return { schema: "wp-codebox/runner-workspace-publication-result/v1", success: true, status: "published", backend: "github-rest", branch: { base, head, name: head }, commit: { sha: string(commit.sha) }, pull_request: { number: pull.number, url: pull.html_url, reused: Boolean(Array.isArray(pulls) && pulls[0]), opened: !(Array.isArray(pulls) && pulls[0]) } }
+  pull ||= await api("POST", "/pulls", { title: string(config.title || request.workload?.label || "Apply agent task changes"), head, base, body: string(config.body || "") })
+  if (!isExactPull(pull, head) || !/^https:\/\/github\.com\//.test(string(pull.html_url))) throw new Error("GitHub publication response did not match the requested repository and branches.")
+  return { schema: "wp-codebox/runner-workspace-publication-result/v1", success: true, status: "published", backend: "github-rest", branch: { base, base_sha: baseSha, head, name: head }, commit: { sha: string(commit.sha), parent_sha: parent }, pull_request: { number: pull.number, url: pull.html_url, reused: Boolean(pull && existing && parent !== baseSha), opened: !(existing && parent !== baseSha) } }
 }

--- a/docs/agent-task-reusable-workflow.md
+++ b/docs/agent-task-reusable-workflow.md
@@ -131,6 +131,9 @@ When `success_requires_pr` is true, success requires the canonical
 `status: published`, and a GitHub pull-request URL for `target_repo`.
 WP Codebox then resolves that pull request through the GitHub API with the
 runner token, so a fabricated publication result cannot satisfy the gate.
+Publication results record the effective head branch and resolved base SHA. An
+existing branch is extended only for an exact open pull request that descends
+from that base; otherwise publication starts a base-SHA-suffixed fresh branch.
 
 ## Outputs
 

--- a/packages/runtime-core/src/runner-workspace-publication.ts
+++ b/packages/runtime-core/src/runner-workspace-publication.ts
@@ -86,12 +86,14 @@ export type RunnerWorkspacePublicationResult = {
   }
   branch?: {
     base?: string
+    base_sha?: string
     head?: string
     name?: string
     remote?: string
   }
   commit?: {
     sha?: string
+    parent_sha?: string
     message?: string
   }
   pull_request?: {

--- a/tests/runner-workspace-publisher.test.mjs
+++ b/tests/runner-workspace-publisher.test.mjs
@@ -5,7 +5,7 @@ const request = { target_repo: "owner/repo", workload: { id: "run-1", label: "Up
 const publicationFiles = [{ path: "README.md", mode: "100644", content: Buffer.from("changed\n").toString("base64"), deleted: false }]
 
 function response(status, body) { return { ok: status >= 200 && status < 300, status, json: async () => body } }
-function fetchMock(existing = false, base = "main", defaultBranch) {
+function fetchMock(existing = false, base = "main", defaultBranch, pull = existing, comparison = "ahead", pullBase = base, freshExisting = false) {
   const calls = []
   return { calls, fetch: async (url, init) => {
     calls.push([url, init.method, init.body ? JSON.parse(init.body) : undefined])
@@ -14,14 +14,16 @@ function fetchMock(existing = false, base = "main", defaultBranch) {
     if (path === "") return response(200, { default_branch: defaultBranch })
     if (path === `/git/ref/heads/${base}`) return response(200, { object: { sha: "base" } })
     if (path === "/git/commits/base" || path === "/git/commits/old") return response(200, { tree: { sha: path.endsWith("old") ? "prior-tree" : "tree" } })
+    if (path.includes("/git/ref/heads/wp-codebox/agent-task/run-1-base")) return freshExisting ? response(200, { object: { sha: "collision" } }) : response(404, {})
     if (path.includes("/git/ref/heads/wp-codebox/agent-task/run-1")) return existing ? response(200, { object: { sha: "old" } }) : response(404, {})
+    if (path === "/compare/base...old") return response(200, { status: comparison, merge_base_commit: { sha: "base" } })
     if (path === "/git/blobs") return response(201, { sha: "blob" })
     if (path === "/git/trees") return response(201, { sha: "next-tree" })
     if (path === "/git/commits") return response(201, { sha: "commit" })
     if (path === "/git/refs") return response(201, {})
     if (path.includes("/git/refs/heads/")) return response(200, {})
-    if (path === "/pulls" && parsed.search) return response(200, existing ? [{ number: 4, html_url: "https://github.com/owner/repo/pull/4", base: { repo: { full_name: "owner/repo" }, ref: base }, head: { ref: "wp-codebox/agent-task/run-1" } }] : [])
-    if (path === "/pulls") return response(201, { number: 5, html_url: "https://github.com/owner/repo/pull/5", base: { repo: { full_name: "owner/repo" }, ref: base }, head: { ref: "wp-codebox/agent-task/run-1" } })
+    if (path === "/pulls" && parsed.search) return response(200, pull ? [{ number: 4, html_url: "https://github.com/owner/repo/pull/4", base: { repo: { full_name: "owner/repo" }, ref: pullBase }, head: { repo: { full_name: "owner/repo" }, ref: "wp-codebox/agent-task/run-1" } }] : [])
+    if (path === "/pulls") return response(201, { number: 5, html_url: "https://github.com/owner/repo/pull/5", base: { repo: { full_name: "owner/repo" }, ref: base }, head: { repo: { full_name: "owner/repo" }, ref: init.body ? JSON.parse(init.body).head : "wp-codebox/agent-task/run-1" } })
     throw new Error(`unexpected ${path}`)
   } }
 }
@@ -58,6 +60,7 @@ for (const defaultBranch of [undefined, "invalid branch"]) {
   assert(mock.calls.some(([, method]) => method === "POST"))
   const commitRequest = mock.calls.find(([url, method]) => new URL(url).pathname.endsWith("/git/commits") && method === "POST")
   assert.deepEqual(commitRequest?.[2]?.parents, ["base"], "new branch commits must use the base branch head as their parent")
+  assert.deepEqual(result.branch, { base: "main", base_sha: "base", head: "wp-codebox/agent-task/run-1", name: "wp-codebox/agent-task/run-1" }, "first publication reports its effective branch and resolved base SHA")
 }
 {
   const mock = fetchMock(true)
@@ -69,6 +72,30 @@ for (const defaultBranch of [undefined, "invalid branch"]) {
   assert.deepEqual(treeRequest?.[2]?.tree, [{ path: "README.md", mode: "100644", type: "blob", sha: "blob" }], "the prior branch tree remains the base while only approved changed files are replaced")
   const commitRequest = mock.calls.find(([url, method]) => new URL(url).pathname.endsWith("/git/commits") && method === "POST")
   assert.deepEqual(commitRequest?.[2]?.parents, ["old"], "existing branch commits must use the existing branch head as their parent")
+}
+{
+  const mock = fetchMock(true, "main", undefined, false)
+  const result = await publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: mock.fetch })
+  assert.equal(result.branch.head, "wp-codebox/agent-task/run-1-base", "a stale post-squash branch must get a fresh base-specific publication branch")
+  const treeRequest = mock.calls.find(([url, method]) => new URL(url).pathname.endsWith("/git/trees") && method === "POST")
+  assert.equal(treeRequest?.[2]?.base_tree, "tree", "a fresh branch must use the current base tree, not stale branch content")
+  const commitRequest = mock.calls.find(([url, method]) => new URL(url).pathname.endsWith("/git/commits") && method === "POST")
+  assert.deepEqual(commitRequest?.[2]?.parents, ["base"], "a stale post-squash branch must not become the commit parent")
+}
+{
+  const mock = fetchMock(true, "main", undefined, true, "ahead", "release")
+  const result = await publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: mock.fetch })
+  assert.equal(result.branch.head, "wp-codebox/agent-task/run-1-base", "a PR for a different base must not be reused")
+}
+{
+  const mock = fetchMock(true, "main", undefined, true, "diverged")
+  await assert.rejects(() => publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: mock.fetch }), /does not descend from current base/)
+  assert(!mock.calls.some(([, method]) => method === "POST" || method === "PATCH"), "an unsafe open PR branch must fail before publication writes")
+}
+{
+  const mock = fetchMock(true, "main", undefined, false, "ahead", "main", true)
+  await assert.rejects(() => publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: mock.fetch }), /Fresh publication branch .* already exists/)
+  assert(!mock.calls.some(([, method]) => method === "POST" || method === "PATCH"), "a fresh branch collision must fail without replacing an existing ref")
 }
 await assert.rejects(() => publishRunnerWorkspace({ request: { ...request, runner_workspace: { ...request.runner_workspace, repo: "other/repo" } }, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: fetchMock().fetch }), /not authorized/)
 await assert.rejects(() => publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "", fetchImpl: fetchMock().fetch }), /No GitHub token/)

--- a/tests/runner-workspace-publisher.test.mjs
+++ b/tests/runner-workspace-publisher.test.mjs
@@ -5,7 +5,7 @@ const request = { target_repo: "owner/repo", workload: { id: "run-1", label: "Up
 const publicationFiles = [{ path: "README.md", mode: "100644", content: Buffer.from("changed\n").toString("base64"), deleted: false }]
 
 function response(status, body) { return { ok: status >= 200 && status < 300, status, json: async () => body } }
-function fetchMock(existing = false, base = "main", defaultBranch, pull = existing, comparison = "ahead", pullBase = base, freshExisting = false) {
+function fetchMock(existing = false, base = "main", defaultBranch, pull = existing, comparison = "ahead", pullBase = base, freshExisting = false, freshPull = false) {
   const calls = []
   return { calls, fetch: async (url, init) => {
     calls.push([url, init.method, init.body ? JSON.parse(init.body) : undefined])
@@ -13,16 +13,21 @@ function fetchMock(existing = false, base = "main", defaultBranch, pull = existi
     const path = parsed.pathname.replace("/repos/owner/repo", "")
     if (path === "") return response(200, { default_branch: defaultBranch })
     if (path === `/git/ref/heads/${base}`) return response(200, { object: { sha: "base" } })
-    if (path === "/git/commits/base" || path === "/git/commits/old") return response(200, { tree: { sha: path.endsWith("old") ? "prior-tree" : "tree" } })
+    if (path === "/git/commits/base" || path === "/git/commits/old" || path === "/git/commits/collision") return response(200, { tree: { sha: path.endsWith("base") ? "tree" : "prior-tree" } })
     if (path.includes("/git/ref/heads/wp-codebox/agent-task/run-1-base")) return freshExisting ? response(200, { object: { sha: "collision" } }) : response(404, {})
     if (path.includes("/git/ref/heads/wp-codebox/agent-task/run-1")) return existing ? response(200, { object: { sha: "old" } }) : response(404, {})
     if (path === "/compare/base...old") return response(200, { status: comparison, merge_base_commit: { sha: "base" } })
+    if (path === "/compare/base...collision") return response(200, { status: comparison, merge_base_commit: { sha: "base" } })
     if (path === "/git/blobs") return response(201, { sha: "blob" })
     if (path === "/git/trees") return response(201, { sha: "next-tree" })
     if (path === "/git/commits") return response(201, { sha: "commit" })
     if (path === "/git/refs") return response(201, {})
     if (path.includes("/git/refs/heads/")) return response(200, {})
-    if (path === "/pulls" && parsed.search) return response(200, pull ? [{ number: 4, html_url: "https://github.com/owner/repo/pull/4", base: { repo: { full_name: "owner/repo" }, ref: pullBase }, head: { repo: { full_name: "owner/repo" }, ref: "wp-codebox/agent-task/run-1" } }] : [])
+    if (path === "/pulls" && parsed.search) {
+      const head = parsed.searchParams.get("head")?.split(":").slice(1).join(":")
+      const hasPull = head?.endsWith("-base") ? freshPull : pull
+      return response(200, hasPull ? [{ number: 4, html_url: "https://github.com/owner/repo/pull/4", base: { repo: { full_name: "owner/repo" }, ref: pullBase }, head: { repo: { full_name: "owner/repo" }, ref: head } }] : [])
+    }
     if (path === "/pulls") return response(201, { number: 5, html_url: "https://github.com/owner/repo/pull/5", base: { repo: { full_name: "owner/repo" }, ref: base }, head: { repo: { full_name: "owner/repo" }, ref: init.body ? JSON.parse(init.body).head : "wp-codebox/agent-task/run-1" } })
     throw new Error(`unexpected ${path}`)
   } }
@@ -96,6 +101,15 @@ for (const defaultBranch of [undefined, "invalid branch"]) {
   const mock = fetchMock(true, "main", undefined, false, "ahead", "main", true)
   await assert.rejects(() => publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: mock.fetch }), /Fresh publication branch .* already exists/)
   assert(!mock.calls.some(([, method]) => method === "POST" || method === "PATCH"), "a fresh branch collision must fail without replacing an existing ref")
+}
+{
+  const mock = fetchMock(true, "main", undefined, false, "ahead", "main", true, true)
+  const result = await publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: mock.fetch })
+  assert.equal(result.branch.head, "wp-codebox/agent-task/run-1-base", "an exact open PR on the fresh branch must remain the publication target")
+  assert.equal(result.pull_request.reused, true, "an exact open fresh-branch PR must be reported as reused")
+  assert.equal(result.pull_request.opened, false, "an exact open fresh-branch PR must not be reported as newly opened")
+  const commitRequest = mock.calls.find(([url, method]) => new URL(url).pathname.endsWith("/git/commits") && method === "POST")
+  assert.deepEqual(commitRequest?.[2]?.parents, ["collision"], "continued fresh-branch publication must append to its existing head")
 }
 await assert.rejects(() => publishRunnerWorkspace({ request: { ...request, runner_workspace: { ...request.runner_workspace, repo: "other/repo" } }, changedFiles: ["README.md"], publicationFiles, token: "secret", fetchImpl: fetchMock().fetch }), /not authorized/)
 await assert.rejects(() => publishRunnerWorkspace({ request, changedFiles: ["README.md"], publicationFiles, token: "", fetchImpl: fetchMock().fetch }), /No GitHub token/)


### PR DESCRIPTION
## Summary
- resolve and report the exact base SHA before publishing runner workspace changes
- reuse a publication branch only when it has an exact open head/base PR and descends from the current base
- recover stale post-squash branches onto a deterministic base-SHA-suffixed branch, while safely reusing that recovered PR on later runs
- fail closed on unsafe branch collisions or divergent open PR branches

Closes #1894.

## How to test
1. Run `npm install`.
2. Run `npm run test:runner-workspace-publisher`.
3. Confirm the stale post-squash fixture creates a fresh branch from the base tree and parent SHA.
4. Confirm a later publication reuses the exact open fresh-branch PR and appends to its current head.
5. Run `npm run test:agent-task-workflow-interface`.
6. Run `npm run build`.

## Backwards compatibility
Existing exact open publication PRs continue to be extended. Existing branches without a matching safe PR are no longer reused as commit parents; this intentional behavior change prevents historical commits from leaking into later publications. The result adds `branch.base_sha` and `commit.parent_sha` without removing existing fields.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Reviewed and completed the implementation, added deterministic coverage, and prepared verification evidence.