### PR TITLE
Preserve Playground PHPUnit crash diagnostics

### DIFF
--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -1,4 +1,4 @@
-import { isSensitiveKey } from "@automattic/wp-codebox-core"
+import { isSensitiveKey, redactString } from "@automattic/wp-codebox-core"
 import { errorMessage, parseJsonObject } from "@automattic/wp-codebox-core/internals"
 
 export { errorMessage }
@@ -19,8 +19,17 @@ export interface PlaygroundCliBufferedOutput {
   truncated?: boolean
 }
 
+export interface PlaygroundCommandRequestMetadata {
+  operation: "code" | "script"
+  payloadBytes: number
+  runtimeUrl?: string
+}
+
+export type PlaygroundFailureClassification = "runtime-command-failure" | "runtime-worker-failure"
+
 export class PlaygroundCommandError extends Error {
   readonly code = "wp-codebox-playground-command-failed"
+  readonly failureClassification: PlaygroundFailureClassification = "runtime-command-failure"
 
   constructor(readonly command: string, readonly response: PlaygroundRunResponse) {
     super(playgroundFailureMessage(command, response))
@@ -30,9 +39,10 @@ export class PlaygroundCommandError extends Error {
 
 export class PlaygroundCommandCrashError extends Error {
   readonly code = "wp-codebox-playground-command-crashed"
+  readonly failureClassification: PlaygroundFailureClassification = "runtime-worker-failure"
 
-  constructor(readonly command: string, readonly cause: unknown) {
-    super(playgroundCrashMessage(command, cause))
+  constructor(readonly command: string, readonly cause: unknown, readonly request?: PlaygroundCommandRequestMetadata) {
+    super(playgroundCrashMessage(command, cause, request))
     this.name = "PlaygroundCommandCrashError"
   }
 }
@@ -90,8 +100,24 @@ export function extractPhpunitFailureMessage(log: string): string | undefined {
   return messages.join(" | ")
 }
 
+/**
+ * Keep a PHP-side diagnostics file alongside, rather than in place of, the
+ * original command or worker failure. Consumers commonly serialize only the
+ * Error message, so this makes both boundaries available to them.
+ */
+export function attachPlaygroundDiagnostics(error: unknown, label: string, diagnostics: string): Error {
+  const source = error instanceof Error ? error : new Error(errorMessage(error))
+  const detail = truncateDiagnostic(redactDiagnosticText(diagnostics.trim()))
+  if (!detail || source.message.includes(`--- ${label} ---`)) {
+    return source
+  }
+
+  source.message = `${source.message}\n\n--- ${label} ---\n${detail}`
+  return source
+}
+
 function playgroundFailureMessage(command: string, response: PlaygroundRunResponse): string {
-  const lines = [`${command} failed with exit code ${response.exitCode ?? "unknown"}`]
+  const lines = [`${command} failed with exit code ${response.exitCode ?? "unknown"}`, "failureClassification=runtime-command-failure"]
   const diagnostics = playgroundResponseDiagnostics(response)
 
   if (diagnostics.length > 0) {
@@ -136,8 +162,15 @@ function playgroundResponseDiagnostics(response: PlaygroundRunResponse): string[
   return [...metadata, ...sections]
 }
 
-function playgroundCrashMessage(command: string, cause: unknown): string {
-  const lines = [`${command} crashed before producing a structured response`, "", errorMessage(cause)]
+function playgroundCrashMessage(command: string, cause: unknown, request?: PlaygroundCommandRequestMetadata): string {
+  const lines = [`${command} crashed before producing a structured response`, "failureClassification=runtime-worker-failure", "", redactDiagnosticText(errorMessage(cause))]
+  const worker = workerErrorDiagnostics(cause)
+  if (worker.length > 0) {
+    lines.push("", "--- Playground worker error ---", ...worker)
+  }
+  if (request) {
+    lines.push("", "--- Playground request metadata ---", `operation=${request.operation}`, `payloadBytes=${request.payloadBytes}`, ...(request.runtimeUrl ? [`runtimeUrl=${redactDiagnosticText(request.runtimeUrl)}`] : []))
+  }
   const diagnostics = playgroundCrashDiagnostics(cause)
 
   if (diagnostics.length > 0) {
@@ -145,6 +178,29 @@ function playgroundCrashMessage(command: string, cause: unknown): string {
   }
 
   return lines.join("\n")
+}
+
+function workerErrorDiagnostics(cause: unknown): string[] {
+  if (!(cause instanceof Error)) {
+    return []
+  }
+
+  const lines = [`name=${cause.name || "Error"}`, `message=${redactDiagnosticText(cause.message)}`]
+  const stack = typeof cause.stack === "string" ? truncateDiagnostic(redactDiagnosticText(cause.stack.trim())) : undefined
+  if (stack) {
+    lines.push("stack:", stack)
+  }
+  return lines
+}
+
+function redactDiagnosticText(value: string): string {
+  const exitStatuses: string[] = []
+  const protectedValue = value.replace(/\bexit code (\d+)\b/gi, (_match, exitCode: string) => {
+    const index = exitStatuses.push(exitCode) - 1
+    return `exit status WP_CODEBOX_EXIT_STATUS_${index}`
+  })
+  const redacted = redactString(protectedValue, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
+  return redacted.replace(/exit status WP_CODEBOX_EXIT_STATUS_(\d+)/g, (_match, index: string) => `exit code ${exitStatuses[Number(index)] ?? "unknown"}`)
 }
 
 function playgroundCrashDiagnostics(cause: unknown): string[] {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1765,7 +1765,12 @@ class PlaygroundRuntime implements Runtime {
     try {
       return await abortable(server.playground.run(options), this.activeExecutionSignal)
     } catch (error) {
-      throw new PlaygroundCommandCrashError(command, error)
+      const payload = "code" in options ? options.code : options.scriptPath
+      throw new PlaygroundCommandCrashError(command, error, {
+        operation: "code" in options ? "code" : "script",
+        payloadBytes: Buffer.byteLength(payload, "utf8"),
+        runtimeUrl: server.serverUrl,
+      })
     }
   }
 

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -50,7 +50,7 @@ import {
   themeSetupInputFromArgs,
 } from "./commands.js"
 import { bootstrapAbilityPhpCode, bootstrapPhpCode, phpCodeFromArgs, splitLeadingStrictTypesDeclare } from "./php-bootstrap.js"
-import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
+import { assertPlaygroundResponseOk, attachPlaygroundDiagnostics, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { persistCorePhpunitResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitDiagnostic } from "./runtime-diagnostics.js"
 import type { RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
@@ -946,7 +946,7 @@ export async function runPhpunitCommand({
     await persistVfsDiagnosticFileToHost(server, resultFile, `/wordpress/wp-content/plugins/${pluginSlug}/.pg-test-result.txt`, mounts)
     const structured = await readPluginPhpunitDiagnostic(server, resultFile)
     if (structured) {
-      throw new Error(`wordpress.phpunit could not run: ${structured}`)
+      throw attachPlaygroundDiagnostics(error, "wordpress.phpunit structured diagnostics", structured)
     }
     throw error
   }
@@ -1002,7 +1002,7 @@ export async function runCorePhpunitCommand({
     await persistCorePhpunitResult(server, resultFile, artifactRoot)
     const structured = await readCorePhpunitDiagnostic(server, resultFile)
     if (structured) {
-      throw new Error(`wordpress.core-phpunit could not run: ${structured}`)
+      throw attachPlaygroundDiagnostics(error, "wordpress.core-phpunit structured diagnostics", structured)
     }
     throw error
   }

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -188,6 +188,76 @@ await assert.rejects(
 assert.match(receivedRunPhpCode, /RuntimeException/)
 await runtime.destroy()
 
+const phpunitFailureCliModule: PlaygroundCliModule = {
+  runCLI: async () => ({
+    serverUrl: "http://127.0.0.1:9401",
+    playground: {
+      run: async () => ({
+        exitCode: 1,
+        errors: "PHP Fatal error: PHPUnit bootstrap fixture failed in /wordpress/wp-content/plugins/demo/tests/bootstrap.php on line 12",
+        text: "PHPUnit bootstrap fixture output",
+      }),
+    },
+    [Symbol.asyncDispose]: async () => undefined,
+  }),
+}
+
+const phpunitFailureRuntime = await createRuntime({
+  backend: "wordpress-playground",
+  environment: { kind: "wordpress", name: "phpunit-bootstrap-failure", version: "7.0", blueprint: { steps: [] } },
+  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.phpunit"], secrets: "none", approvals: "never" },
+}, createPlaygroundRuntimeBackend({ cliModule: phpunitFailureCliModule }))
+
+await assert.rejects(
+  () => phpunitFailureRuntime.execute({ command: "wordpress.phpunit", args: ["plugin-slug=demo"] }),
+  (error) => {
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /failureClassification=runtime-command-failure/)
+    assert.match(error.message, /PHP fatal: PHPUnit bootstrap fixture failed/)
+    assert.match(error.message, /PHPUnit bootstrap fixture output/)
+    return true
+  },
+)
+await phpunitFailureRuntime.destroy()
+
+const comlinkFailure = new Error("Comlink method call failed")
+comlinkFailure.name = "ComlinkMethodError"
+comlinkFailure.stack = "ComlinkMethodError: Comlink method call failed\n    at worker.run (worker.js:42:7) token=worker-secret"
+const workerFailureCliModule: PlaygroundCliModule = {
+  runCLI: async () => ({
+    serverUrl: "http://127.0.0.1:9402",
+    playground: {
+      run: async () => { throw comlinkFailure },
+      readFileAsText: async () => "STAGE_FATAL:project_bootstrap:PHPUnit bootstrap fixture failed at /wordpress/wp-content/plugins/demo/tests/bootstrap.php:12\n",
+    },
+    [Symbol.asyncDispose]: async () => undefined,
+  }),
+}
+
+const workerFailureRuntime = await createRuntime({
+  backend: "wordpress-playground",
+  environment: { kind: "wordpress", name: "phpunit-worker-failure", version: "7.0", blueprint: { steps: [] } },
+  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.phpunit"], secrets: "none", approvals: "never" },
+}, createPlaygroundRuntimeBackend({ cliModule: workerFailureCliModule }))
+
+await assert.rejects(
+  () => workerFailureRuntime.execute({ command: "wordpress.phpunit", args: ["plugin-slug=demo"] }),
+  (error) => {
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /failureClassification=runtime-worker-failure/)
+    assert.match(error.message, /name=ComlinkMethodError/)
+    assert.match(error.message, /message=Comlink method call failed/)
+    assert.match(error.message, /worker\.run/)
+    assert.match(error.message, /operation=code/)
+    assert.match(error.message, /runtimeUrl=http:\/\/127\.0\.0\.1:\d+/)
+    assert.match(error.message, /wordpress\.phpunit structured diagnostics/)
+    assert.match(error.message, /PHPUnit bootstrap fixture failed/)
+    assert.doesNotMatch(error.message, /worker-secret/)
+    return true
+  },
+)
+await workerFailureRuntime.destroy()
+
 const bootstrappedRunPhp = bootstrapPhpCode({ kind: "wordpress", name: "fatal-diagnostic", version: "7.0", blueprint: { steps: [] } }, "throw new RuntimeException('boom');", [])
 assert.match(bootstrappedRunPhp, /register_shutdown_function/)
 assert.match(bootstrappedRunPhp, /WP_CODEBOX_PHP_FATAL_DIAGNOSTIC/)


### PR DESCRIPTION
## Summary
- Preserve the original Playground command or worker error when PHPUnit bootstrap diagnostics are recovered from the runtime.
- Classify nonzero command responses separately from worker/Comlink failures, with bounded request metadata and worker name, message, and stack.
- Redact token-like values and URL query values in newly surfaced worker and bootstrap diagnostics.

Closes #1916

## Testing
1. Run `npm ci` from a fresh checkout.
2. Run `npx tsx scripts/playground-command-errors-smoke.ts` to exercise a PHPUnit bootstrap failure and a Comlink worker failure through `runtime.execute()`.
3. Run `npx tsx tests/phpunit-project-autoload.test.ts` to verify PHPUnit command generation and handler behavior.
4. Run `npm run build` and `npm run test:redaction`.

## Compatibility
This is additive diagnostic behavior for existing Playground command failures. Command success behavior and public command inputs remain unchanged; failed commands now retain more actionable error context.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Implemented shared Playground failure diagnostics, deterministic boundary tests, redaction review, and verification; Chris reviews and owns the change.