### PR TITLE
Fix concurrent WP-CLI wrapper collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "test:wordpress-hotspots-contracts": "tsx tests/wordpress-hotspots-contracts.test.ts",
     "test:cache-churn-observation-contracts": "tsx tests/cache-churn-observation-contracts.test.ts",
     "test:wordpress-db-contracts": "tsx tests/wordpress-db-contracts.test.ts",
+    "test:wp-cli-temporary-script": "tsx tests/wp-cli-temporary-script.test.ts",
     "test:browser-sdk-facade": "tsx tests/browser-sdk-facade.test.ts",
     "check": "npm run test:production-boundary-enforcement && npm run smoke -- --group=check"
   },

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -14,7 +14,7 @@ import { browserWordPressDiagnosticProvider, isBrowserCommandArtifactError, runB
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
 import { firstCommandWordPressAdminAuthRequirement } from "./command-auth-requirements.js"
-import { argValue, cleanWpCliOutput, shellArgv, wordpressBlockExerciseInputFromArgs, wordpressBlockExercisePhpCode, wordpressCrudOperationFromArgs, wordpressCrudOperationPhpCode, wordpressDbOperationFromArgs, wordpressDbOperationPhpCode, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { argValue, cleanWpCliOutput, runWithTemporaryWpCliScript, shellArgv, wordpressBlockExerciseInputFromArgs, wordpressBlockExercisePhpCode, wordpressCrudOperationFromArgs, wordpressCrudOperationPhpCode, wordpressDbOperationFromArgs, wordpressDbOperationPhpCode, wpCliCommandFromArgs } from "./commands.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { observeHttpResponse as observeHttpResponseArtifact, observeWordPressState as observeWordPressStateArtifact } from "./observation-artifacts.js"
 import { PlaygroundCommandCrashError, assertPlaygroundResponseOk, errorMessage, type PlaygroundRunResponse } from "./playground-command-errors.js"
@@ -1054,13 +1054,7 @@ class PlaygroundRuntime implements Runtime {
       throw new Error("wordpress.wp-cli requires a non-empty command")
     }
 
-    if (!server.playground.writeFile) {
-      throw new Error("wordpress.wp-cli requires a Playground backend with writeFile support")
-    }
-
-    const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}.php`
-    await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
-    const response = await this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
+    const response = await this.runWpCliCommand(server, argv)
     assertPlaygroundResponseOk("wordpress.wp-cli", response)
 
     return cleanWpCliOutput(response.text)
@@ -1471,13 +1465,18 @@ class PlaygroundRuntime implements Runtime {
   }
 
   private async runWpCliCommand(server: PlaygroundCliServer, argv: string[]): Promise<PlaygroundRunResponse> {
-    if (!server.playground.writeFile) {
-      throw new Error("WP-CLI commands require a Playground backend with writeFile support")
+    if (!server.playground.writeFile || !server.playground.unlink) {
+      throw new Error("WP-CLI commands require a Playground backend with writeFile and unlink support")
     }
-
-    const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}-${Date.now().toString(36)}.php`
-    await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
-    return this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
+    return runWithTemporaryWpCliScript(
+      {
+        writeFile: (path, contents) => server.playground.writeFile!(path, contents),
+        unlink: (path) => server.playground.unlink!(path),
+      },
+      this.runtimeId,
+      argv,
+      (scriptPath) => this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath }),
+    )
   }
 
   private async createRuntimeWpCliBridge(server: PlaygroundCliServer): Promise<RuntimeWpCliBridge> {
@@ -1758,13 +1757,7 @@ class PlaygroundRuntime implements Runtime {
   }
 
   private async runWpCliArgv(server: PlaygroundCliServer, argv: string[]): Promise<PlaygroundRunResponse> {
-    if (!server.playground.writeFile) {
-      throw new Error("WP-CLI commands require a Playground backend with writeFile support")
-    }
-
-    const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}-${Date.now().toString(36)}.php`
-    await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
-    return this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
+    return this.runWpCliCommand(server, argv)
   }
 
   private async runPlaygroundCommand(command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse> {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -13,6 +13,7 @@ export interface PlaygroundCliServer {
     run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundServerRunResponse>
     onMessage?(listener: (data: string) => Promise<string | void> | string | void): Promise<(() => Promise<void> | void) | void> | (() => Promise<void> | void) | void
     readFileAsText?(path: string): string | Promise<string>
+    unlink?(path: string): Promise<void> | void
     writeFile?(path: string, contents: string): Promise<void>
   }
   serverUrl: string

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -23,6 +23,7 @@ interface ProgrammaticPHP {
   onMessage(listener: (data: string) => Promise<string | void> | string | void): () => Promise<void>
   readFileAsText(path: string): string
   run(options: { code: string } | { scriptPath: string }): Promise<ProgrammaticPHPResponse>
+  unlink(path: string): void
   writeFile(path: string, contents: string): void
 }
 
@@ -91,6 +92,9 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
       run: (runOptions) => runPhp(primaryPhp, runOptions),
       onMessage: (listener) => primaryPhp.onMessage(listener),
       readFileAsText: (path) => primaryPhp.readFileAsText(path),
+      unlink(path) {
+        primaryPhp.unlink(path)
+      },
       async writeFile(path, contents) {
         primaryPhp.writeFile(path, contents)
       },

--- a/packages/runtime-playground/src/wp-cli-command-handlers.ts
+++ b/packages/runtime-playground/src/wp-cli-command-handlers.ts
@@ -1,5 +1,11 @@
+import { randomBytes } from "node:crypto"
 import { argValue } from "./command-args.js"
 import { phpCliStreamConstants } from "./php-snippets.js"
+
+interface WpCliTemporaryScriptFilesystem {
+  writeFile(path: string, contents: string): Promise<void>
+  unlink(path: string): Promise<void> | void
+}
 
 export function wpCliCommandFromArgs(args: string[]): string {
   const explicit = argValue(args, "command")
@@ -51,11 +57,26 @@ export function shellArgv(command: string): string[] {
 
 export function wpCliPhpScript(argv: string[]): string {
   return `<?php
+register_shutdown_function(static function (): void {
+    @unlink(__FILE__);
+});
 putenv('SHELL_PIPE=0');
 $GLOBALS['argv'] = array_merge(array('/tmp/wp-cli.phar', '--path=/wordpress', '--no-color'), json_decode(${JSON.stringify(JSON.stringify(argv))}, true));
 ${phpCliStreamConstants()}
 require '/tmp/wp-cli.phar';
 `
+}
+
+export async function runWithTemporaryWpCliScript<T>(filesystem: WpCliTemporaryScriptFilesystem, runtimeId: string, argv: string[], run: (scriptPath: string) => Promise<T>): Promise<T> {
+  const runtimeNamespace = runtimeId.replace(/[^A-Za-z0-9_-]/g, "-").slice(0, 80) || "runtime"
+  const scriptPath = `/tmp/wp-codebox-wp-cli-${runtimeNamespace}-${randomBytes(16).toString("hex")}.php`
+  await filesystem.writeFile(scriptPath, wpCliPhpScript(argv))
+  try {
+    return await run(scriptPath)
+  } finally {
+    // The wrapper also removes itself on PHP shutdown, so a missing file is expected here.
+    await Promise.resolve(filesystem.unlink(scriptPath)).catch(() => undefined)
+  }
 }
 
 export function cleanWpCliOutput(output: string): string {

--- a/packages/runtime-playground/src/wp-cli-command-handlers.ts
+++ b/packages/runtime-playground/src/wp-cli-command-handlers.ts
@@ -57,9 +57,6 @@ export function shellArgv(command: string): string[] {
 
 export function wpCliPhpScript(argv: string[]): string {
   return `<?php
-register_shutdown_function(static function (): void {
-    @unlink(__FILE__);
-});
 putenv('SHELL_PIPE=0');
 $GLOBALS['argv'] = array_merge(array('/tmp/wp-cli.phar', '--path=/wordpress', '--no-color'), json_decode(${JSON.stringify(JSON.stringify(argv))}, true));
 ${phpCliStreamConstants()}
@@ -74,7 +71,6 @@ export async function runWithTemporaryWpCliScript<T>(filesystem: WpCliTemporaryS
   try {
     return await run(scriptPath)
   } finally {
-    // The wrapper also removes itself on PHP shutdown, so a missing file is expected here.
     await Promise.resolve(filesystem.unlink(scriptPath)).catch(() => undefined)
   }
 }

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -120,6 +120,7 @@ export const smokeGroups = {
       tsxSmoke("replay-export-snapshot-scoping-smoke"),
       tsxSmoke("runtime-overlay-validation-smoke"),
       npmScript("test:runtime-php-snippets"),
+      npmScript("test:wp-cli-temporary-script"),
       npmScript("test:php-runtime-provider-registry"),
       tsxSmoke("composer-backed-source-hydration-smoke"),
       tsxSmoke("composer-package-overlay-autoload-layout-smoke"),

--- a/tests/wp-cli-temporary-script.test.ts
+++ b/tests/wp-cli-temporary-script.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { runWithTemporaryWpCliScript, shellArgv } from "../packages/runtime-playground/src/wp-cli-command-handlers.js"
+import { runWithTemporaryWpCliScript, shellArgv } from "../packages/runtime-playground/dist/wp-cli-command-handlers.js"
 
 class MemoryFilesystem {
   readonly files = new Map<string, string>()

--- a/tests/wp-cli-temporary-script.test.ts
+++ b/tests/wp-cli-temporary-script.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import { runWithTemporaryWpCliScript, shellArgv } from "../packages/runtime-playground/src/wp-cli-command-handlers.js"
+
+class MemoryFilesystem {
+  readonly files = new Map<string, string>()
+  readonly writtenPaths: string[] = []
+  readonly unlinkedPaths: string[] = []
+
+  async writeFile(path: string, contents: string): Promise<void> {
+    if (this.files.has(path)) {
+      throw new Error(`Could not write to ${JSON.stringify(path)}: File exists.`)
+    }
+    this.files.set(path, contents)
+    this.writtenPaths.push(path)
+  }
+
+  unlink(path: string): void {
+    this.files.delete(path)
+    this.unlinkedPaths.push(path)
+  }
+}
+
+const oldPaths = Array.from({ length: 16 }, () => "/tmp/wp-codebox-wp-cli-2.php")
+assert.equal(new Set(oldPaths).size, 1, "the old command-count suffix reproduces the shared wrapper path")
+
+const filesystem = new MemoryFilesystem()
+let invocationCount = 0
+for (const { concurrency, iterations, repetitions } of [
+  { concurrency: 2, iterations: 128, repetitions: 3 },
+  { concurrency: 6, iterations: 256, repetitions: 3 },
+  { concurrency: 16, iterations: 512, repetitions: 2 },
+  { concurrency: 64, iterations: 1_024, repetitions: 1 },
+]) {
+  for (let repetition = 0; repetition < repetitions; repetition++) {
+    const markers = Array.from({ length: iterations }, (_, index) => `marker-${concurrency}-${repetition}-${index.toString().padStart(6, "0")}`)
+    const outputs = await runBounded(markers, concurrency, async (marker, index) => {
+      invocationCount++
+      return runWithTemporaryWpCliScript(
+        filesystem,
+        "runtime/shared/../../unsafe",
+        ["eval", `echo ${JSON.stringify(marker)};`],
+        async (scriptPath) => {
+          await new Promise((resolve) => setTimeout(resolve, index % 5))
+          const script = filesystem.files.get(scriptPath)
+          assert.ok(script, `wrapper must exist while ${marker} executes`)
+          assert.match(scriptPath, /^\/tmp\/wp-codebox-wp-cli-runtime-shared-------unsafe-[a-f0-9]{32}\.php$/)
+          assert.ok(script.includes(marker), `${marker} must execute only its own payload`)
+          const otherMarker = markers[(index + 1) % markers.length]
+          assert.equal(script.includes(otherMarker), false, `${marker} must not execute ${otherMarker}`)
+          return marker
+        },
+      )
+    })
+    assert.deepEqual(outputs, markers)
+    assert.equal(filesystem.files.size, 0, `concurrency ${concurrency} must return the temp directory to baseline`)
+  }
+}
+
+assert.equal(new Set(filesystem.writtenPaths).size, invocationCount)
+assert.deepEqual(new Set(filesystem.unlinkedPaths), new Set(filesystem.writtenPaths))
+assert.throws(() => shellArgv("eval 'unterminated"), /Unclosed quote/, "malformed WP-CLI input must fail before allocating a wrapper")
+
+const nonzero = await runWithTemporaryWpCliScript(filesystem, "runtime-nonzero", ["eval", "exit(7)"], async () => ({ exitCode: 7, text: "", errors: "intentional" }))
+assert.deepEqual(nonzero, { exitCode: 7, text: "", errors: "intentional" }, "structured nonzero responses must remain compatible")
+assert.equal(filesystem.files.size, 0, "structured nonzero responses must clean up their wrapper")
+
+for (const failure of [
+  new Error("wrapper execution failure"),
+  new Error("runtime command exceeded timeout"),
+  new Error("runtime execution was aborted"),
+  new Error("adapter exception"),
+]) {
+  await assert.rejects(
+    runWithTemporaryWpCliScript(filesystem, "runtime-failures", ["eval", "broken"], async () => { throw failure }),
+    failure,
+  )
+  assert.equal(filesystem.files.size, 0, `${failure.message} must clean up its owned wrapper`)
+}
+
+let unlinkedAfterRejectedWrite = false
+await assert.rejects(
+  runWithTemporaryWpCliScript({
+    async writeFile() {
+      throw new Error("File exists")
+    },
+    unlink() {
+      unlinkedAfterRejectedWrite = true
+    },
+  }, "runtime-write-failure", ["version"], async () => "unreachable"),
+  /File exists/,
+)
+assert.equal(unlinkedAfterRejectedWrite, false, "a rejected write must not claim or remove another invocation's file")
+
+console.log(`WP-CLI temporary wrapper stress ok: ${invocationCount} isolated invocations at concurrency 2, 6, 16, and 64`)
+
+async function runBounded<T, R>(items: T[], concurrency: number, operation: (item: T, index: number) => Promise<R>): Promise<R[]> {
+  const outputs = new Array<R>(items.length)
+  let nextIndex = 0
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      outputs[index] = await operation(items[index], index)
+    }
+  }))
+  return outputs
+}


