### PR TITLE
Fix adaptive input action classification

### DIFF
--- a/packages/runtime-core/src/browser-adaptive-exploration.ts
+++ b/packages/runtime-core/src/browser-adaptive-exploration.ts
@@ -10,6 +10,10 @@ export const BROWSER_ADAPTIVE_EXPLORATION_ARTIFACT_SCHEMA = "wp-codebox/browser-
 export const BROWSER_ADAPTIVE_ACTION_FAMILIES = ["click", "fill", "select", "submit", "keyboard", "back", "reload", "repeat", "double-submit"] as const
 export type BrowserAdaptiveActionFamily = typeof BROWSER_ADAPTIVE_ACTION_FAMILIES[number]
 
+const TEXT_FILLABLE_INPUT_TYPES = new Set(["text", "search", "tel", "url", "email", "password", "number"])
+const CLICKABLE_INPUT_TYPES = new Set(["checkbox", "radio", "button", "reset", "submit", "image"])
+const SUBMIT_INPUT_TYPES = new Set(["submit", "image"])
+
 export interface BrowserAdaptiveExplorationContract {
   schema: typeof BROWSER_ADAPTIVE_EXPLORATION_SCHEMA
   context: BrowserRandomWalkContext
@@ -197,28 +201,35 @@ export function planBrowserAdaptiveStateActions(state: BrowserAdaptiveState, con
     const id = `${family}:${frameId}:${descriptor?.id ?? state.digest}`
     actions.push({ id, family, frameId, ...(descriptor ? { descriptorId: descriptor.id } : {}), steps, ...(input !== undefined ? { input } : {}) })
   }
+  const addClicks = (descriptor: BrowserActionCorpusDescriptor, submit: boolean) => {
+    const selector = descriptor.selector
+    add("click", descriptor, [{ kind: "click", selector }])
+    add("repeat", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])
+    if (submit && descriptor.formId) {
+      add("submit", descriptor, [{ kind: "click", selector }])
+      add("double-submit", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])
+    }
+  }
   for (const descriptor of state.descriptors) {
     if (descriptor.disabled || descriptor.readonly) continue
     const selector = descriptor.selector
-    if (descriptor.kind === "input" || descriptor.kind === "textarea") {
+    const inputType = (descriptor.type ?? "text").toLowerCase()
+    if (descriptor.kind === "textarea" || (descriptor.kind === "input" && TEXT_FILLABLE_INPUT_TYPES.has(inputType))) {
       const value = generatedValue(contract.seed, descriptor)
       add("fill", descriptor, [{ kind: "fill", selector, value }], value)
       add("keyboard", descriptor, [{ kind: "press", selector, key: "Enter" }])
       if (descriptor.formId) add("submit", descriptor, [{ kind: "fill", selector, value }, { kind: "press", selector, key: "Enter" }], value)
       add("repeat", descriptor, [{ kind: "fill", selector, value }, { kind: "fill", selector, value }], value)
+    } else if (descriptor.kind === "input" && CLICKABLE_INPUT_TYPES.has(inputType)) {
+      addClicks(descriptor, SUBMIT_INPUT_TYPES.has(inputType))
     } else if (descriptor.kind === "select") {
       const values = descriptor.optionValues?.filter(Boolean) ?? []
       if (values.length > 0) {
         const value = values[parseInt(browserAdaptiveDigest("action", `${contract.seed}:${descriptor.id}`).slice(0, 8), 16) % values.length] as string
         add("select", descriptor, [{ kind: "select", selector, value }], value)
       }
-    } else {
-      add("click", descriptor, [{ kind: "click", selector }])
-      add("repeat", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])
-      if (descriptor.type === "submit" && descriptor.formId) {
-        add("submit", descriptor, [{ kind: "click", selector }])
-        add("double-submit", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])
-      }
+    } else if (descriptor.kind !== "input") {
+      addClicks(descriptor, inputType === "submit")
     }
   }
   if (contract.accessibility && contract.actionFamilies.includes("keyboard")) {

--- a/tests/browser-adaptive-exploration.test.ts
+++ b/tests/browser-adaptive-exploration.test.ts
@@ -9,7 +9,9 @@ import {
   planBrowserAdaptiveStateActions,
 } from "../packages/runtime-core/src/browser-adaptive-exploration.js"
 import { getCommandDefinition } from "../packages/runtime-core/src/command-registry.js"
+import { discoverBrowserActionCorpusDescriptors } from "../packages/runtime-playground/src/browser-action-discovery.js"
 import { exploreAdaptiveBrowserStateMachine } from "../packages/runtime-playground/src/browser-adaptive-explorer.js"
+import { executeBrowserInteractionStep } from "../packages/runtime-playground/src/browser-interactions.js"
 import { browserPreviewTopology, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import { closeHttpServer, listenLocalHttpServer } from "../packages/runtime-playground/src/preview-server.js"
 
@@ -109,6 +111,84 @@ test("adaptive contract normalizes every safety and exploration bound", () => {
     loadingIndicators: 0,
   }, allFamilies)
   assert.deepEqual(new Set(planned.map((action) => action.family)), new Set(["click", "fill", "select", "submit", "keyboard", "back", "reload", "repeat", "double-submit"]))
+})
+
+test("adaptive planner selects actions by HTML input type capability", () => {
+  const fillableTypes = ["text", "search", "tel", "url", "email", "password", "number"]
+  const toggleTypes = ["checkbox", "radio"]
+  const buttonTypes = ["button", "reset"]
+  const submitTypes = ["submit", "image"]
+  const unsupportedTypes = ["color", "date", "datetime-local", "file", "hidden", "month", "range", "time", "week"]
+  const descriptors = [
+    { id: "default", kind: "input" as const, selector: "#default", formId: "form", frameId: "document" },
+    ...[...fillableTypes, ...toggleTypes, ...buttonTypes, ...submitTypes, ...unsupportedTypes].map((type) => ({ id: type, kind: "input" as const, selector: `#${type}`, type, formId: "form", frameId: "document" })),
+    { id: "textarea", kind: "textarea" as const, selector: "#textarea", formId: "form", frameId: "document" },
+    { id: "disabled", kind: "input" as const, selector: "#disabled", type: "text", disabled: true, frameId: "document" },
+    { id: "readonly", kind: "input" as const, selector: "#readonly", type: "text", readonly: true, frameId: "document" },
+  ]
+  const contract = browserAdaptiveExplorationContract({ seed: "input-capabilities", startUrl: "/fixture" })
+  const planned = planBrowserAdaptiveStateActions({
+    digest: "state",
+    url: "/fixture",
+    historyLength: 1,
+    historyStateDigest: "history",
+    descriptorDigest: "descriptors",
+    descriptors,
+    frames: [{ id: "document", url: "/fixture", scope: "document" }],
+    visits: 1,
+    depth: 0,
+    loadingIndicators: 0,
+  }, contract)
+  const familiesFor = (id: string) => planned.filter((action) => action.descriptorId === id).map((action) => action.family)
+
+  for (const type of ["default", ...fillableTypes, "textarea"]) assert.deepEqual(familiesFor(type), ["fill", "keyboard", "submit", "repeat"], type)
+  for (const type of toggleTypes) assert.deepEqual(familiesFor(type), ["click", "repeat"], type)
+  for (const type of buttonTypes) assert.deepEqual(familiesFor(type), ["click", "repeat"], type)
+  for (const type of submitTypes) assert.deepEqual(familiesFor(type), ["click", "repeat", "submit", "double-submit"], type)
+  for (const type of [...unsupportedTypes, "disabled", "readonly"]) assert.deepEqual(familiesFor(type), [], type)
+  assert(planned.filter((action) => action.steps.some((step) => step.kind === "fill")).every((action) => ["default", ...fillableTypes, "textarea"].includes(action.descriptorId ?? "")))
+})
+
+test("planned input actions execute safely in a real browser", async () => {
+  const browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+  const fixture = `<!doctype html>
+    <style>input,textarea { display:block; width:180px; height:30px; margin:4px; }</style>
+    <form id="form">
+      <input id="checkbox" type="checkbox"><input id="radio" type="radio" name="choice">
+      <input id="text" type="text"><input id="password" type="password"><input id="email" type="email"><input id="search" type="search">
+      <textarea id="textarea"></textarea><input id="submit" type="submit" value="Submit"><input id="range" type="range"><input id="file" type="file">
+    </form>
+    <script>document.querySelector('#form').addEventListener('submit', (event) => event.preventDefault())</script>`
+  try {
+    await page.addInitScript("globalThis.__name = value => value")
+    await page.setContent(fixture)
+    await page.evaluate("globalThis.__name = value => value")
+    const discovery = await discoverBrowserActionCorpusDescriptors(page)
+    const contract = browserAdaptiveExplorationContract({ seed: "browser-input-capabilities", startUrl: page.url() })
+    const actions = planBrowserAdaptiveStateActions({
+      digest: "state",
+      url: page.url(),
+      historyLength: 1,
+      historyStateDigest: "history",
+      descriptorDigest: "descriptors",
+      descriptors: discovery.descriptors,
+      frames: [{ id: "document", url: page.url(), scope: "document" }],
+      visits: 1,
+      depth: 0,
+      loadingIndicators: 0,
+    }, contract).filter((action) => action.descriptorId)
+
+    assert(actions.some((action) => action.descriptorId?.includes("\"type\":\"checkbox\"") && action.steps.every((step) => step.kind === "click")))
+    assert(actions.some((action) => action.descriptorId?.includes("\"type\":\"radio\"") && action.steps.every((step) => step.kind === "click")))
+    assert(!actions.some((action) => action.descriptorId?.includes("\"type\":\"range\"") || action.descriptorId?.includes("\"type\":\"file\"")))
+    for (const action of actions) {
+      await page.setContent(fixture)
+      for (const step of action.steps) await executeBrowserInteractionStep(page, step, page.url(), 2_000, async () => ({ path: "unused", isDefault: false }))
+    }
+  } finally {
+    await browser.close()
+  }
 })
 
 test("rediscovery finds, minimizes, and replays a defect revealed by a dynamic modal", async () => {


### PR DESCRIPTION
## Summary
- classify adaptive actions by the HTML input type's supported interaction capability instead of treating every input as text-fillable
- use existing click/repeat semantics for checkbox, radio, and button-like inputs while retaining submit/double-submit behavior for submit controls
- leave file and browser-native controls unscheduled, and cover every standard input type plus real Playwright execution

## Root cause
`planBrowserAdaptiveStateActions()` routed every descriptor with `kind === \"input\"` through `locator.fill()`. That included checkbox, radio, submit, reset, file, range, date, color, and other controls that do not accept generated text values.

## Behavior by control type
- Text-fillable: default/text, search, tel, url, email, password, number, and textarea receive fill, keyboard, fill-plus-Enter submit, and repeat-fill actions.
- Toggle/button-like: checkbox, radio, button, and reset use click/repeat-click actions.
- Submit-capable: submit and image inputs use click/repeat-click plus submit/double-submit actions when associated with a form.
- Unsupported/native: color, date, datetime-local, file, hidden, month, range, time, and week receive no speculative adaptive action.
- Disabled and readonly controls remain excluded.

## Determinism and safety
Action IDs, family insertion order, seeded values, budgets, replay, and minimization contracts are unchanged. The fix only changes which existing interaction primitives are eligible for each descriptor. No new primitive or public contract was added, and file/browser-native controls are not manipulated speculatively.

## Verification
- `npm run build` (pass)
- `npx tsx --test tests/browser-adaptive-exploration.test.ts` (pass, 13 tests)
- `npm run test:browser-accessibility-oracles` (pass, 31 tests)
- `npm run test:adversarial-runtime` (pass, 16 tests)
- `npm run test:schema-parity` (pass)
- `npm run test:production-boundary-enforcement` (pass)
- `git diff --check` (pass)
- `npm run test:public-api-contract` (baseline failure: current `origin/main` already exports `browser-accessibility.js`, but the expected list was not updated; test and related source files are byte-identical to `origin/main`)
- `npm run check` (baseline failure after passing production-boundary enforcement and earlier smoke commands: `command-registry-smoke` reports `wordpress.collect-workload-result outputShape should mention outputSchema id`; involved files are byte-identical to `origin/main`)

Fixes #2066