### PR TITLE
Provision multisite PHPUnit runtimes

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipePHPWasmExtensionManifest, WorkspaceRecipeRuntimeBackendPackage, WorkspaceRecipeRuntimeService, WorkspaceRecipeStep } from "./runtime-contracts.js"
+import type { RuntimePreviewSpec, WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipePHPWasmExtensionManifest, WorkspaceRecipeRuntimeBackendPackage, WorkspaceRecipeRuntimeService, WorkspaceRecipeStep } from "./runtime-contracts.js"
 import { commandArg, commandJsonArg, commandStringListArg } from "./command-codecs.js"
 export { buildRuntimePackageRunRecipe, CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA, RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA, RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA, runtimePackageExecutionInput, type RuntimePackageArtifactDeclaration, type RuntimePackageExecutionInput, type RuntimePackageOutputProjection, type RuntimePackageRunRecipeOptions } from "./runtime-package-execution.js"
 export { RUNTIME_PACKAGE_DIAGNOSTIC_SCHEMA, RUNTIME_PACKAGE_RESULT_SCHEMA, RUNTIME_PACKAGE_TASK_SCHEMA, normalizeRuntimePackageResult, normalizeRuntimePackageTask, validateRuntimePackageTask, type RuntimePackageDiagnostic, type RuntimePackageResult, type RuntimePackageTask } from "./runtime-package-contracts.js"