### PR DESCRIPTION
## Summary
- give every WP-CLI invocation a runtime-scoped wrapper path with 128 bits of cryptographic randomness
- centralize the three WP-CLI execution paths on one ownership-safe write, execute, and cleanup lifecycle
- add deterministic collision regression coverage and a 3,200-invocation bounded stress matrix

## Root cause
`runWpCli()` derived `/tmp/wp-codebox-wp-cli-<n>.php` from `this.commands.length`. Executions are appended to `this.commands` only after completion, so all concurrent invocations starting from the same runtime state observed the same value (`2` in the reported fuzz run). The bridge and argv helper variants added only `Date.now()`, which retained the same collision class for calls in one process tick. Concurrent writes could therefore fail with `File exists` or expose a partially written payload to another worker.

## Ownership and atomicity
Every wrapper now uses:

`/tmp/wp-codebox-wp-cli-<sanitized-runtime-id>-<128-bit-random-token>.php`

The runtime namespace is restricted to fixed safe filename characters and the token comes from `crypto.randomBytes(16)`. The existing Playground `writeFile` operation completes before execution starts. Ownership begins only after that write resolves, so a rejected write never triggers deletion of a path the invocation did not create.

All public, bridge, theme/plugin helper, and argv-based WP-CLI calls use the same helper. The sibling audit found no non-WP-CLI adapter reusing this wrapper allocation pattern.

