### PR TITLE
fix: honor routed preview hosts in adaptive exploration

### DIFF
--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -238,6 +238,7 @@ export async function runBrowserActionsCommand({
           baseUrl: preview.effectiveOrigin,
           contract: adaptiveContract,
           observations: { consoleMessages, errors, network },
+          navigationScope: topology.navigationScope,
           signal: spec.signal,
         })
         adaptiveExplorationArtifact = { schema: "wp-codebox/browser-adaptive-exploration-artifact/v1", contract: adaptiveContract, result, capturedAt: now() }

--- a/packages/runtime-playground/src/browser-adaptive-explorer.ts
+++ b/packages/runtime-playground/src/browser-adaptive-explorer.ts
@@ -16,6 +16,7 @@ import { stableJson } from "@automattic/wp-codebox-core/internals"
 import type { Frame, Page } from "playwright"
 
 import { discoverBrowserActionCorpusDescriptors } from "./browser-action-discovery.js"
+import type { BrowserPreviewNavigationScope } from "./browser-preview-routing.js"
 
 interface AdaptiveObservationSources {
   consoleMessages: object[]
@@ -48,6 +49,7 @@ export async function exploreAdaptiveBrowserStateMachine({
   observations,
   signal,
   now = Date.now,
+  navigationScope,
 }: {
   page: Page
   baseUrl: string
@@ -55,6 +57,7 @@ export async function exploreAdaptiveBrowserStateMachine({
   observations: AdaptiveObservationSources
   signal?: AbortSignal
   now?: () => number
+  navigationScope?: BrowserPreviewNavigationScope
 }): Promise<BrowserAdaptiveExplorationResult> {
   const started = now()
   const states = new Map<string, BrowserAdaptiveState>()
@@ -67,7 +70,7 @@ export async function exploreAdaptiveBrowserStateMachine({
   let revisits = 0
   let exhausted: BrowserAdaptiveExplorationResult["summary"]["budgetExhausted"]
 
-  const initial = await captureAdaptiveState(page, contract, 0)
+  const initial = await captureAdaptiveState(page, contract, 0, navigationScope)
   appendDiagnostics(diagnostics, initial.diagnostics, contract.descriptorLimits.maxDiagnostics)
   states.set(initial.state.digest, initial.state)
   const frontier: FrontierEntry[] = [{ state: initial.state, path: [] }]
@@ -90,7 +93,7 @@ export async function exploreAdaptiveBrowserStateMachine({
 
       if (contract.resetPolicy.mode === "start-url" && (transitions.length > 0 || source.path.length > 0)) {
         if (actions + source.path.length >= contract.budgets.maxActions) { exhausted = "maxActions"; break }
-        const restored = await restoreAdaptivePath(page, baseUrl, contract, source.path, signal)
+        const restored = await restoreAdaptivePath(page, baseUrl, contract, source.path, signal, navigationScope)
         actions += restored.executed
         appendDiagnostics(diagnostics, restored.diagnostics, contract.descriptorLimits.maxDiagnostics)
         if (!restored.state || restored.state.digest !== source.state.digest) {
@@ -113,8 +116,9 @@ export async function exploreAdaptiveBrowserStateMachine({
         actionError = error instanceof Error ? error.message : String(error)
       }
       actions += 1
-      const stabilized = await stabilizeAdaptiveState(page, contract, source.path.length + 1, now)
+      const stabilized = await stabilizeAdaptiveState(page, contract, source.path.length + 1, now, navigationScope)
       appendDiagnostics(diagnostics, stabilized.diagnostics, contract.descriptorLimits.maxDiagnostics)
+      const scopeRejection = stabilized.diagnostics.find((diagnostic) => diagnostic.code === "browser_adaptive_redirect_scope_escape_rejected")
       const newConsoleErrors = consoleErrorMessages(observations.consoleMessages.slice(beforeConsole))
       const newPageErrors = errorMessages(observations.errors.slice(beforeErrors))
       const fingerprints = [...new Set([...newConsoleErrors, ...newPageErrors].map((message) => browserAdaptiveDigest("oracle", message)))].sort()
@@ -153,8 +157,8 @@ export async function exploreAdaptiveBrowserStateMachine({
           loadingAfter: stabilized.loading,
           oracleFingerprints: fingerprints,
         },
-        status: actionError ? "error" : newState ? "ok" : "revisited",
-        ...(actionError ? { diagnostic: { code: "browser_adaptive_action_error", message: actionError } } : {}),
+        status: actionError ? "error" : scopeRejection ? "rejected" : newState ? "ok" : "revisited",
+        ...(actionError ? { diagnostic: { code: "browser_adaptive_action_error", message: actionError } } : scopeRejection ? { diagnostic: { code: scopeRejection.code, message: scopeRejection.message } } : {}),
       }
       errors += newConsoleErrors.length + newPageErrors.length + (actionError ? 1 : 0)
       if (artifactBytes(states, [...transitions, transition], diagnostics, findings) > contract.budgets.maxArtifactBytes) {
@@ -199,7 +203,7 @@ export async function exploreAdaptiveBrowserStateMachine({
 
   if (findings.length > 0 && !signal?.aborted) {
     for (const finding of findings) {
-      const minimized = await minimizeAdaptiveFinding(page, baseUrl, contract, finding, observations, Math.max(0, contract.budgets.maxActions - actions), started + contract.budgets.maxDurationMs, signal, now)
+      const minimized = await minimizeAdaptiveFinding(page, baseUrl, contract, finding, observations, Math.max(0, contract.budgets.maxActions - actions), started + contract.budgets.maxDurationMs, signal, now, navigationScope)
       actions += minimized.executed
       finding.minimizedPath = minimized.path
       finding.replay.actions = finding.minimizedPath
@@ -223,8 +227,9 @@ export async function exploreAdaptiveBrowserStateMachine({
   }
 }
 
-async function captureAdaptiveState(page: Page, contract: BrowserAdaptiveExplorationContract, depth: number): Promise<CapturedAdaptiveState> {
+async function captureAdaptiveState(page: Page, contract: BrowserAdaptiveExplorationContract, depth: number, navigationScope?: BrowserPreviewNavigationScope): Promise<CapturedAdaptiveState> {
   const diagnostics: BrowserAdaptiveExplorationResult["diagnostics"] = []
+  diagnostics.push(...(navigationScope?.drainDiagnostics() ?? []))
   const mainOrigin = origin(page.url())
   const frames = frameIdentities(page, contract.descriptorLimits.maxPerState)
   const descriptors: BrowserActionCorpusDescriptor[] = []
@@ -242,9 +247,15 @@ async function captureAdaptiveState(page: Page, contract: BrowserAdaptiveExplora
       const discovery = await discoverBrowserActionCorpusDescriptors(frame)
       diagnostics.push(...discovery.diagnostics.map((diagnostic) => ({ ...diagnostic, metadata: { ...diagnostic.metadata, frameId: identity.id } })))
       const scopedDescriptors = discovery.descriptors.filter((descriptor) => {
-        const hrefOrigin = descriptor.href ? origin(descriptor.href) : undefined
-        if (!hrefOrigin || !mainOrigin || hrefOrigin === mainOrigin) return true
-        diagnostics.push({ code: "browser_adaptive_cross_origin_action_rejected", message: "A link leaving the exploration origin was excluded from the adaptive action frontier.", metadata: { frameId: identity.id, descriptorId: descriptor.id, href: descriptor.href } })
+        if (!descriptor.href) return true
+        const decision = navigationScope?.resolve(descriptor.href, frame.url())
+        const hrefOrigin = origin(descriptor.href)
+        if (decision?.allowed) {
+          if (decision.routeDecision === "routed-preview") diagnostics.push({ code: "browser_adaptive_routed_action_allowed", message: "A link using a declared preview route was included in the adaptive action frontier.", metadata: { frameId: identity.id, descriptorId: descriptor.id, rawHrefOrigin: decision.rawOrigin, effectiveOrigin: decision.effectiveOrigin, routeDecision: decision.routeDecision, reason: decision.reason } })
+          return true
+        }
+        if (!decision && (!hrefOrigin || !mainOrigin || hrefOrigin === mainOrigin)) return true
+        diagnostics.push({ code: "browser_adaptive_cross_origin_action_rejected", message: "A link leaving the declared preview navigation scope was excluded from the adaptive action frontier.", metadata: { frameId: identity.id, descriptorId: descriptor.id, rawHrefOrigin: decision?.rawOrigin ?? hrefOrigin, effectiveOrigin: decision?.effectiveOrigin ?? mainOrigin, routeDecision: decision?.routeDecision ?? "external", reason: decision?.reason ?? "origin-mismatch" } })
         return false
       })
       descriptors.push(...scopedDescriptors.slice(0, contract.descriptorLimits.maxPerState).map((descriptor) => ({ ...descriptor, frameId: identity.id })))
@@ -332,22 +343,35 @@ async function executeAdaptiveAction(page: Page, action: BrowserAdaptiveAction, 
   }
 }
 
-async function stabilizeAdaptiveState(page: Page, contract: BrowserAdaptiveExplorationContract, depth: number, now: () => number): Promise<StabilizationResult> {
+async function stabilizeAdaptiveState(page: Page, contract: BrowserAdaptiveExplorationContract, depth: number, now: () => number, navigationScope?: BrowserPreviewNavigationScope): Promise<StabilizationResult> {
   const started = now()
+  const diagnostics: BrowserAdaptiveExplorationResult["diagnostics"] = []
+  const diagnosticKeys = new Set<string>()
+  const retainDiagnostics = (incoming: BrowserAdaptiveExplorationResult["diagnostics"]) => {
+    for (const diagnostic of incoming) {
+      const key = stableJson(diagnostic)
+      if (!diagnosticKeys.has(key)) {
+        diagnosticKeys.add(key)
+        diagnostics.push(diagnostic)
+      }
+    }
+  }
   let polls = 0
   let quietSince = started
   let previous: CapturedAdaptiveState | undefined
   while (now() - started < contract.stabilization.maxWaitMs) {
     await page.waitForTimeout(contract.stabilization.pollIntervalMs)
-    const current = await captureAdaptiveState(page, contract, depth)
+    const current = await captureAdaptiveState(page, contract, depth, navigationScope)
+    retainDiagnostics(current.diagnostics)
     polls += 1
     if (!previous || current.state.digest !== previous.state.digest) quietSince = now()
     previous = current
     if (current.loading === 0 && now() - quietSince >= contract.stabilization.quietWindowMs) break
   }
-  const state = previous ?? await captureAdaptiveState(page, contract, depth)
+  const state = previous ?? await captureAdaptiveState(page, contract, depth, navigationScope)
+  if (!previous) retainDiagnostics(state.diagnostics)
   const mutations = await readMutationObservers(page, contract)
-  return { ...state, waitedMs: Math.max(0, now() - started), polls, mutationRecords: mutations.count, mutationEvidenceTruncated: mutations.truncated }
+  return { ...state, diagnostics, waitedMs: Math.max(0, now() - started), polls, mutationRecords: mutations.count, mutationEvidenceTruncated: mutations.truncated }
 }
 
 async function installMutationObservers(page: Page, contract: BrowserAdaptiveExplorationContract): Promise<void> {
@@ -386,26 +410,26 @@ async function readMutationObservers(page: Page, contract: BrowserAdaptiveExplor
   return { count, truncated }
 }
 
-async function restoreAdaptivePath(page: Page, baseUrl: string, contract: BrowserAdaptiveExplorationContract, path: BrowserAdaptiveAction[], signal?: AbortSignal): Promise<{ state?: BrowserAdaptiveState; executed: number; diagnostics: BrowserAdaptiveExplorationResult["diagnostics"] }> {
+async function restoreAdaptivePath(page: Page, baseUrl: string, contract: BrowserAdaptiveExplorationContract, path: BrowserAdaptiveAction[], signal?: AbortSignal, navigationScope?: BrowserPreviewNavigationScope): Promise<{ state?: BrowserAdaptiveState; executed: number; diagnostics: BrowserAdaptiveExplorationResult["diagnostics"] }> {
   const diagnostics: BrowserAdaptiveExplorationResult["diagnostics"] = []
   let executed = 0
   try {
     await page.goto(resolveUrl(contract.startUrl, baseUrl), { waitUntil: "domcontentloaded", timeout: contract.stabilization.maxWaitMs })
-    await stabilizeAdaptiveState(page, contract, 0, Date.now)
+    await stabilizeAdaptiveState(page, contract, 0, Date.now, navigationScope)
     for (const action of path) {
       if (signal?.aborted) return { executed, diagnostics }
       executed += 1
       await executeAdaptiveAction(page, action, contract.stabilization.maxWaitMs)
-      await stabilizeAdaptiveState(page, contract, executed, Date.now)
+      await stabilizeAdaptiveState(page, contract, executed, Date.now, navigationScope)
     }
-    return { state: (await captureAdaptiveState(page, contract, path.length)).state, executed, diagnostics }
+    return { state: (await captureAdaptiveState(page, contract, path.length, navigationScope)).state, executed, diagnostics }
   } catch (error) {
     diagnostics.push({ code: "browser_adaptive_reset_replay_failed", message: "The start-URL reset path could not reproduce a queued state.", metadata: { reason: error instanceof Error ? error.message : String(error) } })
     return { executed, diagnostics }
   }
 }
 
-async function minimizeAdaptiveFinding(page: Page, baseUrl: string, contract: BrowserAdaptiveExplorationContract, finding: BrowserAdaptiveFinding, observations: AdaptiveObservationSources, maximumActions: number, deadline: number, signal?: AbortSignal, now: () => number = Date.now): Promise<{ path: BrowserAdaptiveAction[]; executed: number; exhausted?: "maxActions" | "maxDurationMs" | "cancelled" }> {
+async function minimizeAdaptiveFinding(page: Page, baseUrl: string, contract: BrowserAdaptiveExplorationContract, finding: BrowserAdaptiveFinding, observations: AdaptiveObservationSources, maximumActions: number, deadline: number, signal?: AbortSignal, now: () => number = Date.now, navigationScope?: BrowserPreviewNavigationScope): Promise<{ path: BrowserAdaptiveAction[]; executed: number; exhausted?: "maxActions" | "maxDurationMs" | "cancelled" }> {
   let current = [...finding.originalPath]
   let chunk = Math.max(1, Math.floor(current.length / 2))
   let executed = 0
@@ -419,7 +443,7 @@ async function minimizeAdaptiveFinding(page: Page, baseUrl: string, contract: Br
       if (executed + candidate.length > maximumActions) { exhausted = "maxActions"; break }
       const beforeConsole = observations.consoleMessages.length
       const beforeErrors = observations.errors.length
-      const replay = await restoreAdaptivePath(page, baseUrl, contract, candidate, signal)
+      const replay = await restoreAdaptivePath(page, baseUrl, contract, candidate, signal, navigationScope)
       executed += replay.executed
       const fingerprints = [...consoleErrorMessages(observations.consoleMessages.slice(beforeConsole)), ...errorMessages(observations.errors.slice(beforeErrors))].map((message) => browserAdaptiveDigest("oracle", message))
       if (replay.state && fingerprints.includes(finding.fingerprint) && (!finding.stateDigest || replay.state.digest === finding.stateDigest)) {

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -13,6 +13,20 @@ export interface BrowserPreviewNetworkPolicy {
   firstPartyHosts: Set<string>
   recordExternal: boolean
   stats: Map<string, { requests: number; external: boolean; blocked: number; routed: number }>
+  routedRedirectEscapes: Array<{ rawOrigin: string; effectiveOrigin: string; reason: string }>
+}
+
+export interface BrowserPreviewNavigationDecision {
+  allowed: boolean
+  rawOrigin?: string
+  effectiveOrigin?: string
+  routeDecision: "relative" | "effective-preview" | "routed-preview" | "external" | "invalid"
+  reason: string
+}
+
+export interface BrowserPreviewNavigationScope {
+  resolve(href: string, documentUrl: string): BrowserPreviewNavigationDecision
+  drainDiagnostics(): Array<{ code: string; message: string; metadata: Record<string, unknown> }>
 }
 
 export interface BrowserPreviewTopology {
@@ -20,6 +34,7 @@ export interface BrowserPreviewTopology {
   networkPolicy: BrowserPreviewNetworkPolicy
   routedHosts: string[]
   origins: { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string }
+  navigationScope: BrowserPreviewNavigationScope
   resolveUrl(pathOrUrl: string): string
   authCookieUrls(targetUrls: string[]): string[]
 }
@@ -81,11 +96,41 @@ export function browserPreviewTopology(args: string[], runtimeSpec: RuntimeCreat
     networkPolicy,
     routedHosts,
     origins: browserPreviewOrigins(preview),
+    navigationScope: browserPreviewNavigationScope(preview.effectiveOrigin, networkPolicy),
     resolveUrl(pathOrUrl) {
       return resolveBrowserPreviewUrl(pathOrUrl, preview.effectiveOrigin)
     },
     authCookieUrls(targetUrls) {
       return browserPreviewAuthCookieUrls(localPreviewOrigin, routedHosts, targetUrls)
+    },
+  }
+}
+
+export function browserPreviewNavigationScope(effectivePreviewOrigin: string, policy: BrowserPreviewNetworkPolicy): BrowserPreviewNavigationScope {
+  const effectiveOrigin = new URL(effectivePreviewOrigin).origin
+  return {
+    resolve(href, documentUrl) {
+      let resolved: URL
+      try {
+        resolved = new URL(href, documentUrl)
+      } catch {
+        return { allowed: false, routeDecision: "invalid", reason: "href-invalid" }
+      }
+      const rawOrigin = resolved.origin
+      if (rawOrigin === effectiveOrigin) {
+        return { allowed: true, rawOrigin, effectiveOrigin, routeDecision: absoluteHrefOrigin(href) ? "effective-preview" : "relative", reason: "effective-preview-origin" }
+      }
+      if (policy.routeHosts.has(normalizeBrowserPreviewHost(resolved.hostname))) {
+        return { allowed: true, rawOrigin, effectiveOrigin, routeDecision: "routed-preview", reason: "declared-route-host" }
+      }
+      return { allowed: false, rawOrigin, effectiveOrigin: rawOrigin, routeDecision: "external", reason: policy.allowHosts.has(normalizeBrowserPreviewHost(resolved.hostname)) ? "network-host-allowed-but-not-routed" : "host-not-routed-to-preview" }
+    },
+    drainDiagnostics() {
+      return policy.routedRedirectEscapes.splice(0).map((escape) => ({
+        code: "browser_adaptive_redirect_scope_escape_rejected",
+        message: "A routed preview redirect leaving the declared navigation scope was stopped.",
+        metadata: { rawHrefOrigin: escape.rawOrigin, effectiveOrigin: escape.effectiveOrigin, routeDecision: "external", reason: escape.reason },
+      }))
     },
   }
 }
@@ -161,6 +206,7 @@ export function browserPreviewNetworkPolicy(args: string[], routeHosts: string[]
     firstPartyHosts,
     recordExternal: strictBooleanArg(args, "record-external", false),
     stats: new Map(),
+    routedRedirectEscapes: [],
   }
 }
 
@@ -259,7 +305,7 @@ async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (
     }
 
     stat.routed += 1
-    const task = fulfillBrowserPreviewRoutedHost(route, requestUrl, policy.routeHosts, origin)
+    const task = fulfillBrowserPreviewRoutedHost(route, requestUrl, policy, origin)
     tracker?.pending.add(task)
     try {
       await task
@@ -272,8 +318,8 @@ async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (
   })
 }
 
-async function fulfillBrowserPreviewRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, localOrigin: URL): Promise<void> {
-  const response = await fetchBrowserPreviewRoutedHost(route, requestUrl, routedHosts, localOrigin)
+async function fulfillBrowserPreviewRoutedHost(route: Route, requestUrl: URL, policy: BrowserPreviewNetworkPolicy, localOrigin: URL): Promise<void> {
+  const response = await fetchBrowserPreviewRoutedHost(route, requestUrl, policy, localOrigin)
   if (!response) {
     return
   }
@@ -334,11 +380,19 @@ function normalizeBrowserPreviewHost(host: string): string {
   return host.trim().toLowerCase().replace(/:\d+$/, "")
 }
 
+function absoluteHrefOrigin(href: string): string | undefined {
+  try {
+    return new URL(href).origin
+  } catch {
+    return undefined
+  }
+}
+
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, origin: URL): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
+async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, policy: BrowserPreviewNetworkPolicy, origin: URL): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
   let currentUrl = requestUrl
   for (let redirectCount = 0; redirectCount < 10; redirectCount++) {
     const routedUrl = new URL(currentUrl.toString())
@@ -374,8 +428,18 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, rout
     }
 
     const redirectedUrl = new URL(location, currentUrl)
-    if (!routedHosts.has(redirectedUrl.hostname.toLowerCase())) {
+    if (redirectedUrl.origin === origin.origin) {
       return response
+    }
+    const redirectedHost = normalizeBrowserPreviewHost(redirectedUrl.hostname)
+    if (!policy.routeHosts.has(redirectedHost)) {
+      const stat = browserPreviewNetworkPolicyHostStat(policy, redirectedHost)
+      stat.requests += 1
+      stat.external = true
+      stat.blocked += 1
+      policy.routedRedirectEscapes.push({ rawOrigin: redirectedUrl.origin, effectiveOrigin: origin.origin, reason: "redirect-host-not-routed-to-preview" })
+      await route.abort("blockedbyclient")
+      return undefined
     }
 
     currentUrl = redirectedUrl

--- a/tests/browser-adaptive-exploration.test.ts
+++ b/tests/browser-adaptive-exploration.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { createServer } from "node:http"
 import test from "node:test"
 import { chromium, type Page } from "playwright"
 
@@ -9,6 +10,8 @@ import {
 } from "../packages/runtime-core/src/browser-adaptive-exploration.js"
 import { getCommandDefinition } from "../packages/runtime-core/src/command-registry.js"
 import { exploreAdaptiveBrowserStateMachine } from "../packages/runtime-playground/src/browser-adaptive-explorer.js"
+import { browserPreviewTopology, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { closeHttpServer, listenLocalHttpServer } from "../packages/runtime-playground/src/preview-server.js"
 
 const modalFixture = `<!doctype html>
 <style>button,input,select { display:block; width:180px; height:30px; margin:8px; }</style>
@@ -203,6 +206,45 @@ test("cancellation during a partially failed action retains bounded non-replayab
   assert(!run.result.diagnostics.some((diagnostic) => diagnostic.code === "browser_adaptive_reset_replay_failed"))
 })
 
+test("adaptive exploration follows routed canonical multisite links and rejects redirect escapes", async () => {
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://preview.invalid").pathname
+    response.setHeader("content-type", "text/html")
+    if (path === "/escape/") {
+      response.statusCode = 302
+      response.setHeader("location", "https://outside.example/private?token=secret")
+      response.end()
+      return
+    }
+    const next = path === "/" ? "http://localhost/alpha/" : path === "/alpha/" ? "/beta/" : undefined
+    response.end(`<!doctype html><style>a{display:block;width:180px;height:30px}</style><h1>${path}</h1>${next ? `<a id="next" href="${next}">Next</a>` : ""}`)
+  })
+  const effectiveOrigin = await listenLocalHttpServer(server)
+  const topology = browserPreviewTopology(["route-host=localhost,preview.test", "network-policy=block", "allow-host=localhost,cdn.example.test"], undefined, effectiveOrigin)
+  try {
+    const first = await runRoutedFixture(topology, effectiveOrigin)
+    const second = await runRoutedFixture(topology, effectiveOrigin)
+    assert(first.states.some((state) => state.url === "http://localhost/alpha/"))
+    assert(first.states.some((state) => state.url === "http://localhost/beta/"))
+    assert(!first.diagnostics.some((diagnostic) => diagnostic.code === "browser_adaptive_cross_origin_action_rejected"))
+    assert(first.diagnostics.some((diagnostic) => diagnostic.code === "browser_adaptive_routed_action_allowed" && diagnostic.metadata?.rawHrefOrigin === "http://localhost" && diagnostic.metadata?.effectiveOrigin === new URL(effectiveOrigin).origin && diagnostic.metadata?.routeDecision === "routed-preview" && diagnostic.metadata?.reason === "declared-route-host"))
+    assert.deepEqual(stableAdaptiveEvidence(second), stableAdaptiveEvidence(first))
+
+    const escape = await runRoutedFixture(topology, effectiveOrigin, "<a id='escape' href='http://localhost/escape/'>Escape</a>")
+    const diagnostic = escape.diagnostics.find((item) => item.code === "browser_adaptive_redirect_scope_escape_rejected")
+    assert.deepEqual(diagnostic?.metadata, {
+      rawHrefOrigin: "https://outside.example",
+      effectiveOrigin: new URL(effectiveOrigin).origin,
+      routeDecision: "external",
+      reason: "redirect-host-not-routed-to-preview",
+    })
+    assert.equal(escape.transitions[0]?.status, "rejected")
+    assert(!JSON.stringify(diagnostic).includes("secret"), "redirect evidence must not retain query secrets")
+  } finally {
+    await closeHttpServer(server)
+  }
+})
+
 test("loops, budgets, cancellation, frames, and partial evidence remain bounded", async () => {
   const loopFixture = `<!doctype html><style>button,input,a,iframe { display:block;width:100px;height:30px }</style><button id="toggle">Toggle</button><form id="first"><input name="query"></form><form id="second"><input name="query"></form><a id="external" href="https://example.test/outside">External</a><iframe id="same" srcdoc="<style>button{width:100px;height:30px}</style><button id='framed'>Framed</button>"></iframe><script>toggle.onclick=()=>document.body.classList.toggle('on')</script>`
   const bounded = await runFixture(loopFixture, {
@@ -265,5 +307,43 @@ async function runFixture(html: string, input: Record<string, unknown>, signal?:
     return { result, contract }
   } finally {
     await browser.close()
+  }
+}
+
+async function runRoutedFixture(topology: ReturnType<typeof browserPreviewTopology>, effectiveOrigin: string, initialHtml?: string) {
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext()
+  await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, effectiveOrigin)
+  const page = await context.newPage()
+  const consoleMessages: object[] = []
+  const errors: object[] = []
+  const network: object[] = []
+  page.on("console", (message) => consoleMessages.push({ type: message.type(), text: message.text() }))
+  page.on("pageerror", (error) => errors.push({ message: error.message }))
+  page.on("request", (request) => network.push({ url: request.url(), method: request.method() }))
+  await page.addInitScript("globalThis.__name = value => value")
+  await page.goto(effectiveOrigin, { waitUntil: "load" })
+  if (initialHtml) await page.setContent(`<!doctype html><style>a{display:block;width:180px;height:30px}</style>${initialHtml}`)
+  const contract = browserAdaptiveExplorationContract({
+    seed: "routed-multisite",
+    startUrl: effectiveOrigin,
+    failOnFinding: false,
+    resetPolicy: { mode: "none" },
+    actionFamilies: ["click"],
+    budgets: { maxActions: initialHtml ? 1 : 2, maxStates: 4, maxTransitions: 2, maxDurationMs: 10_000 },
+    stabilization: { pollIntervalMs: 25, quietWindowMs: 50, maxWaitMs: 500, maxMutationRecords: 20 },
+  })
+  try {
+    return await exploreAdaptiveBrowserStateMachine({ page, baseUrl: effectiveOrigin, contract, observations: { consoleMessages, errors, network }, navigationScope: topology.navigationScope })
+  } finally {
+    await browser.close()
+  }
+}
+
+function stableAdaptiveEvidence(result: Awaited<ReturnType<typeof runRoutedFixture>>) {
+  return {
+    states: result.states.map((state) => ({ digest: state.digest, url: state.url, descriptors: state.descriptors.map((descriptor) => descriptor.id) })),
+    transitions: result.transitions.map((transition) => ({ source: transition.sourceDigest, destination: transition.destinationDigest, action: transition.action.id, status: transition.status })),
+    diagnostics: result.diagnostics,
   }
 }

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -112,6 +112,28 @@ assert.deepEqual(topology.authCookieUrls(["https://example.test/wp-admin/"]), [
 ])
 assert.equal(topology.networkPolicy.mode, "block")
 assert.deepEqual([...topology.networkPolicy.routeHosts].sort(), ["example.test", "static.example.test"])
+assert.deepEqual(topology.navigationScope.resolve("/beta/", "https://example.test/alpha/"), {
+  allowed: true,
+  rawOrigin: "https://example.test",
+  effectiveOrigin: "https://example.test",
+  routeDecision: "relative",
+  reason: "effective-preview-origin",
+})
+assert.deepEqual(topology.navigationScope.resolve("http://static.example.test:8080/alpha/", "https://example.test/"), {
+  allowed: true,
+  rawOrigin: "http://static.example.test:8080",
+  effectiveOrigin: "https://example.test",
+  routeDecision: "routed-preview",
+  reason: "declared-route-host",
+})
+assert.deepEqual(topology.navigationScope.resolve("https://cdn.example.test/asset", "https://example.test/"), {
+  allowed: false,
+  rawOrigin: "https://cdn.example.test",
+  effectiveOrigin: "https://cdn.example.test",
+  routeDecision: "external",
+  reason: "network-host-allowed-but-not-routed",
+})
+assert.equal(topology.navigationScope.resolve("https://outside.example/", "https://example.test/").reason, "host-not-routed-to-preview")
 assert.deepEqual(browserPreviewAuthCookieUrls("http://localhost:9400", ["PUBLIC.example.test"], ["https://public.example.test/wp-admin/"]), ["http://localhost/", "https://public.example.test/"])
 
 let activeUpstreamRequests = 0


### PR DESCRIPTION
## Summary
- derive adaptive navigation eligibility from runtime-playground's resolved preview topology, treating only the effective origin and declared `route-host` aliases as in-runtime
- retain deterministic, sanitized routing evidence for allowed aliases and rejected external links without promoting network-only `allow-host` entries
- stop routed responses that redirect outside preview scope and record the adaptive transition as rejected

## Root cause
Adaptive descriptor filtering compared each link's raw origin only with Playwright's effective ephemeral preview origin. Canonical WordPress links such as `http://localhost/alpha/` were therefore removed before the existing routed-host layer could map them back to the disposable runtime.

## Routing and layer ownership
The new navigation-scope decision is derived directly from `BrowserPreviewNetworkPolicy.routeHosts` and the effective preview origin in `runtime-playground`. No parallel host allowlist or host literal was added, and runtime-core contracts remain provider-neutral and unchanged.

## Security boundaries
- `network-policy=block` behavior is preserved
- only declared routed aliases resolve to the disposable preview
- `allow-host` remains network access only and does not grant adaptive navigation scope
- undeclared external hosts are rejected before adaptive navigation
- evidence records origins and policy reasons, not URL paths, queries, or secrets

## Redirect behavior
Routed fetches may continue within declared route aliases or return to the effective preview origin. Redirects to any other origin are aborted, counted as blocked, emitted as sanitized `browser_adaptive_redirect_scope_escape_rejected` evidence, and represented by a rejected transition rather than a successful one.

## Tests
Passed:
- `npx tsx --test tests/browser-adaptive-exploration.test.ts tests/browser-callback-materialization-contracts.test.ts` (9/9)
- `npm run build`
- schema, recipe browser evidence, recipe validation, public API, and runtime package export suites (5/5)
- broad browser suite (43/44 relevant tests passed)

The broad browser suite's sole failure is an unchanged stale signature assertion in `tests/browser-blueprint-ref-permission.test.ts`. `npm run check` also reaches the unchanged `command-registry-smoke` failure tracked by #1745; production boundary enforcement and all preceding checks pass. The external Extra Chill multisite campaign was not rerun from this repository worktree, but the focused Playwright fixture reproduces its ephemeral-loopback/canonical-host topology and explores `/alpha/` then relative `/beta/` deterministically.

## Compatibility
Existing same-origin and relative links retain their prior behavior. Existing browser actions, scenarios, replay contracts, and runtime-core schemas are unchanged.

Fixes #2032