### PR TITLE
Wait for complete SVG images before visual capture

### DIFF
--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -1848,11 +1848,10 @@ async function settleVisualComparePageForCapture(page: Page): Promise<void> {
   })
 }
 
-async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Promise<void> {
+export async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Promise<void> {
   const readinessTimeoutMs = Math.max(1_000, Math.min(10_000, timeoutMs))
   await page.waitForLoadState("load", { timeout: readinessTimeoutMs }).catch(() => undefined)
   await page.evaluate(async (timeout) => {
-    const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
     const until = Date.now() + timeout
 
     const stylesheetLinks = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]'))
@@ -1864,17 +1863,20 @@ async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Pr
             link.addEventListener("load", () => resolve(), { once: true })
             link.addEventListener("error", () => resolve(), { once: true })
           }),
-          sleep(100),
+          new Promise<void>((resolve) => setTimeout(resolve, 100)),
         ])
       }
     }))
 
     await (document as Document & { fonts?: { ready?: Promise<unknown> } }).fonts?.ready?.catch(() => undefined)
 
-    const images = Array.from(document.images).filter((image) => !image.complete)
+    const images = Array.from(document.images)
     await Promise.all(images.map(async (image) => {
       if (typeof image.decode === "function") {
-        await image.decode().catch(() => undefined)
+        await Promise.race([
+          image.decode().catch(() => undefined),
+          new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, until - Date.now()))),
+        ])
         return
       }
       if (image.complete) {
@@ -1885,7 +1887,7 @@ async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Pr
           image.addEventListener("load", () => resolve(), { once: true })
           image.addEventListener("error", () => resolve(), { once: true })
         }),
-        sleep(Math.max(0, until - Date.now())),
+        new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, until - Date.now()))),
       ])
     }))
 

--- a/tests/browser-visual-compare-capture-reliability.test.ts
+++ b/tests/browser-visual-compare-capture-reliability.test.ts
@@ -5,7 +5,9 @@ import { join } from "node:path"
 
 import { PNG } from "pngjs"
 
-import { comparePngFiles, visualCompareCaptureReadiness, visualCompareCompactCaptureDiagnostics, visualCompareErrorDetail, visualCompareNavigationPolicy, visualCompareOfflineRequestAllowed, visualCompareRegionElementOverlaps, visualCompareSelectorDeltas, type VisualCompareCaptureDiagnostics } from "../packages/runtime-playground/src/browser-visual-compare.js"
+import { chromium } from "playwright"
+
+import { comparePngFiles, visualCompareCaptureReadiness, visualCompareCompactCaptureDiagnostics, visualCompareErrorDetail, visualCompareNavigationPolicy, visualCompareOfflineRequestAllowed, visualCompareRegionElementOverlaps, visualCompareSelectorDeltas, waitForVisualComparePaintReady, type VisualCompareCaptureDiagnostics } from "../packages/runtime-playground/src/browser-visual-compare.js"
 
 // Build an opaque solid-color PNG. `fill` is [r,g,b].
 function solidPng(width: number, height: number, fill: [number, number, number]): PNG {
@@ -79,6 +81,34 @@ function paintRect(png: PNG, x0: number, y0: number, x1: number, y1: number, fil
   assert.equal(visualCompareOfflineRequestAllowed("https://fonts.example.invalid/font.woff2", "http://127.0.0.1:42573"), false)
 }
 
+// 4. A complete SVG image still needs decode readiness: externally served SVGs can be
+// complete before their embedded font glyphs have been painted.
+{
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    await page.setContent('<img id="svg" src="data:image/svg+xml,%3Csvg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"%3E%3C/svg%3E">')
+    await page.waitForFunction(() => document.images[0]?.complete === true)
+    await page.evaluate(`
+      const image = document.querySelector("#svg");
+      const decode = image.decode.bind(image);
+      let calls = 0;
+      Object.defineProperty(image, "decode", {
+        configurable: true,
+        value() {
+          image.dataset.decodeCalls = String(++calls);
+          return decode();
+        },
+      });
+      image.dataset.decodeCalls = String(calls);
+    `)
+    await waitForVisualComparePaintReady(page, 1_000)
+    assert.equal(await page.locator("#svg").evaluate((image) => image.dataset.decodeCalls), "1")
+  } finally {
+    await browser.close()
+  }
+}
+
 // Count pixels in a diff PNG whose RGB is nonzero — the exact predicate the region
 // detector uses (`visualCompareDiffPixel`). pixelmatch renders even unchanged pixels as
 // a dimmed grayscale of the original, so for a real (or solid) page this is typically the
@@ -95,7 +125,7 @@ function countDiffPixels(png: PNG): number {
   return count
 }
 
-// 4. Mismatch-region attribution ranks DOM elements by how much of the hotspot they
+// 5. Mismatch-region attribution ranks DOM elements by how much of the hotspot they
 //    cover and carries the element path/styles needed for actionable visual repairs.
 {
   const overlaps = visualCompareRegionElementOverlaps({ x: 10, y: 20, width: 100, height: 50, pixels: 5000 }, [
@@ -127,8 +157,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal(overlaps[1]?.styles["background-color"], "rgb(200, 0, 0)")
 }
 
-// 5. The bounded flood-fill region detection runs the real comparePngFiles aggregation
-// 5. Requested single-match selectors produce paired deltas even when source and
+// 6. Requested single-match selectors produce paired deltas even when source and
 //    candidate DOM paths differ after a structural move.
 {
   const selectorDeltas = visualCompareSelectorDeltas(
@@ -151,7 +180,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal(selectorDeltas[0]?.styles.find((style) => style.property === "color")?.category, "paint")
 }
 
-// 6. Capture diagnostics are normalized into compact readiness/noise signals without
+// 7. Capture diagnostics are normalized into compact readiness/noise signals without
 //    changing diff policy. Asset problems and dynamic content lower confidence; clean
 //    settled pages stay high-confidence.
 {
@@ -208,7 +237,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal("title" in (compact.source?.environment ?? {}), false)
 }
 
-// 7. The bounded flood-fill region detection runs the real comparePngFiles aggregation
+// 8. The bounded flood-fill region detection runs the real comparePngFiles aggregation
 //    over a large, tall, high-mismatch canvas — the exact shape that previously OOM'd
 //    old-space by pushing ~4× the diff-pixel count as [x,y] tuple arrays and marking
 //    visited only at pop time. The rewrite (flat numeric index stack, mark-at-push) must


### PR DESCRIPTION
## Summary
Decode every visual-compare image, including already-complete external SVGs, before screenshot capture.

## What changed
- Removed the complete-image filter and bounded decode() for all document images; added browser coverage for an already-complete SVG image.

## How to test
1. Run `npm install`; expect Dependencies install successfully..
2. Run `npm run build`; expect TypeScript packages build successfully..
3. Run `npm exec -- tsx tests/browser-visual-compare-capture-reliability.test.ts`; expect The capture reliability suite passes, including already-complete SVG decode coverage..

## Compatibility
No command or output schema changes. Existing image readiness remains bounded and decode failures remain non-fatal.

## Evidence
- Base unchanged since verification: main remains at 7b1e7740a59d34ed810555feed8f82850e1bcf6c.
- CI expected: Repository CI
- Durable run execution: Failed
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1902
- Verified finalization base: main at 7b1e7740a59d34ed810555feed8f82850e1bcf6c
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, tests, and verification with Chris Huber.

## Source relationships
- Closes #1902