@@ -17,6 +17,7 @@ export interface WordPressPhpunitRecipeOptions {
   blueprint?: unknown
   extensions?: WorkspaceRecipePHPWasmExtensionManifest[]
   backendPackage?: WorkspaceRecipeRuntimeBackendPackage
+  preview?: RuntimePreviewSpec
   mounts?: WorkspaceRecipeMount[]
   services?: WorkspaceRecipeRuntimeService[]
   extra_plugins?: WorkspaceRecipeExtraPlugin[]
@@ -77,7 +78,8 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
     runtime: {
       wp: options.wordpressVersion ?? DEFAULT_WORDPRESS_VERSION,
       ...(options.phpVersion ? { phpVersion: options.phpVersion } : {}),
-      blueprint: options.blueprint ?? { steps: [] },
+      blueprint: blueprintWithMultisite(options.blueprint ?? { steps: [] }, options.multisite ?? false),
+      ...(options.preview || options.multisite ? { preview: multisitePreview(options.preview, options.multisite ?? false) } : {}),
       ...(options.extensions?.length ? { extensions: options.extensions } : {}),
       ...(options.backendPackage ? { backendPackage: options.backendPackage } : {}),
     },
@@ -223,6 +225,35 @@ function blueprintWithWpConfigDefines(blueprint: unknown, defines: JsonObject): 
   return {
     ...blueprint,
     steps: [...existingSteps, { step: "defineWpConfigConsts", consts: defines }],
+  }
+}
+
+function blueprintWithMultisite(blueprint: unknown, multisite: boolean): unknown {
+  if (!multisite) {
+    return blueprint
+  }
+
+  if (!isPlainObject(blueprint)) {
+    return { steps: [{ step: "enableMultisite" }] }
+  }
+
+  const existingSteps = Array.isArray(blueprint.steps) ? blueprint.steps : []
+  if (existingSteps.some((step) => isPlainObject(step) && step.step === "enableMultisite")) {
+    return blueprint
+  }
+  return {
+    ...blueprint,
+    steps: [{ step: "enableMultisite" }, ...existingSteps],
+  }
+}
+
+function multisitePreview(preview: RuntimePreviewSpec | undefined, multisite: boolean): RuntimePreviewSpec {
+  if (!multisite || preview?.siteUrl) {
+    return preview ?? {}
+  }
+  return {
+    ...preview,
+    siteUrl: "http://localhost",
   }
 }
 

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -896,7 +896,7 @@ function pg_ensure_phpunit_harness_loaded(): void {
 }
 
 function pg_run_install_stage(array $cfg) {
-    global $argv, $pg_stage_output_buffering;
+    global $argv, $pg_stage_output_buffering, $wp_rewrite;
     pg_stage_begin('install');
     try {
         $tests_dir = $cfg['tests_dir'];

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -410,6 +410,7 @@ const managedModeCode = phpunitRunCode({
 
 assert.ok(managedModeCode.includes("configured PHPUnit harness autoload file is not readable"))
 assert.ok(managedModeCode.includes("'cacheResult' => false"))
+assert.ok(managedModeCode.includes("global $argv, $pg_stage_output_buffering, $wp_rewrite;"), "managed WordPress installation must expose the rewrite global required by multisite setup")
 assert.ok(managedModeCode.includes('$dep_mounts = "/wordpress/wp-content/plugins/demo-plugin\\n/wordpress/wp-content/plugins/dependency";'), "dependency mounts must be newline-delimited for the generated PHP runner")
 const installStageIndex = managedModeCode.indexOf("pg_run_install_stage(array(")
 const dependencyLoadStageIndex = managedModeCode.indexOf("$loaded_dep_files = pg_run_load_deps_stage", installStageIndex)
@@ -441,6 +442,18 @@ assert.deepEqual(dependencyRecipe.inputs.extra_plugins, [{
   activate: false,
 }])
 assert.ok(dependencyRecipe.workflow.steps[0].args.includes("dependency-mounts=/wordpress/wp-content/plugins/dependency"))
+
+const multisiteRecipe = buildWordPressPhpunitRecipe({
+  pluginSlug: "network-plugin",
+  multisite: true,
+  blueprint: { steps: [{ step: "setSiteOptions", options: { blogname: "Network tests" } }] },
+})
+assert.deepEqual((multisiteRecipe.runtime.blueprint as { steps: unknown[] }).steps, [
+  { step: "enableMultisite" },
+  { step: "setSiteOptions", options: { blogname: "Network tests" } },
+], "multisite PHPUnit recipes must boot Playground as multisite before running tests")
+assert.equal(multisiteRecipe.runtime.preview?.siteUrl, "http://localhost", "multisite PHPUnit recipes need a canonical site URL without the dynamic Playground port")
+assert.ok(multisiteRecipe.workflow.steps[0].args.includes("multisite=1"))
 
 const phpunitCacheAllocator = extractPhpFunction(managedModeCode, "wp_codebox_phpunit_args_private_cache_result_file")
 const phpunitArgsFunction = extractPhpFunction(managedModeCode, "wp_codebox_phpunit_args")

--- a/tests/playground-phpunit-readonly-cache.integration.test.ts
+++ b/tests/playground-phpunit-readonly-cache.integration.test.ts
@@ -25,6 +25,7 @@ try {
 
   const recipe = buildWordPressPhpunitRecipe({
     pluginSlug: "readonly-phpunit-fixture",
+    multisite: true,
     extra_plugins: [{
       source: plugin,
       slug: "readonly-phpunit-fixture",
@@ -62,7 +63,7 @@ async function writeFixture(): Promise<void> {
   await mkdir(dependency, { recursive: true })
   await writeFile(join(plugin, "readonly-phpunit-fixture.php"), "<?php\n/**\n * Plugin Name: Readonly PHPUnit Fixture\n */\n")
   await writeFile(join(plugin, "source-sentinel.bin"), sentinel)
-  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_sentinel_is_available(): void { $this->assertGreaterThan(0, filesize(dirname(__DIR__) . \'/source-sentinel.bin\')); } public function test_dependency_activation_runs_after_install(): void { $this->assertGreaterThanOrEqual(1, get_option(\'wp_codebox_dependency_activation_users\')); } public function test_dependency_plugins_loaded_runs_once(): void { $this->assertSame(1, (int) get_option(\'wp_codebox_dependency_plugins_loaded_count\')); } }\n")
+  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_multisite_runtime_is_active(): void { $this->assertTrue(is_multisite()); } public function test_sentinel_is_available(): void { $this->assertGreaterThan(0, filesize(dirname(__DIR__) . \'/source-sentinel.bin\')); } public function test_dependency_activation_runs_after_install(): void { $this->assertGreaterThanOrEqual(1, get_option(\'wp_codebox_dependency_activation_users\')); } public function test_dependency_plugins_loaded_runs_once(): void { $this->assertSame(1, (int) get_option(\'wp_codebox_dependency_plugins_loaded_count\')); } }\n")
   await writeFile(join(dependency, "activation-dependency.php"), "<?php\n/**\n * Plugin Name: Activation Dependency\n */\nadd_action('plugins_loaded', static function (): void { update_option('wp_codebox_dependency_plugins_loaded_count', (int) get_option('wp_codebox_dependency_plugins_loaded_count', 0) + 1); });\nregister_activation_hook(__FILE__, static function (): void { update_option('wp_codebox_dependency_activation_users', count(get_users(array('number' => 1)))); });\n")
 }
 


### PR DESCRIPTION
## Summary

- provision `multisite: true` PHPUnit recipes with Playground's native `enableMultisite` blueprint step
- provide a no-port `http://localhost` site URL required by Playground multisite, while preserving explicit preview overrides
- expose WordPress's `$wp_rewrite` global to the function-scoped test installer include
- run the existing real PHPUnit integration in multisite mode and assert `is_multisite()`

## Why

Passing `multisite=1` only to `wordpress.phpunit` was insufficient because Playground had already booted WordPress as single-site. Native multisite provisioning also requires a canonical site URL without the dynamic CLI port. Once provisioned, WordPress's test installer needs `$wp_rewrite` imported into the function scope where WP Codebox includes it.

Closes #1898.

## Verification

- `npm run build`
- `npx tsx tests/phpunit-project-autoload.test.ts`
- `npx tsx tests/playground-phpunit-readonly-cache.integration.test.ts`
- Extra Chill Users network-only suite boots and runs: 257 tests discovered, 149 passed, 7 skipped; remaining failures are missing Extra Chill dependency fixtures rather than multisite/runtime failures