### PR TITLE
Preserve binary staged file bytes

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -237,8 +237,17 @@ async function materializeHostMountToVfs(server: PlaygroundCliServer, mount: Mou
       skipped++
       return
     }
+    const contents = Buffer.from(payload.contentsBase64, "base64")
+    const text = contents.toString("utf8")
+    if (!Buffer.from(text, "utf8").equals(contents)) {
+      fileBatch.push(payload)
+      if (fileBatch.length >= HOST_MOUNT_FILE_BATCH_SIZE) {
+        await flushFileBatch()
+      }
+      return
+    }
     try {
-      await server.playground.writeFile(target, Buffer.from(payload.contentsBase64, "base64").toString("utf8"))
+      await server.playground.writeFile(target, text)
       materialized++
     } catch {
       const fallback = await materializeHostMountFilesWithPhp(server, [payload], [])

--- a/tests/playground-readonly-mounts-integration.test.ts
+++ b/tests/playground-readonly-mounts-integration.test.ts
@@ -13,12 +13,14 @@ const projectConfigSource = join(projectSource, "config.php")
 const overlaySource = join(root, "config-overlay.php")
 const readonlySource = join(root, "readonly.bin")
 const readwriteSource = join(root, "readwrite.bin")
+const stagedBinarySource = join(root, "staged-binary.bin")
 const recipePath = join(root, "recipe.json")
 const artifactsPath = join(root, "artifacts")
 const originalConfig = "<?php return 'parent';\n"
 const overlayConfig = "<?php return 'overlay';\n"
 const readonlyBytes = Buffer.from([0, 255, 1, 2, 3, 127, 128])
 const overwrittenBytes = Buffer.from([128, 127, 3, 2, 1, 255, 0])
+const stagedBinaryBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x80, 0xfe])
 const stagingDirectoriesBefore = await readonlyStagingDirectories()
 
 try {
@@ -27,6 +29,7 @@ try {
   await writeFile(overlaySource, overlayConfig)
   await writeFile(readonlySource, readonlyBytes)
   await writeFile(readwriteSource, readonlyBytes)
+  await writeFile(stagedBinarySource, stagedBinaryBytes)
   await writeFile(recipePath, `${JSON.stringify({
     schema: "wp-codebox/workspace-recipe/v1",
     runtime: { backend: "wordpress-playground", wp: "6.5", blueprint: { steps: [] } },
@@ -37,11 +40,14 @@ try {
         { source: readonlySource, target: "/wordpress/readonly.bin", mode: "readonly" },
         { source: readwriteSource, target: "/wordpress/readwrite.bin", mode: "readwrite" },
       ],
+      stagedFiles: [
+        { source: stagedBinarySource, target: "/wordpress/staged-binary.bin" },
+      ],
     },
     workflow: {
       steps: [{
         command: "wordpress.run-php",
-        args: [`code=$config = file_get_contents('/home/project/config.php'); if ($config !== "<?php return 'overlay';\\n") { fwrite(STDERR, $config); exit(1); } $contents = base64_decode('${overwrittenBytes.toString("base64")}'); file_put_contents('/home/project/config.php', "overwritten"); file_put_contents('/home/project/mutated.txt', 'parent mutation'); file_put_contents('/wordpress/readonly.bin', $contents); file_put_contents('/wordpress/readwrite.bin', $contents);`],
+        args: [`code=$config = file_get_contents('/home/project/config.php'); if ($config !== "<?php return 'overlay';\\n") { fwrite(STDERR, $config); exit(1); } $staged = file_get_contents('/wordpress/staged-binary.bin'); if ($staged !== base64_decode('${stagedBinaryBytes.toString("base64")}')) { fwrite(STDERR, 'staged binary bytes changed'); exit(1); } $contents = base64_decode('${overwrittenBytes.toString("base64")}'); file_put_contents('/home/project/config.php', "overwritten"); file_put_contents('/home/project/mutated.txt', 'parent mutation'); file_put_contents('/wordpress/readonly.bin', $contents); file_put_contents('/wordpress/readwrite.bin', $contents);`],
       }],
     },
   })}\n`)

--- a/tests/staged-input-materialization.test.ts
+++ b/tests/staged-input-materialization.test.ts
@@ -80,4 +80,39 @@ await withTempDir("wp-codebox-staged-input-materialization-fallback-", async (ro
   assert.equal(written.get("/workspace/wp-site-generator/bundles/store-idea-agent/manifest.json"), `${JSON.stringify({ schema: "test/runtime-bundle/v1" })}\n`)
 })
 
+await withTempDir("wp-codebox-staged-input-materialization-binary-", async (root) => {
+  const source = join(root, "image.bin")
+  const contents = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x80, 0xfe])
+  await writeFile(source, contents)
+
+  let directWrites = 0
+  let binaryWriteCode = ""
+  const server = {
+    playground: {
+      async run({ code }: { code: string }) {
+        if (code.includes("wp-codebox/host-mount-materialization/v1")) {
+          binaryWriteCode = code
+          return { text: JSON.stringify({ schema: "wp-codebox/host-mount-materialization/v1", materialized: 1, created: 0, skipped: 0 }) }
+        }
+        return { text: JSON.stringify({ schema: "wp-codebox/host-mount-directory-materialization/v1", created: 1, skipped: 0 }) }
+      },
+      async writeFile() {
+        directWrites++
+      },
+    },
+  }
+
+  const result = await materializePlaygroundStagedInputs(server as never, [{
+    type: "file",
+    source,
+    target: "/wordpress/wp-content/uploads/image.bin",
+    mode: "readwrite",
+  }])
+
+  assert.equal(result.materialized, 1)
+  assert.equal(result.skipped, 0)
+  assert.equal(directWrites, 0, "arbitrary bytes bypass the UTF-8-only direct writer")
+  assert.ok(binaryWriteCode.includes(contents.toString("base64")), "the PHP materializer receives the exact base64 payload")
+})
+
 console.log("staged input materialization ok")


### PR DESCRIPTION
## Summary

- preserve arbitrary binary bytes when materializing recipe `stagedFiles` into WordPress Playground
- retain the direct `playground.writeFile` path for content that round-trips losslessly through UTF-8
- batch non-UTF-8 payloads through the existing base64/PHP materializer
- verify invalid UTF-8 bytes in both focused unit coverage and a real Playground recipe

Fixes #1919.

## Root cause

The staged-input materializer decoded every base64 payload with `Buffer.toString("utf8")` before calling Playground’s string-only `writeFile` API. Invalid UTF-8 bytes were replaced, changing file size and SHA-256 and breaking staged images.

## How to test

1. Run `npm run build`.
2. Run `npx tsx tests/mount-materialization.test.ts`.
3. Run `npx tsx tests/staged-input-materialization.test.ts`.
4. Run `npm run test:playground-readonly-mounts`.
5. Run `npm run test:playground-readonly-mounts-integration`. The integration recipe reads a binary `stagedFiles` target inside Playground PHP and fails unless every byte matches the host source.

## Compatibility

This corrects the existing `stagedFiles` contract without changing its recipe schema or public API. Valid UTF-8 text continues using the existing direct writer; binary payloads now use the existing base64 materialization path.

## AI disclosure

Implemented with OpenCode using `openai/gpt-5.6-sol`; all listed tests were run locally.