### PR TITLE
Preserve glob strings in generated D1 config

### DIFF
--- a/scripts/provision-cloudflare-d1-coordinator.mjs
+++ b/scripts/provision-cloudflare-d1-coordinator.mjs
@@ -55,5 +55,34 @@ async function run(command) {
 }
 
 function parseJsonc(value) {
-  return JSON.parse(value.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "").replace(/,\s*([}\]])/g, "$1"))
+  let output = ""
+  let string = false
+  let escaped = false
+  let lineComment = false
+  let blockComment = false
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index]
+    const next = value[index + 1]
+    if (lineComment) {
+      if (character === "\n") { lineComment = false; output += character }
+      continue
+    }
+    if (blockComment) {
+      if (character === "*" && next === "/") { blockComment = false; index++ }
+      else if (character === "\n") output += character
+      continue
+    }
+    if (string) {
+      output += character
+      if (escaped) escaped = false
+      else if (character === "\\") escaped = true
+      else if (character === '"') string = false
+      continue
+    }
+    if (character === '"') { string = true; output += character }
+    else if (character === "/" && next === "/") { lineComment = true; index++ }
+    else if (character === "/" && next === "*") { blockComment = true; index++ }
+    else output += character
+  }
+  return JSON.parse(output.replace(/,\s*([}\]])/g, "$1"))
 }

--- a/tests/cloudflare-d1-provisioner.test.mjs
+++ b/tests/cloudflare-d1-provisioner.test.mjs
@@ -17,7 +17,7 @@ test("D1 provisioner creates once and emits a deployable config deterministicall
     const output = join(directory, "production.json")
     await writeFile(state, "missing")
     await writeFile(calls, "")
-    await writeFile(template, `// template\n{"name":"worker","main":"src/worker-d1.ts","d1_databases":[{"binding":"WORDPRESS_STATE_DATABASE","database_name":"wp-codebox-runtime-state","database_id":"00000000-0000-0000-0000-000000000000"}],}`)
+    await writeFile(template, `// template\n{"name":"worker","main":"src/worker-d1.ts","d1_databases":[{"binding":"WORDPRESS_STATE_DATABASE","database_name":"wp-codebox-runtime-state","database_id":"00000000-0000-0000-0000-000000000000"}],"rules":[{"globs":["**/*.wasm","https://example.test/*"]}],}`)
     await writeFile(wrangler, `#!${process.execPath}\nimport { appendFileSync, readFileSync, writeFileSync } from "node:fs"; const args=process.argv.slice(2); appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args)+"\\n"); if(args[1]==="list") process.stdout.write(readFileSync(${JSON.stringify(state)},"utf8")==="created"?JSON.stringify([{name:"wp-codebox-runtime-state",uuid:"11111111-2222-3333-4444-555555555555"}]):"[]"); else if(args[1]==="create") writeFileSync(${JSON.stringify(state)},"created");`)
     await chmod(wrangler, 0o755)
 
@@ -28,6 +28,7 @@ test("D1 provisioner creates once and emits a deployable config deterministicall
     const config = JSON.parse(await readFile(output, "utf8"))
     assert.equal(config.d1_databases[0].database_id, first.databaseId)
     assert.equal(config.main, join(directory, "src/worker-d1.ts"))
+    assert.deepEqual(config.rules[0].globs, ["**/*.wasm", "https://example.test/*"])
     const invocations = (await readFile(calls, "utf8")).trim().split("\n").map(JSON.parse)
     assert.equal(invocations.filter((args) => args[1] === "create").length, 1)
   } finally {


### PR DESCRIPTION
## Summary

- replace regex JSONC comment removal with a string-aware scanner
- preserve Worker glob and URL strings while removing actual comments
- prove the emitted D1 config retains deployment rules

Continues #1976 after production preflight caught corrupted glob strings before D1 promotion.

## Verification

- `node --test tests/cloudflare-d1-provisioner.test.mjs`

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode implemented this parser fix and regression coverage under Chris Huber's direction and review. Chris remains responsible for every line.