### PR TITLE
Allow mounts to skip artifact capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,8 @@ Current bundles include:
 - `files/diffs/<mount>.patch`: unified text diff from the mount baseline (a seeded baseline directory, or the git `HEAD` of a git work-tree mount) to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
+Readwrite mounts capture files and diffs by default. Set `captureArtifacts` to `false` on a mount when its mutations are runtime-only and do not need review or apply-back evidence. WP Codebox then skips both the pre-run filesystem baseline and post-run traversal for that mount while preserving readwrite behavior.
+
 Recipes that import a generated site into a clean runtime can export replay evidence before final artifact collection with a workflow step:
 
 ```json

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -66,6 +66,10 @@ WordPress runtime name and currently resolves to the WordPress Playground backen
 Existing recipes that specify `wordpress-playground` continue to work as a
 compatibility spelling.
 
+Input mounts capture artifacts by default. A large readwrite mount whose
+mutations are runtime-only can set `"captureArtifacts": false` to skip its
+pre-run baseline and post-run file/diff capture without changing mount access.
+
 Raw Playground-oriented fields such as `runtime.blueprint`, `runtime.phpVersion`,
 `runtime.wordpressInstallMode`, and Playground backend packages are advanced
 compatibility fields. Prefer the neutral `wordpress` backend and recipe inputs

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "test:runtime-contract-manifest": "tsx tests/runtime-contract-manifest.test.ts",
     "test:runtime-contract-package-exports": "tsx tests/runtime-contract-package-exports.test.ts",
     "test:runtime-command-result-envelope": "tsx tests/runtime-command-result-envelope.test.ts",
+    "test:mount-artifact-capture-policy": "tsx tests/mount-artifact-capture-policy.test.ts",
     "test:wordpress-runtime-discovery-contracts": "tsx tests/wordpress-runtime-discovery-contracts.test.ts",
     "test:wordpress-runtime-discovery-coverage-plan": "tsx tests/wordpress-runtime-discovery-coverage-plan.test.ts",
     "test:wordpress-block-fuzz-suite": "tsx tests/wordpress-block-fuzz-suite.test.ts",

--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -68,6 +68,7 @@ export async function applyRecipeRuntimeSetup(args: {
       source,
       target: mount.target,
       mode: mount.mode ?? "readonly",
+      ...(mount.captureArtifacts !== undefined ? { captureArtifacts: mount.captureArtifacts } : {}),
       metadata: {
         kind: "runtime-stack-mount",
         index,
@@ -84,6 +85,7 @@ export async function applyRecipeRuntimeSetup(args: {
       source,
       target: mount.target,
       mode: mount.mode ?? "readonly",
+      ...(mount.captureArtifacts !== undefined ? { captureArtifacts: mount.captureArtifacts } : {}),
       metadata: {
         kind: "distribution-source-mount",
         index,
@@ -168,6 +170,7 @@ export async function applyRecipeRuntimeSetup(args: {
       source,
       target,
       mode: mount.mode ?? "readwrite",
+      ...(mount.captureArtifacts !== undefined ? { captureArtifacts: mount.captureArtifacts } : {}),
       metadata,
     }
     inputMounts.push(inputMount)
@@ -437,6 +440,9 @@ async function inputMountMetadataWithBaseline(source: string, mount: WorkspaceRe
     canonicalizedTarget: canonicalTarget !== originalTarget,
   }
   if ((mount.mode ?? "readwrite") !== "readwrite") {
+    return Object.keys(metadata).length > 0 ? metadata : undefined
+  }
+  if (mount.captureArtifacts === false) {
     return Object.keys(metadata).length > 0 ? metadata : undefined
   }
   if (typeof metadata.baselineSource === "string" && metadata.baselineSource.length > 0) {

--- a/packages/cli/src/runtime-command-wrappers.ts
+++ b/packages/cli/src/runtime-command-wrappers.ts
@@ -8,7 +8,7 @@ import { defaultPolicy, runPolicy } from "./recipe-validation.js"
 export const WP_CODEBOX_RUNTIME_VERSION = "0.0.0"
 
 export interface RunOptions {
-  mounts: Array<{ type?: MountSpec["type"]; source: string; target: string; mode: "readonly" | "readwrite"; metadata?: Record<string, unknown> }>
+  mounts: Array<{ type?: MountSpec["type"]; source: string; target: string; mode: "readonly" | "readwrite"; captureArtifacts?: boolean; metadata?: Record<string, unknown> }>
   command: string
   args: string[]
   wpVersion?: string
@@ -197,7 +197,7 @@ export async function run(options: RunOptions): Promise<RunOutput> {
     )
 
     for (const mount of options.mounts) {
-      await runtime.mount({ type: await recipeMountType(mount.source, mount.type), source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
+      await runtime.mount({ type: await recipeMountType(mount.source, mount.type), source: mount.source, target: mount.target, mode: mount.mode, captureArtifacts: mount.captureArtifacts, metadata: mount.metadata })
     }
 
     execution = await runtime.execute({ command: options.command, args: options.args })
@@ -261,7 +261,7 @@ export async function boot(options: BootOptions): Promise<BootOutput> {
     )
 
     for (const mount of options.mounts) {
-      await runtime.mount({ type: await recipeMountType(mount.source, mount.type), source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
+      await runtime.mount({ type: await recipeMountType(mount.source, mount.type), source: mount.source, target: mount.target, mode: mount.mode, captureArtifacts: mount.captureArtifacts, metadata: mount.metadata })
     }
 
     await runtime.observe({ type: "runtime-info" })

--- a/packages/runtime-core/src/mount-primitives.ts
+++ b/packages/runtime-core/src/mount-primitives.ts
@@ -23,6 +23,9 @@ export function normalizeSharedMount(mount: WorkspaceRecipeMount, index = 0, opt
   if (mount.type !== undefined) {
     normalized.type = mount.type
   }
+  if (mount.captureArtifacts !== undefined) {
+    normalized.captureArtifacts = mount.captureArtifacts
+  }
   if (mount.metadata !== undefined) {
     normalized.metadata = mount.metadata
   }

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -532,6 +532,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           source: { type: "string" },
           target: { type: "string", pattern: "^/" },
           mode: { enum: ["readonly", "readwrite"] },
+          captureArtifacts: { type: "boolean" },
           metadata: { $ref: "#/$defs/metadata" },
         },
       },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -109,6 +109,7 @@ export interface WorkspaceRecipeMount {
   source: string
   target: string
   mode?: "readonly" | "readwrite"
+  captureArtifacts?: boolean
   metadata?: Record<string, unknown>
 }
 
@@ -700,6 +701,7 @@ export interface MountSpec {
   source: string
   target: string
   mode: "readonly" | "readwrite"
+  captureArtifacts?: boolean
   metadata?: Record<string, unknown>
 }
 

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -571,6 +571,7 @@ export function buildArtifactProvenance({
       source: mount.source,
       target: mount.target,
       mode: mount.mode,
+      captureArtifacts: mount.captureArtifacts,
       metadata: mount.metadata,
     })),
   })

--- a/packages/runtime-playground/src/mounted-artifact-capture.ts
+++ b/packages/runtime-playground/src/mounted-artifact-capture.ts
@@ -30,7 +30,7 @@ export async function captureMountedFiles(filesDirectory: string, mounts: MountS
   }
 
   for (const [mountIndex, mount] of mounts.entries()) {
-    if (mount.mode !== "readwrite") {
+    if (mount.mode !== "readwrite" || mount.captureArtifacts === false) {
       continue
     }
     const artifactExcludePaths = mountArtifactExcludePaths(mount)
@@ -58,10 +58,10 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
   const diagnostics: ArtifactDiagnostic[] = []
 
   for (const [mountIndex, mount] of mounts.entries()) {
-    const baselineSource = typeof mount.metadata?.baselineSource === "string" ? mount.metadata.baselineSource : ""
-    if (mount.mode !== "readwrite") {
+    if (mount.mode !== "readwrite" || mount.captureArtifacts === false) {
       continue
     }
+    const baselineSource = typeof mount.metadata?.baselineSource === "string" ? mount.metadata.baselineSource : ""
     const artifactExcludePaths = mountArtifactExcludePaths(mount)
 
     const artifactPath = `files/diffs/mount-${mountIndex}.patch`

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -103,6 +103,7 @@ export const smokeGroups = {
       tsxSmoke("executable-browser-dto-smoke"),
       tsxSmoke("partial-artifact-discovery-smoke"),
       tsxSmoke("mounted-workspace-diff-smoke"),
+      npmScript("test:mount-artifact-capture-policy"),
       tsxSmoke("replay-export-blueprint-smoke"),
       tsxSmoke("replay-export-manifest-integrity-smoke"),
       tsxSmoke("materialize-replay-package-smoke"),

--- a/tests/mount-artifact-capture-policy.test.ts
+++ b/tests/mount-artifact-capture-policy.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { validateWorkspaceRecipeJsonSchema, type MountSpec, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { applyRecipeRuntimeSetup, prepareRecipeRuntimeSetup } from "../packages/cli/src/commands/recipe-runtime-setup.js"
+import { captureMountedFiles, captureMountDiffs } from "../packages/runtime-playground/src/mounted-artifact-capture.js"
+
+const validRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    mounts: [{
+      source: ".",
+      target: "/workspace",
+      mode: "readwrite",
+      captureArtifacts: false,
+    }],
+  },
+  workflow: { steps: [{ command: "wordpress.run-php" }] },
+}
+
+assert.equal(validateWorkspaceRecipeJsonSchema(validRecipe).valid, true)
+assert.equal(validateWorkspaceRecipeJsonSchema({
+  ...validRecipe,
+  inputs: { mounts: [{ ...validRecipe.inputs.mounts[0], captureArtifacts: "disabled" }] },
+}).valid, false)
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-mount-artifact-policy-"))
+const artifactRoot = join(root, "artifacts")
+const filesDirectory = join(artifactRoot, "files")
+const inputSource = join(root, "large-input")
+const mount: MountSpec = {
+  type: "directory",
+  source: join(root, "source-that-must-not-be-read"),
+  target: "/workspace",
+  mode: "readwrite",
+  captureArtifacts: false,
+}
+const redactor = { redact: (_path: string, contents: string) => contents }
+
+try {
+  await mkdir(inputSource)
+  await writeFile(join(inputSource, "fixture.txt"), "fixture")
+  const setupRecipe: WorkspaceRecipe = {
+    ...validRecipe,
+    inputs: { mounts: [{ ...validRecipe.inputs.mounts[0], source: inputSource }] },
+  }
+  const prepared = await prepareRecipeRuntimeSetup(setupRecipe, root, "wordpress-playground")
+  let mountedInput: MountSpec | undefined
+  await applyRecipeRuntimeSetup({
+    recipe: setupRecipe,
+    recipeDirectory: root,
+    prepared,
+    runtime: {
+      async mount(spec: MountSpec) { mountedInput = spec },
+    } as never,
+    phaseExecutor: {
+      tracker: {
+        list: () => [],
+        async run<T>(_name: string, _data: unknown, operation: () => Promise<T>) { return await operation() },
+      },
+      async operation<T>(_operation: string, operation: Promise<T> | (() => Promise<T>)) {
+        return await (typeof operation === "function" ? operation() : operation)
+      },
+    } as never,
+  })
+  assert.equal(prepared.inputMountBaselinePaths.length, 0, "disabled mounts do not create filesystem baselines")
+  assert.equal(mountedInput?.captureArtifacts, false, "runtime mount retains the artifact policy")
+  assert.equal(mountedInput?.metadata?.baselineSource, undefined)
+
+  const captured = await captureMountedFiles(filesDirectory, [mount], redactor)
+  assert.deepEqual(captured.files, [], "disabled mounts do not capture files")
+  assert.deepEqual(captured.skipped, [], "disabled mounts are not traversed")
+
+  const diffs = await captureMountDiffs(artifactRoot, filesDirectory, [mount], redactor)
+  assert.deepEqual(diffs.mountDiffs, [], "disabled mounts do not extract diffs")
+  assert.deepEqual(diffs.changedFiles.files, [])
+  assert.equal(diffs.patch, "")
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("mount artifact capture policy ok")


### PR DESCRIPTION
## Summary

- add an explicit `captureArtifacts` mount policy
- skip pre-run filesystem baselines and post-run traversal when capture is disabled
- preserve current capture behavior by default
- document and test the recipe contract

Fixes #1908.

## How to test

1. Run `npm ci`.
2. Run `npm run build`.
3. Run `npm run test:mount-artifact-capture-policy`.
4. Run `npm run test:recipe-runtime-setup-staged-materialization`.
5. Run `npx tsx tests/trusted-apply-artifact-channel.integration.test.ts`.

## Backwards compatibility

Existing recipes are unchanged because artifact capture remains enabled unless a mount explicitly sets `captureArtifacts` to `false`. No extension path or existing runtime behavior changes by default.

## Verification

- `npm run build`
- `npm run test:mount-artifact-capture-policy`
- `npm run test:recipe-runtime-setup-staged-materialization`
- `npx tsx tests/trusted-apply-artifact-channel.integration.test.ts`

The wider artifact smoke group currently reaches the pre-existing `artifact-patch-git-apply-smoke` path-prefix assertion failure on `main`; this change does not touch that diff implementation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Investigated the baseline-copy failure, implemented the mount policy and deterministic tests, and prepared verification and documentation.