## Cleanup and errors
The runtime owner unlinks its exact path in `finally`, covering successful execution, structured nonzero responses, wrapper crashes, timeouts/cancellation, and adapter exceptions without changing existing WP-CLI output cleaning or error classification.

An initial revision also deleted the wrapper from a PHP shutdown handler. Fresh CI exposed that as a runtime-source integration regression because it could run before WP-CLI's own later shutdown handlers. Commit `3237ca76` removed that redundant in-script cleanup and leaves lifecycle ownership exclusively with the host invocation. The base SHA's contracts run was green (`30029484653`), the focused integration passed twice locally after the correction, and the next fresh CI run passed.

The programmatic Playground adapter now exposes the existing PHP WASM `unlink` primitive; no parallel temp subsystem was introduced.

## Original evidence
The isolated two-factor bounded plan used concurrency 6 with 13 entries and produced 6 successes / 7 failures. Concurrent workers reused `/tmp/wp-codebox-wp-cli-2.php`, including:

```text
Could not write to "/tmp/wp-codebox-wp-cli-2.php": File exists.
PHP Parse error: Unclosed '{' on line 10 in /tmp/wp-codebox-wp-cli-2.php on line 11
```

The regression test explicitly reproduces the old deterministic allocator yielding one path for 16 concurrent allocations before exercising the replacement seam.

