### PR TITLE
fix: rebuild stale source launcher output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,7 @@ Callers can gate success on post-agent verification through `verify_steps`: an a
 
 Each component contract declares `slug`, `path` or `source`, optional explicit `pluginFile`, optional `activate`, optional `loadAs`, and optional `readiness_probe` metadata.
 
-The CLI binary can come from ability input, the `wp_codebox_bin` option, or the `wp_codebox_bin` filter. Source-checkout snapshots that do not include generated `dist/` files should point at `bin/wp-codebox-source.mjs`; it builds WP Codebox when needed before delegating to the compiled CLI.
+The CLI binary can come from ability input, the `wp_codebox_bin` option, or the `wp_codebox_bin` filter. Source-checkout snapshots should point at `bin/wp-codebox-source.mjs`; it runs the incremental source build before every invocation so ignored `dist/` output cannot predate the checked-out core, Playground, or CLI source, then delegates to the compiled CLI.
 
 Caller-owned runtime components can provide workspace, file, GitHub, or other tools to the sandboxed agent. WP Codebox owns the parent-site ability surface, sandbox lifecycle, and artifact capture boundary.
 

--- a/bin/wp-codebox-source.mjs
+++ b/bin/wp-codebox-source.mjs
@@ -35,18 +35,21 @@ function run(command, args, options = {}) {
   }
 
   if (result.status !== 0) {
+    if (options.failureContext) {
+      console.error(`WP Codebox source entrypoint failed to ${options.failureContext} (exit ${result.status ?? 1}).`)
+    }
     process.exit(result.status ?? 1)
   }
 }
 
