### PR TITLE
Support external MariaDB PHPUnit runtimes

### DIFF
--- a/packages/cli/src/commands/recipe-build.ts
+++ b/packages/cli/src/commands/recipe-build.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises"
-import { buildGenericAbilityRuntimeRunRecipe, buildRuntimePackageRunRecipe, buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, compileRecipeTemplate, type GenericAbilityRuntimeRunOptions, type RecipeTemplateInput, type RuntimePackageRunRecipeOptions, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount, type WorkspaceRecipePHPWasmExtensionManifest, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeService, type WorkspaceRecipeStep } from "@automattic/wp-codebox-core"
+import { buildGenericAbilityRuntimeRunRecipe, buildRuntimePackageRunRecipe, buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, compileRecipeTemplate, type GenericAbilityRuntimeRunOptions, type RecipeTemplateInput, type RuntimePackageRunRecipeOptions, type RuntimeWordPressInstallMode, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount, type WorkspaceRecipePHPWasmExtensionManifest, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeService, type WorkspaceRecipeStep } from "@automattic/wp-codebox-core"
 
 interface RecipeBuildOptions {
   recipeType: "phpunit" | "bench" | "template" | "generic-ability-runtime-run" | "runtime-package-run"
@@ -11,6 +11,7 @@ interface WordPressPhpunitBuilderOptions {
   blueprint?: unknown
   wordpressVersion?: string
   phpVersion?: string
+  wordpressInstallMode?: RuntimeWordPressInstallMode
   extensions?: WorkspaceRecipePHPWasmExtensionManifest[]
   backendPackage?: WorkspaceRecipeRuntimeBackendPackage
   mounts?: WorkspaceRecipeMount[]
@@ -80,6 +81,7 @@ function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: Word
         blueprint: phpunitOptions.blueprint,
         wordpressVersion: stringOrUndefined(phpunitOptions.wordpressVersion),
         phpVersion: stringOrUndefined(phpunitOptions.phpVersion),
+        wordpressInstallMode: phpunitOptions.wordpressInstallMode,
         extensions: Array.isArray(phpunitOptions.extensions) ? phpunitOptions.extensions : [],
         backendPackage: phpunitOptions.backendPackage,
         mounts: Array.isArray(phpunitOptions.mounts) ? phpunitOptions.mounts : [],

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -202,6 +202,7 @@ export async function runRecipe(options: RecipeRunOptions, interruption?: Recipe
       version: plan.runtime.wp,
       phpVersion: plan.runtime.phpVersion,
       wordpressInstallMode: plan.runtime.wordpressInstallMode,
+      databaseSetup: recipe.inputs?.services?.some(({ kind }) => kind === "mysql") ? "external" as const : undefined,
       blueprint: plan.runtime.blueprint,
       assets: resolveRecipeRuntimeAssets(recipe, recipeDirectory),
       extensions: resolveRecipeRuntimeExtensionManifests(recipe, recipeDirectory),

--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util"
 import type { WorkspaceRecipeRuntimeService } from "@automattic/wp-codebox-core"
 
 const execFileAsync = promisify(execFile)
-const MYSQL_IMAGE = "mysql:8.4"
+const MYSQL_IMAGES = { mysql: "mysql:8.4", mariadb: "mariadb:11.4" } as const
 
 export interface RuntimeServiceEvidence {
   id: string
@@ -51,7 +51,7 @@ export interface RuntimeServiceDependencies {
 export interface RuntimeServiceProvider {
   readonly name: string
   readonly kind: string
-  readonly version: string
+  version(service: WorkspaceRecipeRuntimeService): string
   provision(service: WorkspaceRecipeRuntimeService, dependencies: RuntimeServiceDependencies, signal: AbortSignal | undefined, evidence: RuntimeServiceEvidence[]): Promise<ManagedRuntimeService>
 }
 
@@ -64,7 +64,7 @@ const defaultDependencies: RuntimeServiceDependencies = {
 export function runtimeServicePlan(services: WorkspaceRecipeRuntimeService[]): Array<{ id: string; kind: string; provider: string; version: string; bind: "loopback"; port: "ephemeral"; persistentVolume: false; configuration?: WorkspaceRecipeRuntimeService["configuration"]; outputs: Record<string, string> }> {
   return services.map((service) => {
     const provider = runtimeServiceProvider(service.kind)
-    return { id: service.id, kind: service.kind, provider: provider.name, version: provider.version, bind: "loopback", port: "ephemeral", persistentVolume: false, ...(service.configuration ? { configuration: service.configuration } : {}), outputs: service.outputs }
+    return { id: service.id, kind: service.kind, provider: provider.name, version: provider.version(service), bind: "loopback", port: "ephemeral", persistentVolume: false, ...(service.configuration ? { configuration: service.configuration } : {}), outputs: service.outputs }
   })
 }
 
@@ -135,8 +135,12 @@ export async function provisionRuntimeServicesForRecipe(
 const mysqlDockerProvider: RuntimeServiceProvider = {
   name: "docker",
   kind: "mysql",
-  version: MYSQL_IMAGE,
+  version: mysqlDockerImage,
   provision: provisionMysqlDockerService,
+}
+
+function mysqlDockerImage(service: WorkspaceRecipeRuntimeService): string {
+  return MYSQL_IMAGES[service.configuration?.engine ?? "mysql"]
 }
 
 function runtimeServiceProvider(kind: string): RuntimeServiceProvider {
@@ -145,19 +149,24 @@ function runtimeServiceProvider(kind: string): RuntimeServiceProvider {
 }
 
 async function provisionMysqlDockerService(service: WorkspaceRecipeRuntimeService, dependencies: RuntimeServiceDependencies, signal: AbortSignal | undefined, evidenceList: RuntimeServiceEvidence[]): Promise<ManagedRuntimeService> {
-  const evidence: RuntimeServiceEvidence = { id: service.id, kind: service.kind, provider: "docker", version: MYSQL_IMAGE, readiness: "pending", lifecycle: "provisioning" }
+  const engine = service.configuration?.engine ?? "mysql"
+  const image = mysqlDockerImage(service)
+  const evidence: RuntimeServiceEvidence = { id: service.id, kind: service.kind, provider: "docker", version: image, readiness: "pending", lifecycle: "provisioning" }
   evidenceList.push(evidence)
   const container = `wp-codebox-${service.id}-${dependencies.randomBytes(6).toString("hex")}`
   const password = dependencies.randomBytes(24).toString("base64url")
   const emptyRootPassword = service.configuration?.rootAuthentication === "empty-password"
-  const rootEnvironment = emptyRootPassword ? { MYSQL_ALLOW_EMPTY_PASSWORD: "yes" } : { MYSQL_ROOT_PASSWORD: password }
-  const childEnvironment = { ...process.env, MYSQL_DATABASE: "runtime", MYSQL_USER: "runtime", MYSQL_PASSWORD: password, ...rootEnvironment }
-  const rootEnvironmentName = emptyRootPassword ? "MYSQL_ALLOW_EMPTY_PASSWORD" : "MYSQL_ROOT_PASSWORD"
-  const runArgs = ["run", "--detach", "--rm", "--name", container, "--publish", "127.0.0.1::3306", "--tmpfs", "/var/lib/mysql", "--env", "MYSQL_DATABASE", "--env", "MYSQL_USER", "--env", "MYSQL_PASSWORD", "--env", rootEnvironmentName, MYSQL_IMAGE]
+  const environmentPrefix = engine === "mariadb" ? "MARIADB" : "MYSQL"
+  const rootEnvironmentName = emptyRootPassword ? engine === "mariadb" ? "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" : "MYSQL_ALLOW_EMPTY_PASSWORD" : `${environmentPrefix}_ROOT_PASSWORD`
+  const rootEnvironment = { [rootEnvironmentName]: emptyRootPassword ? "yes" : password }
+  const childEnvironment = { ...process.env, [`${environmentPrefix}_DATABASE`]: "runtime", [`${environmentPrefix}_USER`]: "runtime", [`${environmentPrefix}_PASSWORD`]: password, ...rootEnvironment }
+  const foreignKeyTargetPolicy = service.configuration?.foreignKeyTargetPolicy
+  const mysqlArguments = engine === "mysql" && foreignKeyTargetPolicy ? [`--restrict-fk-on-non-standard-key=${foreignKeyTargetPolicy === "indexed" ? "OFF" : "ON"}`] : []
+  const runArgs = ["run", "--detach", "--rm", "--name", container, "--publish", "127.0.0.1::3306", "--tmpfs", "/var/lib/mysql", "--env", `${environmentPrefix}_DATABASE`, "--env", `${environmentPrefix}_USER`, "--env", `${environmentPrefix}_PASSWORD`, "--env", rootEnvironmentName, image, ...mysqlArguments]
   let started = false
   try {
     throwIfAborted(signal)
-    await ensureDockerImage(dependencies, signal)
+    await ensureDockerImage(image, dependencies, signal)
     await dependencies.execute("docker", runArgs, { env: childEnvironment, signal, timeout: 30_000 })
     started = true
     const { stdout } = await dependencies.execute("docker", ["port", container, "3306/tcp"], { signal, timeout: 10_000 })
@@ -177,12 +186,12 @@ async function provisionMysqlDockerService(service: WorkspaceRecipeRuntimeServic
   }
 }
 
-async function ensureDockerImage(dependencies: RuntimeServiceDependencies, signal?: AbortSignal): Promise<void> {
+async function ensureDockerImage(image: string, dependencies: RuntimeServiceDependencies, signal?: AbortSignal): Promise<void> {
   try {
-    await dependencies.execute("docker", ["image", "inspect", MYSQL_IMAGE], { signal, timeout: 10_000 })
+    await dependencies.execute("docker", ["image", "inspect", image], { signal, timeout: 10_000 })
   } catch {
     throwIfAborted(signal)
-    await dependencies.execute("docker", ["pull", MYSQL_IMAGE], { signal, timeout: 5 * 60_000 })
+    await dependencies.execute("docker", ["pull", image], { signal, timeout: 5 * 60_000 })
   }
 }
 

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -1,4 +1,4 @@
-import type { RuntimePreviewSpec, WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipePHPWasmExtensionManifest, WorkspaceRecipeRuntimeBackendPackage, WorkspaceRecipeRuntimeService, WorkspaceRecipeStep } from "./runtime-contracts.js"
+import type { RuntimePreviewSpec, RuntimeWordPressInstallMode, WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipePHPWasmExtensionManifest, WorkspaceRecipeRuntimeBackendPackage, WorkspaceRecipeRuntimeService, WorkspaceRecipeStep } from "./runtime-contracts.js"
 import { commandArg, commandJsonArg, commandStringListArg } from "./command-codecs.js"
 export { buildRuntimePackageRunRecipe, CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA, RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA, RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA, runtimePackageExecutionInput, type RuntimePackageArtifactDeclaration, type RuntimePackageExecutionInput, type RuntimePackageOutputProjection, type RuntimePackageRunRecipeOptions } from "./runtime-package-execution.js"
 export { RUNTIME_PACKAGE_DIAGNOSTIC_SCHEMA, RUNTIME_PACKAGE_RESULT_SCHEMA, RUNTIME_PACKAGE_TASK_SCHEMA, normalizeRuntimePackageResult, normalizeRuntimePackageTask, validateRuntimePackageTask, type RuntimePackageDiagnostic, type RuntimePackageResult, type RuntimePackageTask } from "./runtime-package-contracts.js"
@@ -14,6 +14,7 @@ export interface NormalizeRecipeMountsOptions {
 export interface WordPressPhpunitRecipeOptions {
   wordpressVersion?: string
   phpVersion?: string
+  wordpressInstallMode?: RuntimeWordPressInstallMode
   blueprint?: unknown
   extensions?: WorkspaceRecipePHPWasmExtensionManifest[]
   backendPackage?: WorkspaceRecipeRuntimeBackendPackage
@@ -78,6 +79,7 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
     runtime: {
       wp: options.wordpressVersion ?? DEFAULT_WORDPRESS_VERSION,
       ...(options.phpVersion ? { phpVersion: options.phpVersion } : {}),
+      ...(options.wordpressInstallMode ? { wordpressInstallMode: options.wordpressInstallMode } : {}),
       blueprint: blueprintWithMultisite(options.blueprint ?? { steps: [] }, options.multisite ?? false),
       ...(options.preview || options.multisite ? { preview: multisitePreview(options.preview, options.multisite ?? false) } : {}),
       ...(options.extensions?.length ? { extensions: options.extensions } : {}),

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -916,7 +916,9 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "object",
             additionalProperties: false,
             properties: {
+              engine: { enum: ["mysql", "mariadb"] },
               rootAuthentication: { enum: ["generated-password", "empty-password"] },
+              foreignKeyTargetPolicy: { enum: ["unique-only", "indexed"] },
             },
           },
           outputs: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -3,7 +3,7 @@ import type { RuntimePolicy } from "./runtime-policy.js"
 import { SANDBOX_WORKSPACE_ROOT } from "./runtime-action-adapter.js"
 import type { ArtifactFileDigest, ArtifactManifestFile, ArtifactSpec, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import type { HostToolDefinition, HostToolRegistry } from "./host-tool-registry.js"
-import type { BackendNeutralRuntimeProvenance, RuntimePHPWasmExtensionManifest, RuntimeWordPressAssetSpec, RuntimeWordPressEnvironmentSpec, RuntimeWordPressInstallModeContract, RuntimeWordPressProvenance } from "./runtime-neutral-contracts.js"
+import type { BackendNeutralRuntimeProvenance, RuntimePHPWasmExtensionManifest, RuntimeWordPressAssetSpec, RuntimeWordPressDatabaseSetupContract, RuntimeWordPressEnvironmentSpec, RuntimeWordPressInstallModeContract, RuntimeWordPressProvenance } from "./runtime-neutral-contracts.js"
 import type {
   RUNTIME_EPISODE_ACTION_SCHEMA,
   RUNTIME_EPISODE_OBSERVATION_SCHEMA,
@@ -19,6 +19,7 @@ export type SandboxWorkspaceMode = "repo-backed" | "site-backed"
 export interface EnvironmentSpec extends RuntimeWordPressEnvironmentSpec {}
 
 export type RuntimeWordPressInstallMode = RuntimeWordPressInstallModeContract
+export type RuntimeWordPressDatabaseSetup = RuntimeWordPressDatabaseSetupContract
 
 export interface RuntimeAssetSpec extends RuntimeWordPressAssetSpec {}
 
@@ -136,7 +137,9 @@ export interface WorkspaceRecipeRuntimeService {
   id: string
   kind: "mysql" | (string & {})
   configuration?: {
+    engine?: "mysql" | "mariadb"
     rootAuthentication?: "generated-password" | "empty-password"
+    foreignKeyTargetPolicy?: "unique-only" | "indexed"
   }
   /** Explicit map from a provider output (for example `port`) to a runtime env name. */
   outputs: Record<string, string>

--- a/packages/runtime-core/src/runtime-neutral-contracts.ts
+++ b/packages/runtime-core/src/runtime-neutral-contracts.ts
@@ -46,6 +46,7 @@ export interface BackendNeutralEnvironmentSpec {
 }
 
 export type RuntimeWordPressInstallModeContract = "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
+export type RuntimeWordPressDatabaseSetupContract = "runtime-managed" | "external"
 
 export interface RuntimeWordPressAssetSpec extends BackendNeutralRuntimeAssetSpec {
   wordpressDirectory?: string
@@ -62,6 +63,7 @@ export interface RuntimeWordPressEnvironmentSpec extends BackendNeutralEnvironme
   phpVersion?: string
   assets?: RuntimeWordPressAssetSpec
   wordpressInstallMode?: RuntimeWordPressInstallModeContract
+  databaseSetup?: RuntimeWordPressDatabaseSetupContract
   extensions?: RuntimePHPWasmExtensionManifest[]
 }
 
@@ -115,6 +117,7 @@ export function normalizeRuntimeWordPressEnvironmentSpec(input: unknown): Runtim
     phpVersion: optionalString(value.phpVersion, "environment.phpVersion"),
     assets: normalizeRuntimeWordPressAssetSpec(value.assets),
     wordpressInstallMode: optionalString(value.wordpressInstallMode, "environment.wordpressInstallMode") as RuntimeWordPressInstallModeContract | undefined,
+    databaseSetup: optionalString(value.databaseSetup, "environment.databaseSetup") as RuntimeWordPressDatabaseSetupContract | undefined,
     extensions: normalizeRuntimePHPWasmExtensionManifests(value.extensions),
   })
 }

--- a/packages/runtime-playground/src/php-snippets.ts
+++ b/packages/runtime-playground/src/php-snippets.ts
@@ -19,7 +19,11 @@ if (!defined('STDERR')) {
 export function phpEnvAssignments(env: Record<string, unknown>): string {
   const lines = Object.entries(env)
     .filter(([name]) => isSafeEnvName(name))
-    .map(([name, value]) => `putenv(${JSON.stringify(`${name}=${String(value)}`)});`)
+    .flatMap(([name, value]) => [
+      `putenv(${JSON.stringify(`${name}=${String(value)}`)});`,
+      `$_ENV[${JSON.stringify(name)}] = ${JSON.stringify(String(value))};`,
+      `$_SERVER[${JSON.stringify(name)}] = ${JSON.stringify(String(value))};`,
+    ])
 
   return lines.length > 0 ? `${lines.join("\n")}\n` : ""
 }
@@ -68,6 +72,7 @@ export function phpEnvAssignmentFunction(functionName: string, jsonFunction = "j
             $string_value = is_scalar($value) ? (string) $value : ${jsonFunction}($value);
             putenv($name . '=' . $string_value);
             $_ENV[$name] = $string_value;
+            $_SERVER[$name] = $string_value;
         }${invalidKeyLogExpression ? ` else {
             ${invalidKeyLogExpression}
         }` : ""}

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -31,6 +31,7 @@ export interface PlaygroundCliModule {
     php?: string
     workers?: number | "auto"
     wordpressInstallMode?: "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
+    skipSqliteSetup?: boolean
     "site-url"?: string
     phpIniEntries?: Record<string, string>
     phpExtension?: string[]
@@ -138,6 +139,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           } : {}),
           wp: localAssetServer?.url ?? wordpressStartupAsset?.wp,
           php: spec.environment.phpVersion,
+          skipSqliteSetup: spec.environment.databaseSetup === "external",
           ...(spec.environment.extensions?.length ? { phpExtension: spec.environment.extensions.map((extension) => extension.manifest) } : {}),
           phpIniEntries: pluginRuntimePhpIniEntries(spec),
           "site-url": spec.preview?.siteUrl,
@@ -265,6 +267,7 @@ class PreviewLeaseProbeError extends Error {
 
 export function shouldUseProgrammaticPlaygroundRunner(spec: RuntimeCreateSpec, options: PlaygroundCliStartupOptions = {}): boolean {
   return !options.cliModule
+    && spec.environment.databaseSetup !== "external"
     && Boolean(spec.environment.assets?.wordpressDirectory)
     && (Boolean(runtimeBootstrapPhpIniEntries(spec)) || Boolean(spec.environment.extensions?.length))
 }
@@ -287,7 +290,7 @@ async function pluginRuntimeBootstrapSharedMount(spec: RuntimeCreateSpec): Promi
 
 function runtimeBootstrapPhpIniEntries(spec: RuntimeCreateSpec): Record<string, string> | undefined {
   const entries = pluginRuntimeBootstrapPhpIniEntries(spec) ?? {}
-  if (Object.keys(entries).length === 0 && !distributionBootstrapPhp(spec)) {
+  if (Object.keys(entries).length === 0 && !runtimeAutoPrependPhpBody(spec)) {
     return undefined
   }
 
@@ -365,7 +368,11 @@ function phpIniContent(entries: Record<string, string>): string {
 }
 
 function runtimeAutoPrependPhp(spec: RuntimeCreateSpec): string {
-  return `<?php\n${distributionBootstrapPhp(spec)}`
+  return `<?php\n${runtimeAutoPrependPhpBody(spec)}`
+}
+
+function runtimeAutoPrependPhpBody(spec: RuntimeCreateSpec): string {
+  return `${phpEnvAssignments(spec.runtimeEnv ?? {})}${distributionBootstrapPhp(spec)}`
 }
 
 function distributionBootstrapPhp(spec: RuntimeCreateSpec): string {

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -6,6 +6,7 @@ import { createServer as createHttpServer, type IncomingMessage, type Server as 
 import { dirname } from "node:path"
 import { playgroundBlueprint } from "./blueprint.js"
 import { assertPhpWasmExternalExtensionsSupported } from "./php-wasm-preflight.js"
+import { phpEnvAssignments } from "./php-snippets.js"
 import type { PlaygroundCliServer, PlaygroundServerRunResponse } from "./preview-server.js"
 
 const { createNodeFsMountHandler, loadNodeRuntime } = PHPWasmNode as unknown as {
@@ -110,14 +111,15 @@ export function programmaticNodeRuntimeOptions(spec: RuntimeCreateSpec, processI
 }
 
 function autoPrependPhp(spec: RuntimeCreateSpec): string {
+  const runtimeEnv = phpEnvAssignments(spec.runtimeEnv ?? {})
   const recipe = spec.metadata?.recipe
   if (!recipe || typeof recipe !== "object" || Array.isArray(recipe)) {
-    return "<?php\n"
+    return `<?php\n${runtimeEnv}`
   }
 
   const distribution = (recipe as { distribution?: unknown }).distribution
   if (!distribution || typeof distribution !== "object" || Array.isArray(distribution)) {
-    return "<?php\n"
+    return `<?php\n${runtimeEnv}`
   }
 
   const env = (distribution as { env?: unknown }).env
@@ -138,7 +140,7 @@ function autoPrependPhp(spec: RuntimeCreateSpec): string {
     }
   }
 
-  return `<?php\n${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`
+  return `<?php\n${runtimeEnv}${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`
 }
 
 function phpLiteral(value: string | number | boolean | null): string {

--- a/tests/disposable-mysql-mysqli.integration.test.ts
+++ b/tests/disposable-mysql-mysqli.integration.test.ts
@@ -23,11 +23,11 @@ if (!await dockerAvailable()) {
   const directory = await mkdtemp(join(tmpdir(), "wp-codebox-mysql-e2e-"))
   try {
     const recipePath = join(directory, "recipe.json")
-    const code = "if (!function_exists('mysqli_init')) { throw new RuntimeException('mysqli is unavailable'); } $db = mysqli_init(); if (!mysqli_real_connect($db, getenv('DB_HOST'), 'root', '', null, (int) getenv('DB_PORT'))) { throw new RuntimeException(mysqli_connect_error()); } $result = mysqli_query($db, 'SELECT 1 AS connected'); echo mysqli_fetch_assoc($result)['connected'];"
+    const code = "if (!function_exists('mysqli_init')) { throw new RuntimeException('mysqli is unavailable'); } $db = mysqli_init(); if (!mysqli_real_connect($db, getenv('DB_HOST'), 'root', '', 'runtime', (int) getenv('DB_PORT'))) { throw new RuntimeException(mysqli_connect_error()); } mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT); mysqli_query($db, 'CREATE TABLE parent (id INT NOT NULL, KEY (id)) ENGINE=InnoDB'); mysqli_query($db, 'CREATE TABLE child (parent_id INT NOT NULL, FOREIGN KEY (parent_id) REFERENCES parent(id)) ENGINE=InnoDB'); $result = mysqli_query($db, 'SELECT 1 AS connected'); echo mysqli_fetch_assoc($result)['connected'];"
     await writeFile(recipePath, JSON.stringify({
       schema: "wp-codebox/workspace-recipe/v1",
       inputs: {
-        services: [{ id: "mysql", kind: "mysql", configuration: { rootAuthentication: "empty-password" }, outputs: { host: "DB_HOST", port: "DB_PORT" } }],
+        services: [{ id: "mysql", kind: "mysql", configuration: { rootAuthentication: "empty-password", foreignKeyTargetPolicy: "indexed" }, outputs: { host: "DB_HOST", port: "DB_PORT" } }],
       },
       workflow: { steps: [{ command: "wordpress.run-php", args: [`code=${code}`] }] },
     }))
@@ -43,7 +43,29 @@ if (!await dockerAvailable()) {
     })
     assert.equal(result.success, true)
     assert.equal(result.executions.at(-1)?.stdout.trim(), "1")
-    console.log("disposable MySQL mysqli E2E passed")
+
+    const mariaDbRecipePath = join(directory, "mariadb-recipe.json")
+    const mariaDbCode = "if (!function_exists('mysqli_init')) { throw new RuntimeException('mysqli is unavailable'); } $db = mysqli_init(); if (!mysqli_real_connect($db, getenv('DB_HOST'), 'root', '', 'runtime', (int) getenv('DB_PORT'))) { throw new RuntimeException(mysqli_connect_error()); } mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT); mysqli_query($db, 'CREATE TABLE parent (id INT NOT NULL, KEY (id)) ENGINE=InnoDB'); mysqli_query($db, 'CREATE TABLE child (parent_id INT NOT NULL, FOREIGN KEY (parent_id) REFERENCES parent(id)) ENGINE=InnoDB'); mysqli_query($db, \"CREATE TABLE settings (payload LONGTEXT NOT NULL DEFAULT '{}') ENGINE=InnoDB\"); $result = mysqli_query($db, 'SELECT 1 AS connected'); echo mysqli_fetch_assoc($result)['connected'];"
+    await writeFile(mariaDbRecipePath, JSON.stringify({
+      schema: "wp-codebox/workspace-recipe/v1",
+      inputs: {
+        services: [{ id: "mariadb", kind: "mysql", configuration: { engine: "mariadb", rootAuthentication: "empty-password" }, outputs: { host: "DB_HOST", port: "DB_PORT" } }],
+      },
+      workflow: { steps: [{ command: "wordpress.run-php", args: [`code=${mariaDbCode}`] }] },
+    }))
+    const mariaDbResult = await runRecipe({
+      recipePath: mariaDbRecipePath,
+      previewHoldBlocking: false,
+      previewLeaseRequested: false,
+      previewLeaseChild: false,
+      timeoutMs: 180_000,
+      json: true,
+      summary: false,
+      dryRun: false,
+    })
+    assert.equal(mariaDbResult.success, true)
+    assert.equal(mariaDbResult.executions.at(-1)?.stdout.trim(), "1")
+    console.log("disposable MySQL and MariaDB mysqli E2E passed")
   } finally {
     await rm(directory, { recursive: true, force: true })
   }

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
-import { startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import { shouldUseProgrammaticPlaygroundRunner, startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
 import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
 
 const wordpressDevelopDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-wordpress-develop-"))
@@ -32,6 +32,7 @@ try {
       version: "mounted-wordpress-source",
       phpVersion: "8.4",
       wordpressInstallMode: "do-not-attempt-installing",
+      databaseSetup: "external",
       assets: { wordpressDirectory: wordpressDevelopDirectory },
       extensions: [{ manifest: "/tmp/sodium/manifest.json" }],
       blueprint: {},
@@ -55,6 +56,7 @@ try {
         },
       },
     },
+    runtimeEnv: { TC_MYSQL_PORT: "33060" },
     artifactsDirectory,
   }
 
@@ -69,6 +71,8 @@ try {
   assert.deepEqual(calls[0].mount, [])
   assert.equal(calls[0].workers, 6)
   assert.equal(calls[0].wordpressInstallMode, "do-not-attempt-installing")
+  assert.equal(calls[0].skipSqliteSetup, true)
+  assert.equal(shouldUseProgrammaticPlaygroundRunner(spec), false)
   assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
   assert.deepEqual(calls[0].phpExtension, ["/tmp/sodium/manifest.json"])
   const sharedMount = calls[0]["mount-before-install"]?.[0]?.hostPath
@@ -78,13 +82,14 @@ try {
   // The runtime default memory ceiling stays high enough for collect_artifacts to
   // base64 heavy snapshot/declared-artifact files without a hard PHP fatal.
   assert.match(sharedPhpIni, /memory_limit=512M/)
-  assert.match(await readFile(join(sharedMount as string, "auto_prepend_file.php"), "utf8"), /<\?php/)
+  assert.match(await readFile(join(sharedMount as string, "auto_prepend_file.php"), "utf8"), /putenv\("TC_MYSQL_PORT=33060"\);/)
   assert.equal((await stat(join(sharedMount as string, "mu-plugins"))).isDirectory(), true)
   assert.equal((await stat(join(sharedMount as string, "preload"))).isDirectory(), true)
 
   calls.length = 0
   const defaultRuntimeIniSpec: RuntimeCreateSpec = {
     ...spec,
+    environment: { ...spec.environment, databaseSetup: undefined },
     metadata: {},
   }
 
@@ -93,6 +98,8 @@ try {
 
   assert.equal(calls.length, 1)
   assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
+  assert.equal(calls[0].skipSqliteSetup, false)
+  assert.equal(shouldUseProgrammaticPlaygroundRunner(defaultRuntimeIniSpec), true)
 
   calls.length = 0
   const distributionOnlySpec: RuntimeCreateSpec = {

--- a/tests/runtime-neutral-contracts.test.ts
+++ b/tests/runtime-neutral-contracts.test.ts
@@ -15,6 +15,7 @@ const wordpressEnvironment: EnvironmentSpec = {
   phpVersion: "8.3",
   blueprint: { preferredVersions: { php: "8.3" } },
   wordpressInstallMode: "install-from-existing-files-if-needed",
+  databaseSetup: "external",
   assets: {
     directory: "/workspace/site",
     archive: "/tmp/site.zip",

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -7,6 +7,32 @@ import { mkdtempSync } from "node:fs"
 import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
 import { bootstrapPhpCode, phpCodeFromArgs } from "../packages/runtime-playground/src/php-bootstrap.js"
+import { phpEnvAssignmentFunction, phpEnvAssignments } from "../packages/runtime-playground/src/php-snippets.js"
+
+const environmentSnippet = phpEnvAssignments({ EXAMPLE_RUNTIME_ENV: "available" })
+const environmentOutput = execFileSync(
+  "php",
+  [
+    "-r",
+    `${environmentSnippet}
+echo json_encode(array(getenv('EXAMPLE_RUNTIME_ENV'), $_ENV['EXAMPLE_RUNTIME_ENV'], $_SERVER['EXAMPLE_RUNTIME_ENV']));`,
+  ],
+  { encoding: "utf8" },
+)
+assert.deepEqual(JSON.parse(environmentOutput), ["available", "available", "available"])
+
+const environmentFunctionSnippet = phpEnvAssignmentFunction("apply_runtime_env")
+const environmentFunctionOutput = execFileSync(
+  "php",
+  [
+    "-r",
+    `${environmentFunctionSnippet}
+apply_runtime_env(array('EXAMPLE_RUNTIME_MAP_ENV' => 'available'));
+echo json_encode(array(getenv('EXAMPLE_RUNTIME_MAP_ENV'), $_ENV['EXAMPLE_RUNTIME_MAP_ENV'], $_SERVER['EXAMPLE_RUNTIME_MAP_ENV']));`,
+  ],
+  { encoding: "utf8" },
+)
+assert.deepEqual(JSON.parse(environmentFunctionOutput), ["available", "available", "available"])
 
 const lifecycleReplaySnippet = phpRuntimeComponentLifecycleReplayFunction("contained_runtime_test")
 assert.match(lifecycleReplaySnippet, /function contained_runtime_test_component_lifecycle_replay_prepare\(\): array/)

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -22,7 +22,14 @@ const unsafe = validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace
 assert.equal(unsafe.valid, false)
 const emptyRootService = { ...service, configuration: { rootAuthentication: "empty-password" as const } }
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [emptyRootService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+const indexedForeignKeyService = { ...service, configuration: { foreignKeyTargetPolicy: "indexed" as const } }
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [indexedForeignKeyService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+const mariaDbService = { ...service, configuration: { engine: "mariadb" as const, rootAuthentication: "empty-password" as const } }
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [mariaDbService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+assert.equal(runtimeServicePlan([mariaDbService])[0]?.version, "mariadb:11.4")
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [{ ...service, configuration: { foreignKeyTargetPolicy: "anything" } }] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, false)
 assert.deepEqual(buildWordPressPhpunitRecipe({ pluginSlug: "example", services: [emptyRootService] }).inputs?.services, [emptyRootService])
+assert.equal(buildWordPressPhpunitRecipe({ pluginSlug: "example", wordpressInstallMode: "do-not-attempt-installing" }).runtime?.wordpressInstallMode, "do-not-attempt-installing")
 const builderDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-phpunit-builder-"))
 try {
   const optionsPath = join(builderDirectory, "options.json")
@@ -124,6 +131,35 @@ assert.equal(emptyRootRun?.args.includes("MYSQL_ROOT_PASSWORD"), false)
 assert.equal(emptyRootRun?.env?.MYSQL_ALLOW_EMPTY_PASSWORD, "yes")
 assert.equal(emptyRootRun?.env?.MYSQL_ROOT_PASSWORD, undefined)
 await emptyRoot.release()
+
+const indexedForeignKeyCalls: Array<{ args: string[] }> = []
+const indexedForeignKeyDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  async execute(command, args, options) {
+    indexedForeignKeyCalls.push({ args })
+    return dependencies.execute(command, args, options)
+  },
+}
+const indexedForeignKey = await provisionRuntimeServices([indexedForeignKeyService], { dependencies: indexedForeignKeyDependencies })
+const indexedForeignKeyRun = indexedForeignKeyCalls.find((call) => call.args[0] === "run")
+assert.deepEqual(indexedForeignKeyRun?.args.slice(-2), ["mysql:8.4", "--restrict-fk-on-non-standard-key=OFF"], "indexed foreign-key targets opt into the MySQL compatibility mode")
+await indexedForeignKey.release()
+
+const mariaDbCalls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = []
+const mariaDbDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  async execute(command, args, options) {
+    mariaDbCalls.push({ args, env: options.env })
+    return dependencies.execute(command, args, options)
+  },
+}
+const mariaDb = await provisionRuntimeServices([mariaDbService], { dependencies: mariaDbDependencies })
+const mariaDbRun = mariaDbCalls.find((call) => call.args[0] === "run")
+assert.ok(mariaDbRun?.args.includes("mariadb:11.4"))
+assert.ok(mariaDbRun?.args.includes("MARIADB_ALLOW_EMPTY_ROOT_PASSWORD"))
+assert.equal(mariaDbRun?.env?.MARIADB_ALLOW_EMPTY_ROOT_PASSWORD, "yes")
+assert.equal(mariaDbRun?.env?.MYSQL_ALLOW_EMPTY_PASSWORD, undefined)
+await mariaDb.release()
 
 const interruptedAfterProvision = new AbortController()
 const provisionedBeforeAbort = await provisionRuntimeServices([service], { dependencies, signal: interruptedAfterProvision.signal })


### PR DESCRIPTION
## Summary

- let managed MySQL services select MySQL or MariaDB and engine-specific startup policy
- model externally managed database setup so Playground skips SQLite initialization
- preserve PHPUnit WordPress install mode and runtime environment across CLI and programmatic runners
- expose managed env through `getenv()`, `$_ENV`, and `$_SERVER`
- add focused contract coverage and a disposable MySQL/MariaDB integration proof

Fixes #1911.

## How to test

1. Run `npm ci`.
2. Run `npm run build`.
3. Run `npm run test:runtime-services`.
4. Run `npm run test:runtime-services-lifecycle`.
5. Run `npm run test:runtime-php-snippets`.
6. Run `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts`.
7. Run `npx tsx tests/runtime-neutral-contracts.test.ts`.
8. Run `npx tsx tests/phpunit-project-autoload.test.ts`.
9. With Docker available, run `npm run test:disposable-mysql-mysqli-e2e`.

## Backwards compatibility

Existing service recipes continue to use `mysql:8.4`, generated root authentication, runtime-managed database setup, and current WordPress installation behavior by default. MariaDB, external database setup, and foreign-key compatibility are explicit opt-ins. No extension paths are changed.

## Verification

The build and focused deterministic tests pass locally. The disposable database test is skipped locally when `docker info` is unavailable; a runner-backed Docker result will be added separately.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Rebased the pending runtime work onto current main, resolved conflicts, tightened scope, added verification, and prepared the PR.