## Stress results
| Surface | Runtime | Concurrency | Invocations | Result |
| --- | --- | ---: | ---: | --- |
| deterministic memory filesystem | test seam | 2 | 384 across 3 repetitions | passed |
| deterministic memory filesystem | test seam | 6 | 768 across 3 repetitions | passed |
| deterministic memory filesystem | test seam | 16 | 1,024 across 2 repetitions | passed |
| deterministic memory filesystem | test seam | 64 | 1,024 | passed |
| real Playground | PHP 8.3 / WP 6.8 | 2, 6, 16 | 48 | passed |
| real Playground | PHP 8.4 / WP 6.8 | 2, 6, 16 | 48 | passed |

Each invocation used a unique payload marker. All outputs matched only their own marker; no `File exists`, parse errors, missing scripts, cross-payload execution, or orphan wrappers were observed. Both real runtimes also exercised intentional WP-CLI failure and returned `/tmp/wp-codebox-wp-cli-*.php` to an empty baseline.

The exact two-factor recipe was attempted as a final replay but Playground failed during bootstrap, before any workload command, because `https://playground.wordpress.net/wp-cli.phar` could not be downloaded. A cached WP 6.8 attempt reached plugin activation but the current two-factor branch requires WP 6.9. This is an external bootstrap limitation, not a wrapper failure; the same 13-entry/concurrency-6 execution shape is covered by the successful real-runtime stress above.

## Checks
- `npm run test:runtime-sources-playground-integration` passed twice consecutively after the cleanup correction
- `npm run test:wp-cli-temporary-script` passed: 3,200 invocations
- `node --test tests/wp-cli-temporary-script.test.ts` passed
- `npx tsx tests/runtime-wp-cli-bridge.test.ts` passed
- `npm run build` passed
- real Playground PHP 8.3 and 8.4 stress passed: 96 invocations, mixed failure, zero orphans
- `homeboy review --changed-since origin/main` passed audit, lint, and changed tests with no introduced findings (run `2d0f10a3-50c4-4ae0-a325-051cba924dad`)
- GitHub Actions run `30059238805` passed `contracts` and `workflow-lint`, including `test:runtime-sources-playground-integration`
- `npm run check` reached a pre-existing untouched `command-registry-smoke` failure: `wordpress.collect-workload-result outputShape should mention outputSchema id`
- runtime smoke reached a pre-existing untouched redaction expectation failure in `playground-command-errors-smoke`

Closes #2003