### PR TITLE
fix: require explicit plugin composer preparation

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -201,10 +201,13 @@ summary from observed hosts to declared boundary ids where host names match
 
 `inputs.extra_plugins` mounts additional WordPress plugins before workflow steps
 run. Each entry requires `source` or `sourcePath` and may include `sourceSubdir`,
-`mountSlug`, `pluginFile`, `activate`, `loadAs`, and `sha256`. `sourcePath` is
-the source root, `sourceSubdir` is an optional plugin directory below that root,
-`mountSlug` is the WordPress plugin directory, and `pluginFile` is relative to
-the mounted plugin slug.
+`mountSlug`, `pluginFile`, `activate`, `loadAs`, `composer`, and `sha256`.
+`sourcePath` is the source root, `sourceSubdir` is an optional plugin directory
+below that root, `mountSlug` is the WordPress plugin directory, and `pluginFile`
+is relative to the mounted plugin slug. Local plugins are mounted as shipped;
+the presence of `composer.json` does not install dependencies or mutate the
+source. Set `composer` to `install` only when a source-form plugin requires a
+missing `vendor/autoload.php`. WP Codebox then runs Composer in a temporary copy.
 
 ```json
 {
@@ -226,7 +229,8 @@ the mounted plugin slug.
         "sourcePath": "../monorepo",
         "sourceSubdir": "plugins/example-plugin",
         "mountSlug": "example-plugin",
-        "pluginFile": "example-plugin/example-plugin.php"
+        "pluginFile": "example-plugin/example-plugin.php",
+        "composer": "install"
       }
     ]
   }

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -279,7 +279,7 @@ export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeD
     const pluginResolved = sourceSubpath ? { ...resolved, source: join(resolved.source, sourceSubpath) } : resolved
     const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
     const loadAs = plugin.loadAs ?? "plugin"
-    const prepared = await prepareComposerAutoloadForPlugin(pluginResolved, slug, sourceRef, resolved.source)
+    const prepared = await prepareComposerAutoloadForPlugin(pluginResolved, slug, sourceRef, plugin.composer, resolved.source)
     await assertPreparedPluginFileExists(prepared.source, pluginFile.slice(slug.length + 1), sourceRef)
     plugins.push({
       source: prepared.source,
@@ -300,9 +300,13 @@ export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeD
   return plugins
 }
 
-async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource, slug: string, sourceRef: string, copyRoot = prepared.source): Promise<PreparedExternalSource> {
-  if (prepared.provenance.kind !== "local") {
+async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource, slug: string, sourceRef: string, strategy: WorkspaceRecipeExtraPlugin["composer"], copyRoot = prepared.source): Promise<PreparedExternalSource> {
+  if (strategy !== "install") {
     return prepared
+  }
+
+  if (prepared.provenance.kind !== "local") {
+    throw new Error(`Recipe extra plugin Composer preparation only supports local sources: ${sourceRef}`)
   }
 
   try {
@@ -317,7 +321,6 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
   try {
     const autoload = await stat(join(prepared.source, "vendor", "autoload.php"))
     if (autoload.isFile()) {
-      await writeComposerInstalledPackageAutoloader(prepared.source)
       return prepared
     }
   } catch {
@@ -401,6 +404,7 @@ if (is_file($wp_codebox_composer_package_classmap)) {
 
   await writeFile(packageAutoloader, `<?php
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/autoload.php';
 ${classmapLoader}
 `)
 }

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -229,6 +229,9 @@ function normalizeExtraPlugins(plugins: readonly WorkspaceRecipeExtraPlugin[] = 
     if (plugin.loadAs !== undefined) {
       normalized.loadAs = plugin.loadAs
     }
+    if (plugin.composer !== undefined) {
+      normalized.composer = plugin.composer
+    }
 
     return normalized
   })

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -801,6 +801,10 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           pluginFile: { type: "string" },
           activate: { type: "boolean" },
           loadAs: { enum: ["plugin", "mu-plugin"] },
+          composer: {
+            enum: ["install"],
+            description: "Explicitly run Composer install in a staged copy of a local plugin when vendor/autoload.php is missing.",
+          },
           sha256: { type: "string", pattern: "^[a-fA-F0-9]{64}$" },
           metadata: { $ref: "#/$defs/metadata" },
         },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -481,6 +481,7 @@ export interface WorkspaceRecipeExtraPlugin {
   activate?: boolean
   sha256?: string
   loadAs?: "plugin" | "mu-plugin"
+  composer?: "install"
   metadata?: Record<string, unknown>
 }
 

--- a/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
+++ b/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
@@ -133,6 +133,7 @@ writeFileSync(recipePath, `${JSON.stringify({
         sourceSubpath: "plugins/woocommerce",
         slug: "composer-autoload-smoke",
         pluginFile: "composer-autoload-smoke/composer-autoload-smoke.php",
+        composer: "install",
       },
     ],
   },

