### PR TITLE
Settle external SVG images before visual capture

### DIFF
--- a/packages/runtime-playground/src/browser-dom-snapshot.ts
+++ b/packages/runtime-playground/src/browser-dom-snapshot.ts
@@ -21,12 +21,27 @@ export interface BrowserDomSelectorSnapshot {
   error?: string
 }
 
+export interface BrowserDomSvgImagePayloadSnapshot {
+  imagePath: string
+  sha256: string
+  byteCount: number
+  textNodeCount: number
+  fontFamilyAttributes: string[]
+  fontSizeAttributes: string[]
+  fontStyleAttributes: string[]
+  fontWeightAttributes: string[]
+  letterSpacingAttributes: string[]
+  fontFaceRuleCount: number
+  styleText: { sha256: string; byteCount: number }
+}
+
 export interface BrowserDomSnapshot {
   url: string
   title: string
   elementCount: number
   capturedElements: BrowserDomElementSnapshot[]
   selectors?: BrowserDomSelectorSnapshot[]
+  svgImagePayloads?: BrowserDomSvgImagePayloadSnapshot[]
   truncated: boolean
 }
 
@@ -44,7 +59,7 @@ export interface BrowserDomSnapshotArtifact {
 }
 
 export async function captureBrowserDomSnapshot(page: Page, maxElements: number, selectors: string[] = []): Promise<BrowserDomSnapshot> {
-  return page.evaluate(({ maxElements: maxElementsInput, styleProperties, attributeNames, selectors: selectorInputs }) => {
+  return page.evaluate(async ({ maxElements: maxElementsInput, styleProperties, attributeNames, selectors: selectorInputs }) => {
     const maxElements = Math.max(1, Number(maxElementsInput) || 1)
     const elements = Array.from(document.body?.querySelectorAll("*") ?? [])
     const visibleElements = elements
@@ -52,6 +67,7 @@ export async function captureBrowserDomSnapshot(page: Page, maxElements: number,
       .filter((element): element is BrowserDomElementSnapshot => Boolean(element))
     const capturedByPath = new Map(visibleElements.slice(0, maxElements).map((element) => [element.path, element]))
     const selectorSnapshots = selectorInputs.map((selector) => selectorSnapshot(selector, capturedByPath, styleProperties, attributeNames))
+    const svgImagePayloads = await Promise.all(Array.from(document.images).map((image) => svgImagePayloadSnapshot(image)))
 
     return {
       url: window.location.href,
@@ -59,6 +75,7 @@ export async function captureBrowserDomSnapshot(page: Page, maxElements: number,
       elementCount: visibleElements.length,
       capturedElements: [...capturedByPath.values()],
       ...(selectorSnapshots.length > 0 ? { selectors: selectorSnapshots } : {}),
+      ...(svgImagePayloads.some((payload): payload is BrowserDomSvgImagePayloadSnapshot => Boolean(payload)) ? { svgImagePayloads: svgImagePayloads.filter((payload): payload is BrowserDomSvgImagePayloadSnapshot => Boolean(payload)) } : {}),
       truncated: visibleElements.length > maxElements,
     }
 
@@ -87,7 +104,7 @@ export async function captureBrowserDomSnapshot(page: Page, maxElements: number,
         text: compactText(element.textContent || "", 180),
         attributes: Object.fromEntries(attributes.flatMap((name) => {
           const value = element.getAttribute(name)
-          return value === null ? [] : [[name, compactText(value, 180)]]
+          return value === null ? [] : [[name, compactText(redactPayloadUrl(value), 180)]]
         })),
         boundingBox: {
           x: roundNumber(rect.x),
@@ -130,6 +147,102 @@ export async function captureBrowserDomSnapshot(page: Page, maxElements: number,
     function compactText(value: string, maxLength: number): string {
       const compact = value.replace(/\s+/g, " ").trim()
       return compact.length > maxLength ? `${compact.slice(0, maxLength - 1)}…` : compact
+    }
+
+    function redactPayloadUrl(value: string): string {
+      return /^\s*(?:blob:|data:)/i.test(value) ? "[payload URL redacted]" : value
+    }
+
+    async function svgImagePayloadSnapshot(image: HTMLImageElement): Promise<BrowserDomSvgImagePayloadSnapshot | undefined> {
+      // Match the readiness normalizer: responsive sources are left untouched, while
+      // same-document blobs and same-origin standalone SVGs are safe to inspect.
+      if (!crypto.subtle || image.srcset || image.parentElement?.tagName === "PICTURE") {
+        return undefined
+      }
+      const source = image.currentSrc || image.src
+      let parsed: URL
+      try {
+        parsed = new URL(source, document.baseURI)
+      } catch {
+        return undefined
+      }
+      if (parsed.protocol !== "blob:" && (parsed.origin !== location.origin || !/\.svg$/i.test(parsed.pathname))) {
+        return undefined
+      }
+      const maxBytes = 2 * 1024 * 1024
+      try {
+        const response = await fetch(parsed.href)
+        const contentLength = Number(response.headers.get("content-length"))
+        if (!response.ok || (Number.isFinite(contentLength) && contentLength > maxBytes)) {
+          return undefined
+        }
+        const reader = response.body?.getReader()
+        if (!reader) {
+          return undefined
+        }
+        const chunks: Uint8Array[] = []
+        let byteCount = 0
+        while (true) {
+          const next = await reader.read()
+          if (next.done) {
+            break
+          }
+          byteCount += next.value.byteLength
+          if (byteCount > maxBytes) {
+            await reader.cancel()
+            return undefined
+          }
+          chunks.push(next.value)
+        }
+        const bytes = new Uint8Array(byteCount)
+        let offset = 0
+        for (const chunk of chunks) {
+          bytes.set(chunk, offset)
+          offset += chunk.byteLength
+        }
+        const sourceText = new TextDecoder().decode(bytes)
+        if (!/\bimage\/svg\+xml\b/i.test(response.headers.get("content-type") ?? "") && !/^\s*(?:<\?xml[^>]*>\s*)?<svg\b/i.test(sourceText)) {
+          return undefined
+        }
+        const svg = new DOMParser().parseFromString(sourceText, "image/svg+xml")
+        if (svg.querySelector("parsererror")) {
+          return undefined
+        }
+        const styleText = Array.from(svg.querySelectorAll("style")).map((style) => style.textContent ?? "").join("\n")
+        const styleBytes = new TextEncoder().encode(styleText)
+        function attributeValues(name: string): string[] {
+          return [...new Set(Array.from(svg.querySelectorAll("*")).flatMap((element) => {
+            const value = element.getAttribute(name)?.trim()
+            return value ? [value] : []
+          }))].sort()
+        }
+        async function digest(value: Uint8Array): Promise<string> {
+          const result = await crypto.subtle.digest("SHA-256", value as Uint8Array<ArrayBuffer>)
+          return Array.from(new Uint8Array(result)).map((byte) => byte.toString(16).padStart(2, "0")).join("")
+        }
+        const walker = svg.createTreeWalker(svg, NodeFilter.SHOW_TEXT)
+        let textNodeCount = 0
+        while (walker.nextNode()) {
+          textNodeCount += 1
+        }
+        const [sha256, styleSha256] = await Promise.all([digest(bytes), digest(styleBytes)])
+        return {
+          imagePath: elementPath(image),
+          sha256,
+          byteCount,
+          textNodeCount,
+          fontFamilyAttributes: attributeValues("font-family"),
+          fontSizeAttributes: attributeValues("font-size"),
+          fontStyleAttributes: attributeValues("font-style"),
+          fontWeightAttributes: attributeValues("font-weight"),
+          letterSpacingAttributes: attributeValues("letter-spacing"),
+          fontFaceRuleCount: (styleText.match(/@font-face\b/gi) ?? []).length,
+          styleText: { sha256: styleSha256, byteCount: styleBytes.byteLength },
+        }
+      } catch {
+        // Snapshot evidence is diagnostic only; inaccessible payloads must not block capture.
+        return undefined
+      }
     }
 
     function roundNumber(value: number): number {

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -1848,11 +1848,10 @@ async function settleVisualComparePageForCapture(page: Page): Promise<void> {
   })
 }
 
-async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Promise<void> {
+export async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Promise<void> {
   const readinessTimeoutMs = Math.max(1_000, Math.min(10_000, timeoutMs))
   await page.waitForLoadState("load", { timeout: readinessTimeoutMs }).catch(() => undefined)
   await page.evaluate(async (timeout) => {
-    const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
     const until = Date.now() + timeout
 
     const stylesheetLinks = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]'))
@@ -1864,17 +1863,20 @@ async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Pr
             link.addEventListener("load", () => resolve(), { once: true })
             link.addEventListener("error", () => resolve(), { once: true })
           }),
-          sleep(100),
+          new Promise<void>((resolve) => setTimeout(resolve, 100)),
         ])
       }
     }))
 
     await (document as Document & { fonts?: { ready?: Promise<unknown> } }).fonts?.ready?.catch(() => undefined)
 
-    const images = Array.from(document.images).filter((image) => !image.complete)
+    const images = Array.from(document.images)
     await Promise.all(images.map(async (image) => {
       if (typeof image.decode === "function") {
-        await image.decode().catch(() => undefined)
+        await Promise.race([
+          image.decode().catch(() => undefined),
+          new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, until - Date.now()))),
+        ])
         return
       }
       if (image.complete) {
@@ -1885,7 +1887,7 @@ async function waitForVisualComparePaintReady(page: Page, timeoutMs: number): Pr
           image.addEventListener("load", () => resolve(), { once: true })
           image.addEventListener("error", () => resolve(), { once: true })
         }),
-        sleep(Math.max(0, until - Date.now())),
+        new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, until - Date.now()))),
       ])
     }))
 

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -1853,6 +1853,11 @@ export async function waitForVisualComparePaintReady(page: Page, timeoutMs: numb
   await page.waitForLoadState("load", { timeout: readinessTimeoutMs }).catch(() => undefined)
   await page.evaluate(async (timeout) => {
     const until = Date.now() + timeout
+    const normalizedSvgBlobUrlsKey = "__wpCodeboxVisualCompareSvgBlobUrls"
+    const blobUrlTarget = window as unknown as Window & { [key: string]: string[] | undefined }
+    const normalizedSvgBlobUrls = blobUrlTarget[normalizedSvgBlobUrlsKey] ?? []
+    blobUrlTarget[normalizedSvgBlobUrlsKey] = normalizedSvgBlobUrls
+    const maxSvgBytes = 2 * 1024 * 1024
 
     const stylesheetLinks = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]'))
       .filter((link) => !link.disabled && Boolean(link.href))
@@ -1872,6 +1877,54 @@ export async function waitForVisualComparePaintReady(page: Page, timeoutMs: numb
 
     const images = Array.from(document.images)
     await Promise.all(images.map(async (image) => {
+      // Keep responsive image selection and all non-SVG image paths unchanged.
+      if (!image.srcset && image.parentElement?.tagName !== "PICTURE") {
+        try {
+          const source = new URL(image.currentSrc || image.src, document.baseURI)
+          if (source.origin === location.origin && /\.svg$/i.test(source.pathname)) {
+            const controller = new AbortController()
+            const abortTimer = setTimeout(() => controller.abort(), Math.max(0, until - Date.now()))
+            try {
+              const response = await fetch(source.href, { signal: controller.signal })
+              const contentLength = Number(response.headers.get("content-length"))
+              if (response.ok && (!Number.isFinite(contentLength) || contentLength <= maxSvgBytes) && /\bsvg\b/i.test(response.headers.get("content-type") ?? "")) {
+                const reader = response.body?.getReader()
+                if (reader) {
+                  const chunks: ArrayBuffer[] = []
+                  let size = 0
+                  while (Date.now() < until) {
+                    const next = await reader.read()
+                    if (next.done) {
+                      break
+                    }
+                    size += next.value.byteLength
+                    if (size > maxSvgBytes) {
+                      await reader.cancel()
+                      break
+                    }
+                    chunks.push(Uint8Array.from(next.value).buffer)
+                  }
+                  if (size <= maxSvgBytes && Date.now() < until) {
+                    const blobUrl = URL.createObjectURL(new Blob(chunks, { type: "image/svg+xml" }))
+                    image.src = blobUrl
+                    try {
+                      await image.decode()
+                      normalizedSvgBlobUrls.push(blobUrl)
+                    } catch {
+                      image.src = source.href
+                      URL.revokeObjectURL(blobUrl)
+                    }
+                  }
+                }
+              }
+            } finally {
+              clearTimeout(abortTimer)
+            }
+          }
+        } catch {
+          // Keep the original image when a bounded same-origin normalization fails.
+        }
+      }
       if (typeof image.decode === "function") {
         await Promise.race([
           image.decode().catch(() => undefined),
@@ -1893,6 +1946,17 @@ export async function waitForVisualComparePaintReady(page: Page, timeoutMs: numb
 
     await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
   }, readinessTimeoutMs).catch(() => undefined)
+}
+
+async function releaseVisualCompareSvgBlobUrls(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const normalizedSvgBlobUrlsKey = "__wpCodeboxVisualCompareSvgBlobUrls"
+    const target = window as unknown as Window & { [key: string]: string[] | undefined }
+    for (const blobUrl of target[normalizedSvgBlobUrlsKey] ?? []) {
+      URL.revokeObjectURL(blobUrl)
+    }
+    delete target[normalizedSvgBlobUrlsKey]
+  }).catch(() => undefined)
 }
 
 export interface VisualCompareNavigationPolicy {
@@ -2203,7 +2267,11 @@ async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath
   // `animations: "disabled"` fast-forwards finite CSS/Web animations and transitions
   // to their final state and freezes infinite ones to a deterministic frame, so the
   // capture does not depend on transition timing. Applied to both sides equally.
-  await captureVisualComparePageScreenshot(page, outputPath, { fullPage, timeoutMs, maxFullPageHeightPx: maxFullPageHeight })
+  try {
+    await captureVisualComparePageScreenshot(page, outputPath, { fullPage, timeoutMs, maxFullPageHeightPx: maxFullPageHeight })
+  } finally {
+    await releaseVisualCompareSvgBlobUrls(page)
+  }
   return { finalUrl: page.url(), domSnapshot, captureDiagnostics }
 }
 

--- a/tests/browser-visual-compare-capture-reliability.test.ts
+++ b/tests/browser-visual-compare-capture-reliability.test.ts
@@ -5,7 +5,9 @@ import { join } from "node:path"
 
 import { PNG } from "pngjs"
 
-import { comparePngFiles, visualCompareCaptureReadiness, visualCompareCompactCaptureDiagnostics, visualCompareErrorDetail, visualCompareNavigationPolicy, visualCompareOfflineRequestAllowed, visualCompareRegionElementOverlaps, visualCompareSelectorDeltas, type VisualCompareCaptureDiagnostics } from "../packages/runtime-playground/src/browser-visual-compare.js"
+import { chromium } from "playwright"
+
+import { comparePngFiles, visualCompareCaptureReadiness, visualCompareCompactCaptureDiagnostics, visualCompareErrorDetail, visualCompareNavigationPolicy, visualCompareOfflineRequestAllowed, visualCompareRegionElementOverlaps, visualCompareSelectorDeltas, waitForVisualComparePaintReady, type VisualCompareCaptureDiagnostics } from "../packages/runtime-playground/src/browser-visual-compare.js"
 
 // Build an opaque solid-color PNG. `fill` is [r,g,b].
 function solidPng(width: number, height: number, fill: [number, number, number]): PNG {
@@ -79,6 +81,34 @@ function paintRect(png: PNG, x0: number, y0: number, x1: number, y1: number, fil
   assert.equal(visualCompareOfflineRequestAllowed("https://fonts.example.invalid/font.woff2", "http://127.0.0.1:42573"), false)
 }
 
+// 4. A complete SVG image still needs decode readiness: externally served SVGs can be
+// complete before their embedded font glyphs have been painted.
+{
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    await page.setContent('<img id="svg" src="data:image/svg+xml,%3Csvg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"%3E%3C/svg%3E">')
+    await page.waitForFunction(() => document.images[0]?.complete === true)
+    await page.evaluate(`
+      const image = document.querySelector("#svg");
+      const decode = image.decode.bind(image);
+      let calls = 0;
+      Object.defineProperty(image, "decode", {
+        configurable: true,
+        value() {
+          image.dataset.decodeCalls = String(++calls);
+          return decode();
+        },
+      });
+      image.dataset.decodeCalls = String(calls);
+    `)
+    await waitForVisualComparePaintReady(page, 1_000)
+    assert.equal(await page.locator("#svg").evaluate((image) => image.dataset.decodeCalls), "1")
+  } finally {
+    await browser.close()
+  }
+}
+
 // Count pixels in a diff PNG whose RGB is nonzero — the exact predicate the region
 // detector uses (`visualCompareDiffPixel`). pixelmatch renders even unchanged pixels as
 // a dimmed grayscale of the original, so for a real (or solid) page this is typically the
@@ -95,7 +125,7 @@ function countDiffPixels(png: PNG): number {
   return count
 }
 
-// 4. Mismatch-region attribution ranks DOM elements by how much of the hotspot they
+// 5. Mismatch-region attribution ranks DOM elements by how much of the hotspot they
 //    cover and carries the element path/styles needed for actionable visual repairs.
 {
   const overlaps = visualCompareRegionElementOverlaps({ x: 10, y: 20, width: 100, height: 50, pixels: 5000 }, [
@@ -127,8 +157,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal(overlaps[1]?.styles["background-color"], "rgb(200, 0, 0)")
 }
 
-// 5. The bounded flood-fill region detection runs the real comparePngFiles aggregation
-// 5. Requested single-match selectors produce paired deltas even when source and
+// 6. Requested single-match selectors produce paired deltas even when source and
 //    candidate DOM paths differ after a structural move.
 {
   const selectorDeltas = visualCompareSelectorDeltas(
@@ -151,7 +180,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal(selectorDeltas[0]?.styles.find((style) => style.property === "color")?.category, "paint")
 }
 
-// 6. Capture diagnostics are normalized into compact readiness/noise signals without
+// 7. Capture diagnostics are normalized into compact readiness/noise signals without
 //    changing diff policy. Asset problems and dynamic content lower confidence; clean
 //    settled pages stay high-confidence.
 {
@@ -208,7 +237,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal("title" in (compact.source?.environment ?? {}), false)
 }
 
-// 7. The bounded flood-fill region detection runs the real comparePngFiles aggregation
+// 8. The bounded flood-fill region detection runs the real comparePngFiles aggregation
 //    over a large, tall, high-mismatch canvas — the exact shape that previously OOM'd
 //    old-space by pushing ~4× the diff-pixel count as [x,y] tuple arrays and marking
 //    visited only at pop time. The rewrite (flat numeric index stack, mark-at-push) must

--- a/tests/browser-visual-compare-capture-reliability.test.ts
+++ b/tests/browser-visual-compare-capture-reliability.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { createServer } from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -81,13 +82,25 @@ function paintRect(png: PNG, x0: number, y0: number, x1: number, y1: number, fil
   assert.equal(visualCompareOfflineRequestAllowed("https://fonts.example.invalid/font.woff2", "http://127.0.0.1:42573"), false)
 }
 
-// 4. A complete SVG image still needs decode readiness: externally served SVGs can be
-// complete before their embedded font glyphs have been painted.
+// 4. A complete same-origin external SVG is rehydrated through a Blob before decode.
+// Embedded-font metrics are browser-specific, so this asserts the resource path itself.
 {
+  const server = createServer((request, response) => {
+    if (request.url === "/image.svg") {
+      response.writeHead(200, { "content-type": "image/svg+xml" })
+      response.end('<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24"><text x="0" y="18">settled SVG</text></svg>')
+      return
+    }
+    response.writeHead(200, { "content-type": "text/html" })
+    response.end('<img id="svg" src="/image.svg">')
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  assert.ok(address && typeof address !== "string")
   const browser = await chromium.launch({ headless: true })
   try {
     const page = await browser.newPage()
-    await page.setContent('<img id="svg" src="data:image/svg+xml,%3Csvg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"%3E%3C/svg%3E">')
+    await page.goto(`http://127.0.0.1:${address.port}`)
     await page.waitForFunction(() => document.images[0]?.complete === true)
     await page.evaluate(`
       const image = document.querySelector("#svg");
@@ -103,9 +116,11 @@ function paintRect(png: PNG, x0: number, y0: number, x1: number, y1: number, fil
       image.dataset.decodeCalls = String(calls);
     `)
     await waitForVisualComparePaintReady(page, 1_000)
-    assert.equal(await page.locator("#svg").evaluate((image) => image.dataset.decodeCalls), "1")
+    assert.equal(await page.locator("#svg").evaluate((image) => image.dataset.decodeCalls), "2")
+    assert.match(await page.locator("#svg").evaluate((image) => (image as HTMLImageElement).src), /^blob:/)
   } finally {
     await browser.close()
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
   }
 }
 

--- a/tests/browser-visual-compare-capture-reliability.test.ts
+++ b/tests/browser-visual-compare-capture-reliability.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createServer } from "node:http"
 import { tmpdir } from "node:os"
@@ -9,6 +10,7 @@ import { PNG } from "pngjs"
 import { chromium } from "playwright"
 
 import { comparePngFiles, visualCompareCaptureReadiness, visualCompareCompactCaptureDiagnostics, visualCompareErrorDetail, visualCompareNavigationPolicy, visualCompareOfflineRequestAllowed, visualCompareRegionElementOverlaps, visualCompareSelectorDeltas, waitForVisualComparePaintReady, type VisualCompareCaptureDiagnostics } from "../packages/runtime-playground/src/browser-visual-compare.js"
+import { captureBrowserDomSnapshot } from "../packages/runtime-playground/src/browser-dom-snapshot.js"
 
 // Build an opaque solid-color PNG. `fill` is [r,g,b].
 function solidPng(width: number, height: number, fill: [number, number, number]): PNG {
@@ -124,6 +126,79 @@ function paintRect(png: PNG, x0: number, y0: number, x1: number, y1: number, fil
   }
 }
 
+// 5. SVG image payload evidence is bounded and metadata-only. Identical payloads have
+// identical digests, style changes are isolated through styleText, and untrusted bodies
+// never enter a DOM snapshot.
+{
+  const styleA = "@font-face { font-family: Embedded; src: url(data:font/woff2;base64,secret); }"
+  const styleB = "@font-face { font-family: Embedded; font-style: italic; src: url(data:font/woff2;base64,secret); }"
+  const svgA = `<svg xmlns="http://www.w3.org/2000/svg"><style>${styleA}</style><text font-family="Embedded" font-size="16" font-style="normal" font-weight="700" letter-spacing=".1em">Evidence</text></svg>`
+  const svgB = `<svg xmlns="http://www.w3.org/2000/svg"><style>${styleB}</style><text font-family="Embedded" font-size="16" font-style="normal" font-weight="700" letter-spacing=".1em">Evidence</text></svg>`
+  const server = createServer((request, response) => {
+    if (request.url === "/same.svg") {
+      response.writeHead(200, { "content-type": "image/svg+xml" })
+      response.end(svgA)
+      return
+    }
+    if (request.url === "/style-change.svg") {
+      response.writeHead(200, { "content-type": "image/svg+xml" })
+      response.end(svgB)
+      return
+    }
+    if (request.url === "/too-large.svg") {
+      response.writeHead(200, { "content-type": "image/svg+xml" })
+      response.end(" ".repeat(2 * 1024 * 1024 + 1))
+      return
+    }
+    if (request.url === "/not-svg.svg") {
+      response.writeHead(200, { "content-type": "text/plain" })
+      response.end("not SVG")
+      return
+    }
+    response.writeHead(200, { "content-type": "text/html" })
+    response.end(`<img src="/same.svg"><img src="/same.svg"><img src="/style-change.svg"><img src="/too-large.svg"><img src="/not-svg.svg"><img id="blob">\n<script>document.querySelector("#blob").src = URL.createObjectURL(new Blob([${JSON.stringify(svgA)}], { type: "image/svg+xml" }))</script>`)
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  assert.ok(address && typeof address !== "string")
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    await page.goto(`http://127.0.0.1:${address.port}`)
+    // tsx injects this helper into nested async functions serialized by page.evaluate.
+    await page.evaluate("globalThis.__name = (value) => value")
+    const snapshot = await captureBrowserDomSnapshot(page, 100)
+    assert.equal(snapshot.svgImagePayloads?.length, 4, "two matching URLs, one style variant, and one blob payload are retained")
+    const [first, second, changed, blob] = snapshot.svgImagePayloads ?? []
+    const sha256 = (value: string) => createHash("sha256").update(value).digest("hex")
+    assert.equal(first?.sha256, sha256(svgA))
+    assert.equal(second?.sha256, first?.sha256, "matching payloads have matching hashes")
+    assert.equal(first?.byteCount, Buffer.byteLength(svgA))
+    assert.equal(first?.textNodeCount, 2)
+    assert.deepEqual(first?.fontFamilyAttributes, ["Embedded"])
+    assert.deepEqual(first?.fontSizeAttributes, ["16"])
+    assert.deepEqual(first?.fontStyleAttributes, ["normal"])
+    assert.deepEqual(first?.fontWeightAttributes, ["700"])
+    assert.deepEqual(first?.letterSpacingAttributes, [".1em"])
+    assert.equal(first?.fontFaceRuleCount, 1)
+    assert.equal(first?.styleText.sha256, sha256(styleA))
+    assert.equal(first?.styleText.byteCount, Buffer.byteLength(styleA))
+    assert.notEqual(changed?.styleText.sha256, first?.styleText.sha256, "style changes have different style hashes")
+    assert.equal(blob?.sha256, first?.sha256, "blob SVG payloads use the same metadata-only path")
+    const serialized = JSON.stringify(snapshot)
+    assert.equal(serialized.includes(svgA), false, "raw SVG is not retained")
+    assert.equal(serialized.includes(styleA), false, "raw SVG CSS is not retained")
+    assert.equal(serialized.includes("data:font/woff2;base64,secret"), false, "embedded font data is not retained")
+    assert.equal(serialized.includes("blob:"), false, "full blob URLs are not retained")
+    await page.evaluate("Object.defineProperty(globalThis.crypto, 'subtle', { configurable: true, value: undefined })")
+    const withoutWebCrypto = await captureBrowserDomSnapshot(page, 100)
+    assert.equal(withoutWebCrypto.svgImagePayloads, undefined, "WebCrypto absence omits optional payload evidence without failing the snapshot")
+  } finally {
+    await browser.close()
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }
+}
+
 // Count pixels in a diff PNG whose RGB is nonzero — the exact predicate the region
 // detector uses (`visualCompareDiffPixel`). pixelmatch renders even unchanged pixels as
 // a dimmed grayscale of the original, so for a real (or solid) page this is typically the
@@ -140,7 +215,7 @@ function countDiffPixels(png: PNG): number {
   return count
 }
 
-// 5. Mismatch-region attribution ranks DOM elements by how much of the hotspot they
+// 6. Mismatch-region attribution ranks DOM elements by how much of the hotspot they
 //    cover and carries the element path/styles needed for actionable visual repairs.
 {
   const overlaps = visualCompareRegionElementOverlaps({ x: 10, y: 20, width: 100, height: 50, pixels: 5000 }, [
@@ -172,7 +247,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal(overlaps[1]?.styles["background-color"], "rgb(200, 0, 0)")
 }
 
-// 6. Requested single-match selectors produce paired deltas even when source and
+// 7. Requested single-match selectors produce paired deltas even when source and
 //    candidate DOM paths differ after a structural move.
 {
   const selectorDeltas = visualCompareSelectorDeltas(
@@ -195,7 +270,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal(selectorDeltas[0]?.styles.find((style) => style.property === "color")?.category, "paint")
 }
 
-// 7. Capture diagnostics are normalized into compact readiness/noise signals without
+// 8. Capture diagnostics are normalized into compact readiness/noise signals without
 //    changing diff policy. Asset problems and dynamic content lower confidence; clean
 //    settled pages stay high-confidence.
 {
@@ -252,7 +327,7 @@ function countDiffPixels(png: PNG): number {
   assert.equal("title" in (compact.source?.environment ?? {}), false)
 }
 
-// 8. The bounded flood-fill region detection runs the real comparePngFiles aggregation
+// 9. The bounded flood-fill region detection runs the real comparePngFiles aggregation
 //    over a large, tall, high-mismatch canvas — the exact shape that previously OOM'd
 //    old-space by pushing ~4× the diff-pixel count as [x,y] tuple arrays and marking
 //    visited only at pop time. The rewrite (flat numeric index stack, mark-at-push) must


### PR DESCRIPTION
## Summary
Normalize bounded same-origin external SVG images through Blob-backed decoding before screenshots.

## What changed
- Fetch eligible same-origin SVG bytes with timeout and size bounds, render them through temporary Blob URLs, decode them, and revoke URLs after capture.
- Extend browser coverage to prove an already-complete same-origin SVG takes the Blob-backed decode path.

## How to test
1. Run `npm install`; expect Dependencies install successfully..
2. Run `npm run build`; expect TypeScript packages build successfully..
3. Run `npm exec -- tsx tests/browser-visual-compare-capture-reliability.test.ts`; expect The capture reliability suite passes, including same-origin external SVG Blob normalization..

## Compatibility
No command or output schema changes. Raster, responsive, cross-origin, oversized, and failed SVG requests retain their existing paths.

## Evidence
- Base advanced after verification: verified main at 7b1e7740a59d34ed810555feed8f82850e1bcf6c; publication observed c4cb30a20bd6e21e82402953668e19ab7286be5a. Candidate ancestry was validated against the verified snapshot.
- CI expected: Repository CI
- Durable run execution: Failed
- Reviewer-resolvable source evidence: https://github.com/Automattic/wp-codebox/issues/1902
- Verified finalization base: main at 7b1e7740a59d34ed810555feed8f82850e1bcf6c
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Downstream evidence analysis, implementation, browser tests, and verification with Chris Huber.

## Source relationships
- Closes #1902
