### PR TITLE
Wait for readonly mount staging before cleanup

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -78,7 +78,7 @@ export async function stageReadonlyPlaygroundMounts(mounts: MountSpec[]): Promis
 
   const root = await mkdtemp(join(tmpdir(), "wp-codebox-readonly-mounts-"))
   try {
-    const stagedMounts = await Promise.all(mounts.map(async (mount, index) => {
+    const stagedMountResults = await Promise.allSettled(mounts.map(async (mount, index) => {
       if (mount.mode !== "readonly") {
         return mount
       }
@@ -86,6 +86,16 @@ export async function stageReadonlyPlaygroundMounts(mounts: MountSpec[]): Promis
       await cp(mount.source, source, { recursive: mount.type !== "file", dereference: true })
       return { ...mount, source }
     }))
+    const failedMount = stagedMountResults.find((result) => result.status === "rejected")
+    if (failedMount?.status === "rejected") {
+      throw failedMount.reason
+    }
+    const stagedMounts = stagedMountResults.map((result) => {
+      if (result.status !== "fulfilled") {
+        throw result.reason
+      }
+      return result.value
+    })
     return {
       mounts: stagedMounts,
       async [Symbol.asyncDispose]() {

--- a/tests/playground-readonly-mounts.test.ts
+++ b/tests/playground-readonly-mounts.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import { stageReadonlyPlaygroundMounts } from "../packages/runtime-playground/src/mount-materialization.js"
 import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-readonly-mounts-"))
@@ -41,6 +42,19 @@ const cliModule: PlaygroundCliModule = {
 }
 
 try {
+  const danglingSource = join(root, "dangling")
+  const largeSource = join(root, "large")
+  await mkdir(danglingSource)
+  await mkdir(largeSource)
+  await symlink("missing.php", join(danglingSource, "build.sh"))
+  await Promise.all(Array.from({ length: 500 }, (_, index) => writeFile(join(largeSource, `File${index}.php`), `<?php return ${index};\n`)))
+  const stagingDirectoriesBefore = await readonlyStagingDirectories()
+  await assert.rejects(stageReadonlyPlaygroundMounts([
+    { source: danglingSource, target: "/dangling", mode: "readonly" },
+    { source: largeSource, target: "/large", mode: "readonly" },
+  ]), /ENOENT/, "the source failure must not be masked by cleanup racing another mount copy")
+  assert.deepEqual(await readonlyStagingDirectories(), stagingDirectoriesBefore, "failed concurrent staging must remove its temporary root")
+
   const beforeReadonlyHash = sha256(await readFile(readonlySource))
   const server = await startPlaygroundCliServer(spec, [
     { type: "file", source: readonlySource, target: "/readonly", mode: "readonly" },
@@ -59,6 +73,10 @@ try {
 
 function sha256(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex")
+}
+
+async function readonlyStagingDirectories(): Promise<string[]> {
+  return (await readdir(tmpdir())).filter((entry) => entry.startsWith("wp-codebox-readonly-mounts-")).sort()
 }
 
 console.log("playground readonly mount isolation ok")


### PR DESCRIPTION
## Summary

- wait for all concurrent readonly mount copies to settle before evaluating staging failures
- preserve the original source error instead of masking it with a cleanup `ENOTEMPTY`
- verify failed concurrent staging removes its temporary root

## Why

`Promise.all()` returned as soon as one readonly source failed, while sibling `fs.cp()` operations continued writing into the shared staging root. The error path immediately removed that root and raced those copies, producing nondeterministic `ENOTEMPTY` failures instead of the actionable source error.

Closes #1896.

## Verification

- `npm run build`
- `npx tsx tests/playground-readonly-mounts.test.ts`
- `npx tsx tests/playground-readonly-mounts-integration.test.ts`
- reproduced through a Homeboy WordPress PHPUnit recipe with a large Composer vendor mount; the `ENOTEMPTY` failure is cleared and the original dangling-source `ENOENT` is now reported