### PR TITLE
Reuse canonical publication snapshots

### DIFF
--- a/packages/runtime-cloudflare/src/worker.ts
+++ b/packages/runtime-cloudflare/src/worker.ts
@@ -585,14 +585,20 @@ async function drainNextPublicationJob(env: RuntimeEnv, coordinator: RevisionCoo
     if (!plan) throw new Error("Publication progress plan is unavailable.")
     if (progress.next < plan.upsert.length) {
       const route = plan.upsert[progress.next]
-      runtime = await bootRuntime(env.WORDPRESS_STATE_BUCKET, job.canonical, SITE_URL, await canonicalWordPressAuthConstants(env))
-      const compiled = await compilePublicationRoutes(runtime, [route], SITE_URL)
-      const page = compiled[0]
-      const objectKey = await publishedPageObjectKey(job.canonical.revision, page.route)
-      const snapshot: WordPressPageSnapshot = { schema: PUBLISHED_PAGE_SCHEMA, canonicalRevision: job.canonical.revision, route: page.route, status: page.status, statusText: page.statusText, headers: page.headers, body: page.body }
-      const serialized = JSON.stringify(snapshot)
-      if (new TextEncoder().encode(serialized).byteLength > MAX_PUBLISHED_PAGE_BYTES) throw new Error(`Affected publication artifact exceeds its size budget: ${page.route}.`)
-      await putImmutableJson(env.WORDPRESS_STATE_BUCKET, objectKey, serialized)
+      const objectKey = await publishedPageObjectKey(job.canonical.revision, route)
+      let snapshot = await readWordPressPageSnapshot(env.WORDPRESS_STATE_BUCKET, objectKey, job.canonical.revision, route)
+      if (!snapshot) {
+        runtime = await bootRuntime(env.WORDPRESS_STATE_BUCKET, job.canonical, SITE_URL, await canonicalWordPressAuthConstants(env))
+        const page = (await compilePublicationRoutes(runtime, [route], SITE_URL))[0]
+        snapshot = { schema: PUBLISHED_PAGE_SCHEMA, canonicalRevision: job.canonical.revision, route: page.route, status: page.status, statusText: page.statusText, headers: page.headers, body: page.body }
+        const serialized = JSON.stringify(snapshot)
+        if (new TextEncoder().encode(serialized).byteLength > MAX_PUBLISHED_PAGE_BYTES) throw new Error(`Affected publication artifact exceeds its size budget: ${page.route}.`)
+        try {
+          await putImmutableJson(env.WORDPRESS_STATE_BUCKET, objectKey, serialized)
+        } catch (error) {
+          if (!await readWordPressPageSnapshot(env.WORDPRESS_STATE_BUCKET, objectKey, job.canonical.revision, route)) throw error
+        }
+      }
       await writePublicationProgress(env.WORDPRESS_STATE_BUCKET, job, { ...progress, next: progress.next + 1, rendered: [...progress.rendered, route] })
       return { schema: "wp-codebox/cloudflare-publication/v1", status: "rendered", jobKey: job.key, route }
     }
@@ -765,10 +771,9 @@ async function matchWordPressPageCache(request: Request, pointer: MarkdownPointe
   try {
     const cached = cache ? await cache.match(wordPressPageCacheKey(request, pointer)) : null
     if (cached) return pageCacheResponse(cached, request.method === "HEAD", "hit", "edge")
-    const object = await bucket.get(await wordPressPageSnapshotKey(request, pointer))
-    if (!object) return null
-    const snapshot = JSON.parse(await object.text()) as WordPressPageSnapshot
-    validateWordPressPageSnapshot(snapshot, pointer.revision, canonicalPublicRoute(request))
+    const route = canonicalPublicRoute(request)
+    const snapshot = await readWordPressPageSnapshot(bucket, await wordPressPageSnapshotKey(request, pointer), pointer.revision, route)
+    if (!snapshot) return null
     if (snapshot.status !== 200) return null
     const response = new Response(snapshot.body, { status: snapshot.status, statusText: snapshot.statusText, headers: snapshot.headers })
     if (cache) await cache.put(wordPressPageCacheKey(request, pointer), response.clone())
@@ -776,6 +781,15 @@ async function matchWordPressPageCache(request: Request, pointer: MarkdownPointe
   } catch {
     return null
   }
+}
+
+async function readWordPressPageSnapshot(bucket: R2Bucket, objectKey: string, canonicalRevision: string, route: string): Promise<WordPressPageSnapshot | null> {
+  const object = await bucket.get(objectKey)
+  if (!object) return null
+  if (object.size > MAX_PUBLISHED_PAGE_BYTES) throw new Error(`Published page artifact exceeds its size budget: ${objectKey}.`)
+  const snapshot = JSON.parse(await object.text()) as WordPressPageSnapshot
+  validateWordPressPageSnapshot(snapshot, canonicalRevision, route)
+  return snapshot
 }
 
 async function cacheWordPressPage(request: Request, pointer: MarkdownPointer, response: Response, bucket: R2Bucket): Promise<Response> {

--- a/scripts/cloudflare-local-gate.mjs
+++ b/scripts/cloudflare-local-gate.mjs
@@ -46,6 +46,7 @@ try {
   await assertAnonymousWordPressPage(origin, "homepage publication candidate")
   const initialPublication = await publishRoutes(["/", post.route])
   const updatedPost = await updatePost(adminHtml, post, initialPublication.revision)
+  await assertAnonymousWordPressPage(new URL(post.route, origin), "updated post canonical snapshot before publication")
   // Restart with an explicit pending job to prove progress is durable rather than isolate-local.
   await stopWorker()
   await startWorker()

--- a/tests/cloudflare-runtime.test.ts
+++ b/tests/cloudflare-runtime.test.ts
@@ -402,6 +402,8 @@ test("Cloudflare runtime injects composable coordinators without moving PHP out 
   assert.match(worker, /coordinator\.committed\(candidate\.coordinatorVersion\)/)
   assert.match(worker, /\.list\(\{ prefix: `\$\{R2_PUBLICATION_JOB_PREFIX\}\/`, limit: 16 \}\)/)
   assert.match(worker, /canonicalVersion: job\.coordinatorVersion/)
+  assert.match(worker, /readWordPressPageSnapshot\(env\.WORDPRESS_STATE_BUCKET, objectKey, job\.canonical\.revision, route\)/)
+  assert.match(worker, /if \(!await readWordPressPageSnapshot\(env\.WORDPRESS_STATE_BUCKET, objectKey, job\.canonical\.revision, route\)\) throw error/)
   const publicationDrain = worker.slice(worker.indexOf("async function drainNextPublicationJob"), worker.indexOf("async function compilePublicationRoutes"))
   assert.match(publicationDrain, /bootRuntime\(env\.WORDPRESS_STATE_BUCKET, job\.canonical, SITE_URL/)
   assert.match(publicationDrain, /compilePublicationRoutes\(runtime, \[route\], SITE_URL\)/)


### PR DESCRIPTION
Fixes #1966.

## Production evidence

After #1965 deployed as Worker `7717e6bf-8cd8-47fe-a91c-598b8b2a8bf2`, the previously stuck `/` route resumed successfully in `18604 ms` wall / `3401 ms` CPU. Job 31 advanced from `next: 0` to `next: 1`.

The next route then failed because an anonymous request had already rendered the same canonical revision and route into the same create-once R2 key. Dynamic page caching and scheduled publication produced different serialized header decorations, so the immutable guard correctly rejected replacement.

## Change

- Read and validate an existing canonical page snapshot before booting PHP for publication.
- Reuse exact revision/route snapshots and advance durable progress without rerendering.
- If another producer wins during creation, validate and converge on its immutable snapshot.
- Share snapshot reading and validation with the canonical page-cache path.
- Reproduce the collision in the production-shaped gate by rendering the updated post before restarting and draining its publication job.

Invalid, oversized, wrong-revision, and wrong-route snapshots continue to fail closed. Job claims, ordering, progress, CAS promotion, and immutable object keys remain unchanged.

## Verification

- `npm run test:cloudflare-runtime`: 24 tests and TypeScript pass.
- `npm run cloudflare:dry-run` and `npm run cloudflare:dry-run:d1`: both profiles build.
- `npm run cloudflare:local-gate`: Durable Object snapshot-producer race, restart, draining, and coordinator-free publication pass.
- `npm run cloudflare:local-gate:d1`: equivalent D1 workflow passes.

No deployment was performed for this PR. After merge, production validation should deploy the exact merge and confirm existing job 31 advances from `next: 1` through promotion without modifying or deleting its retained evidence.

## AI disclosure

OpenCode with OpenAI GPT-5.6 Sol diagnosed the production producer race, implemented snapshot convergence, and ran the complete verification suite. Chris Huber remains responsible for the change.