### PR TITLE
Handle cross-realm PHP-WASM worker failures

### DIFF
--- a/patches/@wp-playground+cli+3.1.46.patch
+++ b/patches/@wp-playground+cli+3.1.46.patch
@@ -6,7 +6,7 @@ index 93b7099..65f76be 100644
  }
  process.on("unhandledRejection", (r) => {
    S.error("Unhandled rejection:", r);
-+  if (r instanceof WebAssembly.RuntimeError && String(r.stack).includes("php.wasm"))
++  if (r?.name === "RuntimeError" && String(r.stack).includes("php.wasm"))
 +    throw r;
  });
  const i = new _(), [c, p] = y(
@@ -19,7 +19,7 @@ index fb79a59..77ddb67 100644
  }
  process.on("unhandledRejection", (r) => {
    E.error("Unhandled rejection:", r);
-+  if (r instanceof WebAssembly.RuntimeError && String(r.stack).includes("php.wasm"))
++  if (r?.name === "RuntimeError" && String(r.stack).includes("php.wasm"))
 +    throw r;
  });
  const i = new m(), [h, u] = k(

--- a/patches/README.md
+++ b/patches/README.md
@@ -11,7 +11,9 @@ contains the same change.
 
 `@wp-playground+cli+3.1.46.patch` makes blueprint worker threads rethrow fatal
 `WebAssembly.RuntimeError` rejections originating from `php.wasm` after logging
-them. Other unhandled rejections retain the released CLI's log-only behavior.
+them. Detection uses the error name because PHP-WASM errors may cross JavaScript
+realm boundaries where `instanceof` is false. Other unhandled rejections retain
+the released CLI's log-only behavior.
 Without this narrow terminalization, a poisoned PHP-WASM worker remains alive
 and leaves the parent request pending until the recipe timeout. Remove the patch
 after the Playground CLI ships the same worker terminalization behavior.

--- a/tests/playground-worker-runtime-rejection.test.ts
+++ b/tests/playground-worker-runtime-rejection.test.ts
@@ -10,13 +10,14 @@ const preloadPath = join(root, "reject-on-command.mjs")
 
 await writeFile(preloadPath, `
 import { parentPort } from "node:worker_threads"
+import { runInNewContext } from "node:vm"
 parentPort?.on("message", (message) => {
   if (message === "wp-codebox-trigger-non-wasm-rejection") {
     Promise.reject(new Error("ordinary worker rejection"))
     setTimeout(() => parentPort?.postMessage("wp-codebox-worker-survived"), 25)
   }
   if (message === "wp-codebox-trigger-php-wasm-rejection") {
-    const error = new WebAssembly.RuntimeError("null function or function signature mismatch")
+    const error = runInNewContext('new WebAssembly.RuntimeError("null function or function signature mismatch")')
     error.stack = "RuntimeError: null function or function signature mismatch\\n    at php.wasm.zif_mysqli_poll (wasm://wasm/php.wasm-05996276:wasm-function[12986]:0x9949a8)"
     Promise.reject(error)
   }


### PR DESCRIPTION
## Summary

- detect fatal PHP-WASM runtime rejections across JavaScript realm boundaries
- retain the narrow `RuntimeError` name plus `php.wasm` stack signature
- make the real worker-thread regression construct its runtime error in a separate VM realm

## Root cause

The Data Machine rerun loaded WP Codebox merge `c7127392` but reproduced the same 25-minute timeout. The production PHP-WASM error crosses a JavaScript realm boundary, so `error instanceof WebAssembly.RuntimeError` is false even though its name is `RuntimeError` and its stack originates from `php.wasm`. The original regression constructed the error in the worker realm and therefore missed this compatibility surface.

This follow-up preserves ordinary Playground rejection handling while recognizing the reproduced cross-realm fatal error. Evidence: Extra-Chill/data-machine Actions run 30094573746, attempt 4, job 89554191976.

Follow-up to #2012. Related: #2010 and WordPress/wordpress-playground#4160.

## Verification

- `npm ci`
- `npm run build`
- `npm run test:playground-worker-runtime-rejection`
- `npm run test:phpunit-runtime-rejection`
- `npm run test:playground-phpunit-readonly-cache-integration`
- `npm run test:php-wasm-extension-manifests`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed the failed CI evidence, identified the cross-realm mismatch, drafted the predicate and regression update, and ran the listed verification. Chris Huber reviewed and remains responsible for the change.