-if (!existsSync(distEntrypoint)) {
+const distIsAbsent = !existsSync(distEntrypoint)
+if (distIsAbsent) {
   console.error("WP Codebox CLI dist entrypoint is absent; bootstrapping the source checkout before running the CLI.")
-
-  if (!existsSync(nodeModules)) {
-    run("npm", [existsSync(packageLock) ? "ci" : "install"])
-  }
-
-  run("npm", ["run", "build"])
 }
 
+if (!existsSync(nodeModules)) {
+  run("npm", [existsSync(packageLock) ? "ci" : "install"], { failureContext: "install source checkout dependencies" })
+}
+
+run("npm", ["run", "build"], { failureContext: "build the source checkout" })
 run(process.execPath, [distEntrypoint, ...process.argv.slice(2)], { cwd: callerCwd, delegate: true })

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -32,11 +32,11 @@ entrypoint instead of an ignored build artifact:
 node /path/to/wp-codebox/bin/wp-codebox-source.mjs commands --json
 ```
 
-The source entrypoint runs the compiled CLI when `packages/cli/dist/index.js`
-exists. When `dist/` is absent, it installs dependencies if needed, runs
-`npm run build`, then delegates to the compiled CLI. Parent WordPress runners
-also fail early with a diagnostic if `wp_codebox_bin` points at a missing `.js`
-or `.mjs` file.
+The source entrypoint installs dependencies when needed, runs the incremental
+`npm run build` across the core, Playground, and CLI packages, then delegates to
+the compiled CLI. This prevents ignored `dist/` output from an older checkout
+from being executed as current source. Parent WordPress runners also fail early
+with a diagnostic if `wp_codebox_bin` points at a missing `.js` or `.mjs` file.
 
 ## Smoke
 

--- a/scripts/source-checkout-entrypoint-smoke.ts
+++ b/scripts/source-checkout-entrypoint-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
-import { copyFile, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { promisify } from "node:util"
@@ -14,6 +14,11 @@ try {
   await mkdir(join(fixture, "bin"), { recursive: true })
   await mkdir(join(fixture, "node_modules"), { recursive: true })
   await mkdir(join(fixture, "scripts"), { recursive: true })
+  for (const packageName of ["runtime-core", "runtime-playground", "cli"]) {
+    await mkdir(join(fixture, "packages", packageName, "src"), { recursive: true })
+    await writeFile(join(fixture, "packages", packageName, "src", "index.ts"), `${packageName}-v1`)
+  }
+  await writeFile(join(fixture, "tsconfig.json"), "config-v1")
   await copyFile(join(root, "bin/wp-codebox-source.mjs"), join(fixture, "bin/wp-codebox-source.mjs"))
 
   await writeFile(
@@ -28,23 +33,64 @@ try {
 
   await writeFile(
     join(fixture, "scripts/build-fixture.mjs"),
-    `import { mkdir, writeFile } from "node:fs/promises"\n` +
+    `import { access, mkdir, readFile, writeFile } from "node:fs/promises"\n` +
+      `try { await access("fail-build"); console.error("fixture build failed intentionally"); process.exit(23) } catch (error) { if (error.code !== "ENOENT") throw error; }\n` +
+      `const inputs = ["packages/runtime-core/src/index.ts", "packages/runtime-playground/src/index.ts", "packages/cli/src/index.ts", "tsconfig.json"]\n` +
+      `const snapshot = await Promise.all(inputs.map(async (path) => await readFile(path, "utf8")))\n` +
+      `let builds = 0\n` +
+      `try { builds = Number(await readFile("build-count.txt", "utf8")) } catch (error) { if (error.code !== "ENOENT") throw error; }\n` +
       `await mkdir("packages/cli/dist", { recursive: true })\n` +
-      `await writeFile("build-ran.txt", "yes")\n` +
-      `await writeFile("packages/cli/dist/index.js", "console.log(JSON.stringify({ built: true, args: process.argv.slice(2), cwd: process.cwd() }))\\n")\n`,
+      `await writeFile("build-count.txt", String(builds + 1))\n` +
+      `await writeFile("packages/cli/dist/index.js", "const snapshot = " + JSON.stringify(snapshot) + "; console.log(JSON.stringify({ snapshot, args: process.argv.slice(2), cwd: process.cwd() })); if (process.argv.includes('exit-17')) process.exit(17)\\n")\n`,
   )
 
-  const { stdout, stderr } = await execFileAsync(process.execPath, [join(fixture, "bin/wp-codebox-source.mjs"), "commands", "--json"], { cwd: consumerWorkspace })
-  const output = JSON.parse(stdout)
+  const firstRun = await runLauncher("commands", "--json")
+  const output = JSON.parse(firstRun.stdout)
 
-  assert.match(stderr, /dist entrypoint is absent/)
-  assert.match(stderr, /> build/)
-  assert.equal(output.built, true)
+  assert.match(firstRun.stderr, /dist entrypoint is absent/)
+  assert.match(firstRun.stderr, /> build/)
   assert.deepEqual(output.args, ["commands", "--json"])
   assert.equal(await realpath(output.cwd), await realpath(consumerWorkspace))
+  assert.deepEqual(output.snapshot, ["runtime-core-v1", "runtime-playground-v1", "cli-v1", "config-v1"])
+
+  const currentRun = JSON.parse((await runLauncher("commands", "--json")).stdout)
+  assert.deepEqual(currentRun.snapshot, output.snapshot, "current dist still passes through the incremental build")
+
+  const staleInputs = [
+    ["packages/runtime-core/src/index.ts", "runtime-core-v2", 0],
+    ["packages/runtime-playground/src/index.ts", "runtime-playground-v2", 1],
+    ["packages/cli/src/index.ts", "cli-v2", 2],
+    ["tsconfig.json", "config-v2", 3],
+  ] as const
+  for (const [path, value, snapshotIndex] of staleInputs) {
+    await writeFile(join(fixture, path), value)
+    const rebuilt = JSON.parse((await runLauncher("commands", "--json")).stdout)
+    assert.equal(rebuilt.snapshot[snapshotIndex], value, `${path} did not invalidate generated output`)
+  }
+  assert.equal(await readFile(join(fixture, "build-count.txt"), "utf8"), "6")
+
+  await writeFile(join(fixture, "fail-build"), "yes")
+  await assert.rejects(runLauncher("commands", "--json"), (error: NodeJS.ErrnoException & { stderr?: string, stdout?: string }) => {
+    assert.equal(error.code, 23)
+    assert.equal(error.stdout, "", "stale CLI output must not run after a failed build")
+    assert.match(error.stderr ?? "", /fixture build failed intentionally/)
+    assert.match(error.stderr ?? "", /failed to build the source checkout \(exit 23\)/)
+    return true
+  })
+  await rm(join(fixture, "fail-build"))
+
+  await assert.rejects(runLauncher("exit-17"), (error: NodeJS.ErrnoException & { code?: number, stderr?: string }) => {
+    assert.equal(error.code, 17)
+    assert.doesNotMatch(error.stderr ?? "", /source entrypoint failed/)
+    return true
+  })
 
   console.log("Source checkout entrypoint smoke passed")
 } finally {
   await rm(fixture, { recursive: true, force: true })
   await rm(consumerWorkspace, { recursive: true, force: true })
+}
+
+async function runLauncher(...args: string[]) {
+  return await execFileAsync(process.execPath, [join(fixture, "bin/wp-codebox-source.mjs"), ...args], { cwd: consumerWorkspace })
 }


### PR DESCRIPTION
## Summary

- run the existing incremental TypeScript project-reference build before every source-launcher invocation
- fail closed with an actionable diagnostic when dependency installation or the source build fails
- expand the source-launcher smoke fixture across absent/current output, runtime-core, runtime-playground, CLI/config changes, build failure, caller CWD/arguments, and delegated exit propagation
- document that source-checkout startup validates generated output before delegation

Fixes #2067

## Freshness semantics

`bin/wp-codebox-source.mjs` now invokes `npm run build` on every source invocation after preserving the existing dependency bootstrap behavior. That build is the repository's existing incremental `tsc -b` graph over `packages/runtime-core`, `packages/runtime-playground`, and `packages/cli`, followed by the CLI executable-bit check.

Because delegation happens only after that graph succeeds, ignored generated packages from an older checkout cannot bypass TypeScript's source/config freshness checks. Runtime-core and runtime-playground are explicit project references of the CLI build, so stale runtime packages are checked before the CLI entrypoint runs. A build failure exits with the build status and never delegates to the stale CLI.

Installed and release CLIs remain unchanged: they continue to execute packaged `packages/cli/dist/index.js` directly. This behavior applies only to the committed source launcher.

## Startup cost and tradeoff

This deliberately reuses the existing incremental compiler rather than introducing a parallel digest, stamp, or cache substrate. On this checkout, a current no-op build took about 0.4 seconds. Changed projects pay their normal incremental compile cost in exchange for source-revision correctness.

## Verification

Passed:

- `npm exec -- tsx scripts/source-checkout-entrypoint-smoke.ts`
- `npm run build:release && node packages/cli/dist/index.js --version`
- `npm run test:runtime-package-execution`
- `npm run test:runtime-contract-package-exports`
- `npm run test:release-package-coverage`
- `node bin/wp-codebox-source.mjs --version`
- `git diff --check`

Repository baseline limitation:

- `npm run check` passed production boundary enforcement and proceeded into its 96-command smoke group, then failed in the unrelated existing `command-registry-smoke` assertion: `wordpress.collect-workload-result outputShape should mention outputSchema id`. This PR changes only the source launcher, its smoke fixture, and source-development documentation; it does not touch command registry or collect-workload-result code.