### PR TITLE
Preserve structured WP-CLI recipe results

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
     "test:cache-churn-observation-contracts": "tsx tests/cache-churn-observation-contracts.test.ts",
     "test:wordpress-db-contracts": "tsx tests/wordpress-db-contracts.test.ts",
     "test:wp-cli-temporary-script": "tsx tests/wp-cli-temporary-script.test.ts",
+    "test:wp-cli-recipe-result": "tsx tests/wp-cli-recipe-result.test.ts",
     "test:browser-sdk-facade": "tsx tests/browser-sdk-facade.test.ts",
     "check": "npm run test:production-boundary-enforcement && npm run smoke -- --group=check"
   },

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1480,7 +1480,10 @@ class PlaygroundRuntime implements Runtime {
       },
       this.runtimeId,
       argv,
-      (scriptPath) => this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath }),
+      async (scriptPath) => {
+        const response = await this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
+        return { ...response, text: response.text }
+      },
     )
   }
 

--- a/tests/wp-cli-recipe-result.test.ts
+++ b/tests/wp-cli-recipe-result.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createRuntime } from "../packages/runtime-core/src/index.js"
+import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+import { createPlaygroundRuntimeBackend } from "../packages/runtime-playground/src/index.js"
+import type { PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-wp-cli-result-"))
+const wordpressDirectory = join(root, "wordpress")
+const files = new Map<string, string>()
+const payload = { schema: "example/validation-result/v1", status: "ok", evidence: { retained: true } }
+let wrapperPath = ""
+
+const cliModule: PlaygroundCliModule = {
+  async runCLI() {
+    return {
+      serverUrl: "http://127.0.0.1:9404",
+      playground: {
+        async writeFile(path, contents) {
+          files.set(path, contents)
+          wrapperPath = path
+        },
+        unlink(path) {
+          files.delete(path)
+        },
+        async run(options) {
+          assert.ok("scriptPath" in options)
+          const scriptPath = options.scriptPath
+          assert.equal(files.has(scriptPath), true, "WP-CLI wrapper must exist while the command runs")
+          return {
+            exitCode: 0,
+            errors: "",
+            get text() {
+              return files.has(scriptPath) ? `${JSON.stringify(payload)}\n` : ""
+            },
+          }
+        },
+      },
+      async [Symbol.asyncDispose]() {},
+    }
+  },
+}
+
+const runtime = await createRuntime({
+  backend: "wordpress-playground",
+  artifactsDirectory: join(root, "artifacts"),
+  environment: {
+    kind: "wordpress",
+    name: "wp-cli-result",
+    version: "mounted-wordpress-source",
+    phpVersion: "8.4",
+    wordpressInstallMode: "do-not-attempt-installing",
+    assets: { wordpressDirectory },
+    blueprint: {},
+  },
+  policy: {
+    network: "deny",
+    filesystem: "sandbox",
+    commands: ["wordpress.wp-cli"],
+    secrets: "none",
+    approvals: "never",
+  },
+}, createPlaygroundRuntimeBackend({ cliModule }))
+
+try {
+  const execution = await executeRecipeWorkflowStep(runtime, {
+    phase: "steps",
+    index: 0,
+    step: { command: "wordpress.wp-cli", args: ["command=example validate --format=json"] },
+  }, root)
+
+  assert.equal(execution.exitCode, 0)
+  assert.equal(files.has(wrapperPath), false, "completed WP-CLI wrappers must be cleaned up")
+  assert.equal(execution.stdout, `${JSON.stringify(payload)}\n`)
+  assert.deepEqual(execution.result?.json, payload, "recipe output must retain successful structured WP-CLI output")
+} finally {
+  await runtime.destroy()
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("WP-CLI recipe result survives temporary wrapper cleanup")


### PR DESCRIPTION
## Summary
Preserve successful structured WP-CLI output before temporary wrapper cleanup so recipe consumers receive the command result.

## What changed
- Snapshot Playground response text while the temporary WP-CLI wrapper still exists.
- Add a recipe-level regression proving JSON output survives wrapper cleanup.
- Register the focused regression test as an npm script.

## How to test
1. Run `npm run test:wp-cli-recipe-result`; expect Structured WP-CLI JSON remains in execution.result.json after wrapper cleanup..
2. Run `npx tsx tests/wp-cli-temporary-script.test.ts`; expect All 3200 temporary wrapper invocations remain isolated across concurrency levels..

## Compatibility
Restores the existing WP-CLI recipe result contract without changing response schemas; exit codes, errors, and cleanup behavior remain intact.

## Evidence
- Base unchanged since verification: main remains at 6aa2b97cd4170cc6a3d2e350d316541547f35a7d.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/wp-codebox/issues/2048
- Verified finalization base: main at 6aa2b97cd4170cc6a3d2e350d316541547f35a7d
- build: passed (TypeScript project build completed) (Passed)
- composer-overlay: passed (Autoload layout contract preserved) (Passed)
- wp-cli-recipe-result: passed (Structured JSON survived wrapper cleanup) (Passed)
- wp-cli-temporary-script: passed (3200 isolated invocations) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced the lazy Playground response through temporary-script cleanup, implemented the narrow snapshot boundary, built recipe-level regression coverage, and reviewed deterministic gate evidence.

## Source relationships
- Closes Automattic/wp-codebox#2048