--- a/tests/recipe-extra-plugin-composer-preparation.test.ts
+++ b/tests/recipe-extra-plugin-composer-preparation.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { cleanupRecipePreparedSources, prepareRecipeExtraPlugins } from "../packages/cli/src/recipe-sources.js"
+import { assertWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+await withTempDir("wp-codebox-composer-metadata-plugin-", async (recipeDirectory) => {
+  const source = join(recipeDirectory, "shipped-plugin")
+  await mkdir(source, { recursive: true })
+  await writeFile(join(source, "composer.json"), `${JSON.stringify({ name: "example/shipped-plugin", require: { "composer/installers": "^2" } }, null, 2)}\n`)
+  await writeFile(join(source, "shipped-plugin.php"), "<?php\n/* Plugin Name: Shipped Plugin */\n")
+
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: { extra_plugins: [{ source: "shipped-plugin", slug: "shipped-plugin", pluginFile: "shipped-plugin/shipped-plugin.php" }] },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  }
+
+  assertWorkspaceRecipeJsonSchema(recipe)
+  const [plugin] = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+  assert.equal(plugin.source, source, "Composer metadata alone must not stage or prepare the plugin")
+  assert.deepEqual(plugin.cleanupPaths, [])
+  assert.equal(await pathExists(join(source, "vendor")), false, "the shipped plugin source must remain untouched")
+})
+
+await withTempDir("wp-codebox-explicit-composer-plugin-", async (recipeDirectory) => {
+  const source = join(recipeDirectory, "source-plugin")
+  const bin = join(recipeDirectory, "bin")
+  await mkdir(source, { recursive: true })
+  await mkdir(bin, { recursive: true })
+  await writeFile(join(source, "composer.json"), `${JSON.stringify({ name: "example/source-plugin", autoload: { classmap: ["src/"] } }, null, 2)}\n`)
+  await writeFile(join(source, "source-plugin.php"), "<?php\n/* Plugin Name: Source Plugin */\n")
+  const composer = join(bin, "composer")
+  await writeFile(composer, "#!/bin/sh\nmkdir -p vendor/composer\nprintf '<?php\\n' > vendor/autoload.php\nprintf '[]\\n' > vendor/composer/installed.json\nprintf '<?php return array();\\n' > vendor/composer/autoload_classmap.php\n")
+  await chmod(composer, 0o755)
+
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: { extra_plugins: [{ source: "source-plugin", slug: "source-plugin", pluginFile: "source-plugin/source-plugin.php", composer: "install" }] },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  }
+
+  assertWorkspaceRecipeJsonSchema(recipe)
+  const originalPath = process.env.PATH
+  process.env.PATH = `${bin}:${originalPath ?? ""}`
+  let plugin: Awaited<ReturnType<typeof prepareRecipeExtraPlugins>>[number] | undefined
+  try {
+    ;[plugin] = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+  } finally {
+    process.env.PATH = originalPath
+  }
+
+  assert.ok(plugin)
+  assert.notEqual(plugin.source, source, "explicit Composer preparation must use a staged copy")
+  assert.equal(await pathExists(join(plugin.source, "vendor", "autoload.php")), true)
+  assert.match(await readFile(join(plugin.source, "vendor", "autoload_packages.php"), "utf8"), /require_once __DIR__ \. '\/autoload\.php';/)
+  assert.equal(await pathExists(join(source, "vendor")), false, "explicit preparation must not mutate the caller source")
+  assert.equal(plugin.provenance.localPathCategory, "temporary-composer-autoload")
+  await cleanupRecipePreparedSources([], [plugin])
+})
+
+console.log("recipe extra plugin Composer preparation ok")


### PR DESCRIPTION
## Summary
- mount local extra plugins as shipped instead of treating any `composer.json` as proof that runtime dependencies must be installed
- add the explicit `composer: \"install\"` recipe contract for source-form plugins that require a missing `vendor/autoload.php`
- preserve staged-source provenance and caller immutability, and ensure generated package autoloaders chain into Composer's main autoloader

## Why
A Composer manifest can describe development tools, packaging metadata, or installer behavior without representing a runtime autoload requirement. Its presence alone is therefore insufficient evidence to fetch dependencies or mutate a plugin tree.

## Contract And Compatibility
Local `inputs.extra_plugins` entries are now mounted without Composer preparation by default, even when they contain `composer.json`. Callers that previously relied on implicit preparation must opt in with `composer: \"install\"`; WP Codebox then installs into a temporary staged copy only when `vendor/autoload.php` is absent. Existing shipped plugins with committed runtime dependencies continue to mount unchanged.

## Tests
- `npx tsx tests/recipe-extra-plugin-composer-preparation.test.ts`
- `npx tsx tests/recipe-extra-plugin-nested-source.test.ts`
- `npm run test:schema-parity`
- `npm run test:recipe-validation-descriptors`
- `npm run build`
- `npx tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts`

Fixes #2047