### PR TITLE
Preserve Durable Object class during D1 cutover

### DIFF
--- a/packages/runtime-cloudflare/src/worker-d1.ts
+++ b/packages/runtime-cloudflare/src/worker-d1.ts
@@ -1,4 +1,5 @@
 import { D1RevisionCoordinator } from "./d1-revision-coordinator.js"
+export { WordPressStateCoordinator } from "./state-coordinator.js"
 import type { SiteContext } from "./site-context.js"
 import { createCloudflareRuntime, type RuntimeEnv } from "./worker.js"
 

--- a/tests/cloudflare-runtime.test.ts
+++ b/tests/cloudflare-runtime.test.ts
@@ -343,6 +343,7 @@ test("Cloudflare runtime injects composable coordinators without moving PHP out 
   const corpus = await readFile(new URL("../packages/runtime-cloudflare/src/wordpress-runtime-corpus.ts", import.meta.url), "utf8")
 
   assert.match(worker, /return await runCoordinatedWordPressRequest\(request, env, coordinator, site, route\.kind\)/)
+  assert.match(d1Entry, /export \{ WordPressStateCoordinator \} from "\.\/state-coordinator\.js"/)
   assert.match(worker, /const cachedRuntimes = new Map/)
   assert.match(worker, /cachedRuntimes\.get\(site\.id\)/)
   assert.match(worker, /promise\.catch\(\(\) =>/)


### PR DESCRIPTION
## Summary

- retain the historical Durable Object class export in the D1 Worker bundle
- satisfy Cloudflare service compatibility while D1 replaces the active coordinator binding
- cover the mixed-version deployment requirement explicitly

Continues #1976 after the production promotion preflight was rejected before activation with Cloudflare code 10064.

## Verification

- `npm run test:cloudflare-runtime`
- `npm run cloudflare:dry-run:d1`

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode implemented this compatibility fix and coverage under Chris Huber's direction and review. Chris remains responsible for every line.