### PR TITLE
Restore configless managed PHPUnit discovery

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -59,6 +59,7 @@ interface PhpunitConfigDiscoveryPhpOptions {
   basePathExpression: string
   uniqueReturnValues: boolean
   replaceDefaultMatchers: boolean
+  allowMissingImplicitConfig: boolean
 }
 
 interface PhpunitChangedTestFilterPhpOptions {
@@ -76,6 +77,11 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
         if (is_readable($alternate)) {
             $xml_path = $alternate;
         }
+    }` : ""
+  const missingImplicitConfig = options.allowMissingImplicitConfig ? `
+    if (!is_readable($xml_path)) {
+        ${options.logFunction}('NOTICE:using managed PHPUnit discovery defaults; no implicit config found at ' . $xml_path);
+        return $return_values();
     }` : ""
   const directoryRestriction = options.restrictDirectoriesToTests ? `
         $normalized = trim(str_replace('\\\\', '/', $raw), '/');
@@ -99,7 +105,7 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
     $files = array();
     $return_values = static function() use (&$directories, &$suffixes, &$prefixes, &$excludes, &$files) {
         return ${returnValues};
-    };${fallbackXmlDist}
+    };${fallbackXmlDist}${missingImplicitConfig}
     if (!is_readable($xml_path)) {
         throw new RuntimeException('PHPUnit config is not readable: ' . $xml_path);
     }
@@ -1208,6 +1214,7 @@ ${phpunitConfigDiscoveryPhp({
     basePathExpression: "dirname($xml_path)",
     uniqueReturnValues: false,
     replaceDefaultMatchers: true,
+    allowMissingImplicitConfig: options.phpunitXmlIsDefault,
   })}
 
 ${phpunitDiscoveryPhp("wp_codebox_phpunit_discover", "pg_log")}
@@ -1468,6 +1475,7 @@ ${phpunitConfigDiscoveryPhp({
     basePathExpression: "dirname($xml_path)",
     uniqueReturnValues: true,
     replaceDefaultMatchers: false,
+    allowMissingImplicitConfig: false,
   })}
 
 ${phpunitDiscoveryPhp("core_pg_discover_tests", "core_pg_log")}

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -97,6 +97,7 @@ function assert_phpunit_error($callback, $expected, $label) {
     }
     throw new RuntimeException($label . ' unexpectedly succeeded');
 }
+
 ${!supportsImplicitFallback ? `assert_phpunit_error(function() { ${functionName}(${phpString(explicitMissingXml)}, ${phpString(join(tempDir, "tests"))}); }, 'PHPUnit config is not readable', 'explicit missing config');` : ""}
 assert_phpunit_error(function() { ${functionName}(${phpString(malformedXml)}, ${phpString(join(tempDir, "tests"))}); }, 'PHPUnit config could not be parsed', 'malformed config');
 assert_phpunit_error(function() { ${discoveryFunctionName}(array(${phpString(join(tempDir, "missing-tests"))}), array('Test.php'), array('test-'), array()); }, 'configured PHPUnit test directory is not a readable directory', 'missing configured directory');
@@ -111,6 +112,27 @@ assert_phpunit_error(function() { ${functionName}(${phpString(defaultXml)}, ${ph
 echo "ok\n";
 `)
 
+  assert.equal(execFileSync("php", [scriptPath], { encoding: "utf8" }), "ok\n")
+}
+
+function assertConfiglessPluginUsesManagedDiscovery(source: string): void {
+  const tempDir = mkdtempSync(join(tmpdir(), "wp-codebox-configless-plugin-"))
+  const testsDir = join(tempDir, "tests")
+  const testFile = join(testsDir, "ExampleTest.php")
+  const scriptPath = join(tempDir, "assert-configless-discovery.php")
+  mkdirSync(testsDir)
+  writeFileSync(testFile, "<?php final class ExampleTest extends WP_UnitTestCase {}\n")
+  writeFileSync(scriptPath, `<?php
+function pg_log($message) {}
+${extractPhpFunction(source, "wp_codebox_phpunit_parse_config")}
+${extractPhpFunction(source, "wp_codebox_phpunit_discover")}
+list($directories, $suffixes, $prefixes, $excludes, $files) = wp_codebox_phpunit_parse_config(${phpString(join(tempDir, "phpunit.xml.dist"))}, ${phpString(testsDir)});
+$discovered = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes, $files);
+if ($discovered !== array(${phpString(testFile)})) {
+    throw new RuntimeException('managed discovery did not find the configless plugin test: ' . json_encode($discovered));
+}
+echo "ok\n";
+`)
   assert.equal(execFileSync("php", [scriptPath], { encoding: "utf8" }), "ok\n")
 }
 
@@ -437,6 +459,7 @@ const implicitProjectConfigCode = phpunitRunCode({
   projectBootstrap: "",
   multisite: false,
 })
+assertConfiglessPluginUsesManagedDiscovery(implicitProjectConfigCode)
 
 const bootIndex = projectModeCode.indexOf("$config_path = pg_run_boot_stage")
 const projectBootstrapIndex = projectModeCode.indexOf("pg_run_project_bootstrap_stage", bootIndex)


### PR DESCRIPTION
## Summary
- let implicit plugin PHPUnit profiles use managed discovery defaults when neither default XML file exists
- keep explicit plugin and WordPress core configuration failures fail-closed
- execute generated PHP discovery against a real configless `WP_UnitTestCase` fixture

## Root cause
PR #1940 required the implicit `phpunit.xml.dist` path to be readable, but the recipe builder only supplies that path and never materializes the file. Configless plugin suites therefore failed before discovery.

## Verification
- `npm run build`
- `npx tsx tests/phpunit-project-autoload.test.ts`
- `npm run test:phpunit-runtime-failure-diagnostics`
- `npm run test:playground-phpunit-bootstrap-failure-integration`
- `npm run test:playground-phpunit-readonly-cache-integration`
- `git diff --check`

Closes #1943.
Downstream proof tracker: https://github.com/Extra-Chill/homeboy-extensions/issues/2343

## AI assistance
- AI assistance: Yes
- Tool: OpenAI GPT-5.6 Sol with OpenCode
- Used for: cross-run diagnosis, implementation, regression coverage, and verification.