### PR TITLE
Retain non-fatal PHPUnit bootstrap exits

### DIFF
--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -37,6 +37,7 @@ ${runtimeEnvPhp(spec, args)}
 ${secretEnvPhp(spec)}
 ${componentManifestPhp(spec)}
 require_once '/wordpress/wp-load.php';
+${failureDiagnosticFile ? phpFailureDiagnosticCompletionPhp() : ""}
 ${recipeActivePluginBootstrapPhp(spec, args)}
 ${wpCliBridge ? `putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_URL=${wpCliBridge.url}`)});
 putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)});
@@ -45,13 +46,44 @@ ${command.body}`
 }
 
 function phpFailureDiagnosticFilePhp(path: string): string {
-  return `register_shutdown_function(static function (): void {
-    $wp_codebox_failure = error_get_last();
-    if (!is_array($wp_codebox_failure) || !in_array($wp_codebox_failure['type'] ?? 0, array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR), true)) {
+  return `$wp_codebox_bootstrap_complete = false;
+$wp_codebox_bootstrap_buffer_level = ob_get_level();
+ob_start();
+register_shutdown_function(static function () use (&$wp_codebox_bootstrap_complete, $wp_codebox_bootstrap_buffer_level): void {
+    if ($wp_codebox_bootstrap_complete) {
         return;
     }
-    @file_put_contents(${JSON.stringify(path)}, 'STAGE_FATAL:bootstrap:' . (string) ($wp_codebox_failure['message'] ?? '') . ' at ' . (string) ($wp_codebox_failure['file'] ?? '') . ':' . (int) ($wp_codebox_failure['line'] ?? 0) . "\\n", FILE_APPEND);
+    $wp_codebox_bootstrap_output = '';
+    while (ob_get_level() > $wp_codebox_bootstrap_buffer_level) {
+        $wp_codebox_bootstrap_chunk = ob_get_clean();
+        if ($wp_codebox_bootstrap_chunk !== false) {
+            $wp_codebox_bootstrap_output = $wp_codebox_bootstrap_chunk . $wp_codebox_bootstrap_output;
+        }
+    }
+    $wp_codebox_failure = error_get_last();
+    if (is_array($wp_codebox_failure) && in_array($wp_codebox_failure['type'] ?? 0, array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR), true)) {
+        $wp_codebox_bootstrap_diagnostic = 'STAGE_FATAL:bootstrap:' . (string) ($wp_codebox_failure['message'] ?? '') . ' at ' . (string) ($wp_codebox_failure['file'] ?? '') . ':' . (int) ($wp_codebox_failure['line'] ?? 0);
+    } else {
+        $wp_codebox_bootstrap_detail = trim((string) preg_replace('/\\s+/', ' ', strip_tags($wp_codebox_bootstrap_output)));
+        if ($wp_codebox_bootstrap_detail === '') {
+            $wp_codebox_bootstrap_detail = 'WordPress bootstrap terminated before completion without emitting output';
+        }
+        $wp_codebox_bootstrap_diagnostic = 'STAGE_DIE:bootstrap:' . substr($wp_codebox_bootstrap_detail, 0, 16384);
+    }
+    @file_put_contents(${JSON.stringify(path)}, $wp_codebox_bootstrap_diagnostic . "\\n", FILE_APPEND);
 });`
+}
+
+function phpFailureDiagnosticCompletionPhp(): string {
+  return `$wp_codebox_bootstrap_complete = true;
+$wp_codebox_bootstrap_output = '';
+while (ob_get_level() > $wp_codebox_bootstrap_buffer_level) {
+    $wp_codebox_bootstrap_chunk = ob_get_clean();
+    if ($wp_codebox_bootstrap_chunk !== false) {
+        $wp_codebox_bootstrap_output = $wp_codebox_bootstrap_chunk . $wp_codebox_bootstrap_output;
+    }
+}
+echo $wp_codebox_bootstrap_output;`
 }
 
 export function splitLeadingStrictTypesDeclare(code: string): { strictTypesDeclare: string; body: string } {

--- a/tests/playground-phpunit-bootstrap-failure.integration.test.ts
+++ b/tests/playground-phpunit-bootstrap-failure.integration.test.ts
@@ -11,6 +11,7 @@ const root = await mkdtemp(join(tmpdir(), "wp-codebox-phpunit-bootstrap-failure-
 const fatalMuPlugin = join(root, "fatal-bootstrap.php")
 const recipePath = join(root, "recipe.json")
 const artifactsPath = join(root, "artifacts")
+const exitArtifactsPath = join(root, "exit-artifacts")
 
 try {
   await writeFile(fatalMuPlugin, `<?php\ntrigger_error('PHPUnit bootstrap fixture token: ${secret}', E_USER_ERROR);\n`)
@@ -49,13 +50,28 @@ try {
   assert.match(commandLog, /wordpress\.phpunit structured diagnostics/)
   assert.match(commandLog, /PHPUnit bootstrap fixture token: \[redacted\]/)
   assert.doesNotMatch(commandLog, new RegExp(secret))
+
+  await writeFile(fatalMuPlugin, `<?php\necho 'PHPUnit bootstrap exit fixture token: ${secret}';\nexit(1);\n`)
+  const exitOutput = await runFailedRecipe(exitArtifactsPath)
+  assert.equal(exitOutput.success, false, JSON.stringify(exitOutput))
+  const exitMessage = exitOutput.error?.message ?? ""
+  assert.match(exitMessage, /wordpress\.phpunit structured diagnostics/)
+  assert.match(exitMessage, /PHPUnit bootstrap exit fixture token: \[redacted\]/)
+  assert.doesNotMatch(exitMessage, new RegExp(secret))
+
+  const exitLatest = JSON.parse(await readFile(join(exitArtifactsPath, "latest-runtime.json"), "utf8")) as { paths?: { runtimeDirectory?: string } }
+  const exitRuntimeDirectory = exitLatest.paths?.runtimeDirectory
+  assert.ok(exitRuntimeDirectory, "terminated recipe must retain a runtime artifact directory")
+  const exitDiagnostic = await readFile(join(exitArtifactsPath, exitRuntimeDirectory, "files", "phpunit", ".pg-test-result.txt"), "utf8")
+  assert.match(exitDiagnostic, /STAGE_DIE:bootstrap:PHPUnit bootstrap exit fixture token: \[redacted\]/)
+  assert.doesNotMatch(exitDiagnostic, new RegExp(secret))
 } finally {
   await rm(root, { recursive: true, force: true })
 }
 
-async function runFailedRecipe(): Promise<RecipeRunOutput> {
+async function runFailedRecipe(outputPath = artifactsPath): Promise<RecipeRunOutput> {
   try {
-    const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--artifacts", artifactsPath, "--json"], {
+    const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--artifacts", outputPath, "--json"], {
       cwd: process.cwd(),
       timeout: 300_000,
       maxBuffer: 2 * 1024 * 1024,


### PR DESCRIPTION
## Summary

- treat `wp-load.php` as an explicit completion boundary for PHPUnit commands
- buffer and persist bounded output when bootstrap terminates via `die()` or `exit()` without a PHP fatal
- preserve existing output after successful bootstrap
- extend the real Playground integration with an `exit(1)` MU-plugin fixture

## Root cause

#1918 recorded only fatal `error_get_last()` types. Intelligence CI terminates before `wp-load.php` returns without a fatal payload, so the recorder returned without writing and downstream diagnostics remained empty even on current WP Codebox `main`.

## Verification

- `npm run build`
- `npm run test:phpunit-runtime-failure-diagnostics`
- `npm run test:playground-phpunit-bootstrap-failure-integration`
- `git diff --check`

Fixes #1916