### PR TITLE
fix: enforce accessibility scopes for focus findings

### DIFF
--- a/docs/adversarial-runtime.md
+++ b/docs/adversarial-runtime.md
@@ -177,6 +177,19 @@ each novel state, and the final state. The contract accepts `ruleTags`,
 `includeScopes`, `excludeScopes`, `impactThreshold`, `cadence`, required or
 optional `rules`, `focus`, and `accessibilityTree` capabilities, plus explicit
 scan, violation, focus-history, tree-size, and keyboard-action budgets.
+Scope selectors are resolved independently in every inspectable frame. A target
+is included when it matches or descends from an `includeScopes` selector (or
+when no include selector is declared), and it is always removed when it matches
+or descends from an `excludeScopes` selector. Excludes therefore override
+overlapping or nested includes. The same rule applies to static, keyboard,
+focus, and dialog findings. Focus may cross a scope boundary and remain in the
+bounded transition history or a finding's expected/actual context, but an
+out-of-scope element is never itself emitted as the finding target.
+
+Invalid scope selectors and include selectors that match no inspectable frame
+make the scan inconclusive instead of producing a silent pass. Frames that
+cannot be inspected produce an explicit diagnostic; findings from inspectable
+same-origin frames retain their stable frame identity.
 
 ```json
 {

--- a/packages/runtime-playground/src/browser-accessibility-collector.ts
+++ b/packages/runtime-playground/src/browser-accessibility-collector.ts
@@ -15,9 +15,12 @@ interface PageAccessibilityState {
   url: string
   focusedDocument?: boolean
   active: ElementEvidence
+  activeInScope: boolean
+  activeDialogKey?: string
   dialogs: ElementEvidence[]
   findings: Array<Omit<BrowserAccessibilityFinding, "fingerprint" | "stateDigest" | "transitionId" | "actionId">>
   diagnostics: Array<{ code: string; message: string }>
+  includeScopeMatches: number
 }
 
 interface ElementEvidence {
@@ -35,9 +38,10 @@ export function createBrowserAccessibilityCollector(page: Page, contract: Browse
   const scans: BrowserAccessibilityScan[] = []
   const focusHistory: BrowserAccessibilityEvidence["focusHistory"] = []
   const diagnostics: BrowserAccessibilityEvidence["diagnostics"] = []
-  const dialogTriggers = new Map<string, string>()
+  const dialogTriggers = new Map<string, ElementEvidence>()
   let before: PageAccessibilityState | undefined
-  let previousActive: string | undefined
+  let previousActiveKey: string | undefined
+  let previousActiveLocator: string | undefined
   let currentAction: BrowserAdaptiveAction | undefined
   let truncated = false
   let scanAttempts = 0
@@ -58,26 +62,28 @@ export function createBrowserAccessibilityCollector(page: Page, contract: Browse
       const findings = [...state.findings]
       const action = input.action ?? currentAction
 
-      if (contract.ruleTags.includes("focus-loss") && action && state.url === before?.url && state.active.locator === "body" && before.active.locator !== "body") {
-        findings.push(finding("focus", "focus-loss", "browser-focus-lost", "serious", "focus-lost-to-document", state.active, "an interaction target", "document body"))
+      if (contract.ruleTags.includes("focus-loss") && action && state.url === before?.url && state.active.locator === "body" && before.active.locator !== "body" && before.activeInScope) {
+        findings.push(finding("focus", "focus-loss", "browser-focus-lost", "serious", "focus-lost-to-document", before.active, "focus retained or moved intentionally", "document body"))
       }
 
       if (contract.ruleTags.includes("dialog-focus")) {
-        const beforeDialogs = new Set((before?.dialogs ?? []).map((dialog) => dialog.locator))
-        const currentDialogs = new Set(state.dialogs.map((dialog) => dialog.locator))
+        const beforeDialogs = new Set((before?.dialogs ?? []).map(elementKey))
+        const currentDialogs = new Set(state.dialogs.map(elementKey))
         for (const dialog of state.dialogs) {
-          if (!beforeDialogs.has(dialog.locator) && action) dialogTriggers.set(dialog.locator, before?.active.locator ?? "body")
-          if (!state.active.insideDialog) {
+          const key = elementKey(dialog)
+          if (!beforeDialogs.has(key) && action) dialogTriggers.set(key, before?.active ?? state.active)
+          if (state.activeDialogKey !== key) {
             findings.push(finding("focus", "dialog-focus", "browser-dialog-focus-entry", "serious", "dialog-focus-not-contained", dialog, "focus inside the open dialog", state.active.locator))
           }
         }
         for (const dialog of before?.dialogs ?? []) {
-          if (currentDialogs.has(dialog.locator)) continue
-          const trigger = dialogTriggers.get(dialog.locator)
-          if (trigger && state.active.locator !== trigger) {
-            findings.push(finding("focus", "dialog-focus", "browser-dialog-focus-restoration", "serious", "dialog-focus-not-restored", state.active, trigger, state.active.locator))
+          const key = elementKey(dialog)
+          if (currentDialogs.has(key)) continue
+          const trigger = dialogTriggers.get(key)
+          if (trigger && elementKey(state.active) !== elementKey(trigger)) {
+            findings.push(finding("focus", "dialog-focus", "browser-dialog-focus-restoration", "serious", "dialog-focus-not-restored", dialog, trigger.locator, state.active.locator))
           }
-          dialogTriggers.delete(dialog.locator)
+          dialogTriggers.delete(key)
         }
       }
 
@@ -90,17 +96,20 @@ export function createBrowserAccessibilityCollector(page: Page, contract: Browse
         })
       if (findings.length > retained.length) truncated = true
 
-      if (state.active.locator !== previousActive && focusHistory.length < contract.budgets.maxFocusTransitions) {
-        focusHistory.push({ index: focusHistory.length, phase: input.phase, actionId: action?.id, from: previousActive, to: state.active.locator, visible: state.active.visible, insideDialog: state.active.insideDialog })
-      } else if (state.active.locator !== previousActive) {
+      const activeKey = elementKey(state.active)
+      if (activeKey !== previousActiveKey && focusHistory.length < contract.budgets.maxFocusTransitions) {
+        focusHistory.push({ index: focusHistory.length, phase: input.phase, actionId: action?.id, from: previousActiveLocator, to: state.active.locator, visible: state.active.visible, insideDialog: state.active.insideDialog })
+      } else if (activeKey !== previousActiveKey) {
         truncated = true
       }
-      previousActive = state.active.locator
+      previousActiveKey = activeKey
+      previousActiveLocator = state.active.locator
 
       const tree = await accessibilityTree(page, contract)
       const requiredUnavailable = tree.status !== "captured" && contract.capabilities.accessibilityTree === "required"
       const treeUnavailable = tree.status !== "captured" && contract.capabilities.accessibilityTree !== "disabled"
-      const status: BrowserAccessibilityScan["status"] = retained.length > 0 ? "findings" : treeUnavailable ? "unsupported" : state.diagnostics.some((item) => item.code === "browser_accessibility_scope_invalid") ? "inconclusive" : "passed"
+      const scopeInconclusive = state.diagnostics.some((item) => item.code === "browser_accessibility_scope_invalid" || item.code === "browser_accessibility_scope_unmatched")
+      const status: BrowserAccessibilityScan["status"] = retained.length > 0 ? "findings" : treeUnavailable ? "unsupported" : scopeInconclusive ? "inconclusive" : "passed"
       const scan: BrowserAccessibilityScan = {
         index: scanAttempts - 1,
         phase: input.phase,
@@ -119,7 +128,8 @@ export function createBrowserAccessibilityCollector(page: Page, contract: Browse
     },
     async reset() {
       before = undefined
-      previousActive = undefined
+      previousActiveKey = undefined
+      previousActiveLocator = undefined
       currentAction = undefined
       dialogTriggers.clear()
     },
@@ -167,12 +177,19 @@ async function inspectPage(page: Page, contract: BrowserAccessibilityContract): 
   }
   const main = states.find((state) => state.url === page.url()) ?? states[0]
   const focused = [...states].reverse().find((state) => state.focusedDocument)
+  const stateDiagnostics = states.flatMap((state) => state.diagnostics)
+  if (contract.includeScopes.length > 0 && states.reduce((count, state) => count + state.includeScopeMatches, 0) === 0) {
+    stateDiagnostics.push({ code: "browser_accessibility_scope_unmatched", message: "No declared accessibility include scope matched an inspectable frame; the scan is inconclusive." })
+  }
   return {
     url: page.url(),
     active: focused?.active ?? main?.active ?? { locator: "body", frameId: "document", tag: "body", visible: true, insideDialog: false },
+    activeInScope: focused?.activeInScope ?? main?.activeInScope ?? false,
+    activeDialogKey: focused?.activeDialogKey ?? main?.activeDialogKey,
     dialogs: states.flatMap((state) => state.dialogs),
     findings: states.flatMap((state) => state.findings).slice(0, contract.budgets.maxViolationsPerScan * contract.budgets.maxTargetsPerViolation),
-    diagnostics: [...states.flatMap((state) => state.diagnostics), ...diagnostics],
+    diagnostics: [...stateDiagnostics, ...diagnostics],
+    includeScopeMatches: states.reduce((count, state) => count + state.includeScopeMatches, 0),
   }
 }
 
@@ -216,6 +233,7 @@ async function inspectFrame(frame: Frame, frameId: string, contract: BrowserAcce
       return { locator: path(target), frameId, tag: target.tagName.toLowerCase(), role: role(target), visible: visible(target), insideDialog: Boolean(target.closest("dialog,[role='dialog'],[role='alertdialog']")), states, box: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height), viewportWidth: innerWidth, viewportHeight: innerHeight } }
     }
     const invalidScopes = [...includeScopes, ...excludeScopes].filter((selector) => { try { document.querySelector(selector); return false } catch { return true } })
+    const includeScopeMatches = includeScopes.reduce((count, selector) => { try { return count + (document.querySelector(selector) ? 1 : 0) } catch { return count } }, 0)
     const inScope = (element: Element) => {
       const included = includeScopes.length === 0 || includeScopes.some((selector) => { try { return element.matches(selector) || Boolean(element.closest(selector)) } catch { return false } })
       const excluded = excludeScopes.some((selector) => { try { return element.matches(selector) || Boolean(element.closest(selector)) } catch { return false } })
@@ -278,13 +296,16 @@ async function inspectFrame(frame: Frame, frameId: string, contract: BrowserAcce
       }
     }
     const active = evidence(document.activeElement)
-    if (rules.includes("focus-visible") && document.activeElement && document.activeElement !== document.body && !active.visible) findings.push({ oracle: "focus", rule: "focus-visible", code: "browser-focused-element-hidden", impact: "serious", classification: "focus-in-hidden-inert-or-offscreen-content", target: active, expected: "visible and operable", actual: active.states?.inert === "true" ? "inert" : "hidden, clipped, or offscreen" })
+    const activeInScope = Boolean(document.activeElement && inScope(document.activeElement))
+    const activeDialog = document.activeElement?.closest("dialog,[role='dialog'],[role='alertdialog']")
+    const activeDialogKey = activeDialog ? `${frameId}\n${path(activeDialog)}` : undefined
+    if (rules.includes("focus-visible") && document.activeElement && document.activeElement !== document.body && activeInScope && !active.visible) findings.push({ oracle: "focus", rule: "focus-visible", code: "browser-focused-element-hidden", impact: "serious", classification: "focus-in-hidden-inert-or-offscreen-content", target: active, expected: "visible and operable", actual: active.states?.inert === "true" ? "inert" : "hidden, clipped, or offscreen" })
     const dialogs = Array.from(document.querySelectorAll("dialog,[role='dialog'],[role='alertdialog']")).filter((element) => {
       let nativeModal = false
       try { nativeModal = element.matches(":modal") } catch { nativeModal = element.tagName === "DIALOG" && (element as HTMLDialogElement).open }
       return (nativeModal || element.getAttribute("aria-modal") === "true") && visible(element) && inScope(element)
     }).map(evidence)
-    return { url: location.href, focusedDocument: document.hasFocus(), active, dialogs, findings, diagnostics: invalidScopes.length > 0 ? [{ code: "browser_accessibility_scope_invalid", message: "One or more accessibility scope selectors were invalid; the scan is inconclusive." }] : [] }
+    return { url: location.href, focusedDocument: document.hasFocus(), active, activeInScope, activeDialogKey, dialogs, findings, diagnostics: invalidScopes.length > 0 ? [{ code: "browser_accessibility_scope_invalid", message: "One or more accessibility scope selectors were invalid; the scan is inconclusive." }] : [], includeScopeMatches }
   }, { includeScopes: contract.includeScopes, excludeScopes: contract.excludeScopes, rules: contract.ruleTags, maxTargets: contract.budgets.maxViolationsPerScan * contract.budgets.maxTargetsPerViolation, frameId })
 }
 
@@ -303,6 +324,8 @@ async function accessibilityTree(page: Page, contract: BrowserAccessibilityContr
 function finding(oracle: BrowserAccessibilityFinding["oracle"], rule: BrowserAccessibilityFinding["rule"], code: string, impact: BrowserAccessibilityFinding["impact"], classification: string, target: ElementEvidence, expected?: string, actual?: string): Omit<BrowserAccessibilityFinding, "fingerprint" | "stateDigest" | "transitionId" | "actionId"> {
   return { oracle, rule, code, impact, classification, target, expected, actual }
 }
+
+function elementKey(element: ElementEvidence): string { return `${element.frameId}\n${element.locator}` }
 
 function impactRank(impact: BrowserAccessibilityFinding["impact"]): number { return { minor: 0, moderate: 1, serious: 2, critical: 3 }[impact] }
 

--- a/tests/browser-accessibility-oracles.test.ts
+++ b/tests/browser-accessibility-oracles.test.ts
@@ -116,6 +116,96 @@ test("same-origin frame findings retain frame identity", async () => {
   })
 })
 
+test("include and exclude scopes constrain static and focused targets", async () => {
+  await withPage(`<!doctype html>
+    <style>.offscreen { position:absolute; left:-5000px; width:20px; height:20px }</style>
+    <section id="component">
+      <input id="inside-unnamed">
+      <div id="inside-custom" role="button">Action</div>
+      <div id="inside-tab" tabindex="0">Tab stop</div>
+      <button id="inside-aria" aria-controls="panel" aria-expanded="false">Toggle</button><div id="panel">Panel</div>
+      <button id="inside-focus" class="offscreen">Inside focus</button>
+      <div id="excluded"><button id="excluded-unnamed"></button></div>
+    </section>
+    <button id="outside-unnamed"></button><button id="outside-focus" class="offscreen">Outside focus</button>`, async (page) => {
+    const contract = browserAccessibilityContract({ includeScopes: ["#component"], excludeScopes: ["#excluded"], impactThreshold: "moderate", capabilities: { accessibilityTree: "disabled" } })!
+    const collector = createBrowserAccessibilityCollector(page, contract)
+
+    await page.locator("#outside-focus").focus()
+    const outsideFocused = await collector.scan({ phase: "initial" })
+    assert(!outsideFocused.findings.some((finding) => finding.code === "browser-focused-element-hidden"), "out-of-scope focus is context, not a finding")
+    const unnamed = outsideFocused.findings.filter((finding) => finding.code === "browser-accessible-name-missing")
+    assert.equal(unnamed.length, 1)
+    assert.equal(unnamed[0]?.target.tag, "input", "outside and excluded unnamed buttons are filtered")
+    assert(outsideFocused.findings.some((finding) => finding.code === "browser-keyboard-unreachable"))
+    assert(outsideFocused.findings.some((finding) => finding.code === "browser-unexpected-tab-stop"))
+    assert(outsideFocused.findings.some((finding) => finding.code === "browser-aria-expanded-drift"))
+
+    await page.locator("#inside-focus").focus()
+    const insideFocused = await collector.scan({ phase: "novel-state" })
+    assert(insideFocused.findings.some((finding) => finding.code === "browser-focused-element-hidden" && finding.target.tag === "button"))
+    assert.equal(collector.evidence().focusHistory.length, 2, "bounded focus history retains cross-boundary context")
+  })
+})
+
+test("focus loss is attributed only to the scoped element that lost focus", async () => {
+  await withPage("<!doctype html><section id='component'><button id='inside'>Inside</button></section><button id='outside'>Outside</button>", async (page) => {
+    const contract = browserAccessibilityContract({ includeScopes: ["#component"], ruleTags: ["focus-loss"], capabilities: { accessibilityTree: "disabled" } })!
+    const collector = createBrowserAccessibilityCollector(page, contract)
+    const blur = action("blur", "#inside")
+
+    await page.locator("#outside").focus()
+    await collector.beforeAction(blur)
+    await page.evaluate(() => { document.body.tabIndex = -1; document.body.focus() })
+    const outside = await collector.scan({ phase: "novel-state", action: blur })
+    assert(!outside.findings.some((finding) => finding.code === "browser-focus-lost"))
+
+    await page.locator("#inside").focus()
+    await collector.beforeAction(blur)
+    await page.evaluate(() => document.body.focus())
+    const inside = await collector.scan({ phase: "novel-state", action: blur })
+    assert(inside.findings.some((finding) => finding.code === "browser-focus-lost" && finding.target.locator !== "body"))
+  })
+})
+
+test("scoped dialogs may cross focus boundaries without emitting out-of-scope targets", async () => {
+  await withPage(`<!doctype html>
+    <button id="outside-trigger">Open</button>
+    <div id="outside-dialog" role="dialog" aria-modal="true"><button id="outside-dialog-action">Outside dialog</button></div>
+    <section id="component"><div id="dialog" role="dialog" aria-modal="true" hidden><button>Close</button></div></section>
+    <script>
+      document.querySelector('#outside-trigger').onclick=()=>{ document.querySelector('#dialog').hidden=false };
+    </script>`, async (page) => {
+    const contract = browserAccessibilityContract({ includeScopes: ["#component"], ruleTags: ["dialog-focus"], capabilities: { accessibilityTree: "disabled" } })!
+    const collector = createBrowserAccessibilityCollector(page, contract)
+    const open = action("open", "#outside-trigger")
+    await page.locator("#outside-trigger").focus()
+    await collector.beforeAction(open)
+    await page.locator("#outside-trigger").click()
+    await page.locator("#outside-dialog-action").focus()
+    const opened = await collector.scan({ phase: "novel-state", action: open })
+    assert(opened.findings.some((finding) => finding.code === "browser-dialog-focus-entry" && finding.target.role === "dialog"))
+    assert(opened.findings.every((finding) => finding.target.role === "dialog"))
+
+    await collector.beforeAction(action("close", "#dialog"))
+    await page.locator("#dialog").evaluate((element) => { element.setAttribute("hidden", ""); document.querySelector<HTMLElement>("#outside-trigger")?.focus() })
+    const closed = await collector.scan({ phase: "novel-state" })
+    assert(!closed.findings.some((finding) => finding.code === "browser-dialog-focus-restoration"), "restoration to an out-of-scope trigger remains valid")
+  })
+})
+
+test("same-origin frame scopes filter static and focused findings within that frame", async () => {
+  await withPage(`<!doctype html><iframe srcdoc="<style>.offscreen{position:absolute;left:-5000px;width:20px;height:20px}</style><section class='scope'><input id='inside'><button id='inside-focus' class='offscreen'>Focus</button></section><button id='outside'></button>"></iframe>`, async (page) => {
+    const frame = page.locator("iframe").contentFrame()
+    await frame.locator("#inside-focus").focus()
+    const contract = browserAccessibilityContract({ includeScopes: [".scope"], ruleTags: ["accessible-name", "focus-visible"], capabilities: { accessibilityTree: "disabled" } })!
+    const scan = await createBrowserAccessibilityCollector(page, contract).scan({ phase: "initial" })
+    assert(scan.findings.some((finding) => finding.code === "browser-accessible-name-missing" && finding.target.frameId === "frame:0" && finding.target.tag === "input"))
+    assert(scan.findings.some((finding) => finding.code === "browser-focused-element-hidden" && finding.target.frameId === "frame:0"))
+    assert(!scan.findings.some((finding) => finding.code === "browser-accessible-name-missing" && finding.target.tag === "button"))
+  })
+})
+
 test("ARIA state drift is observed after both opening and closing a controlled panel", async () => {
   await withPage(`<!doctype html><button id="toggle" aria-controls="panel" aria-expanded="false">Toggle</button><div id="panel" hidden>Panel</div><script>document.querySelector('#toggle').onclick=()=>{ const panel=document.querySelector('#panel'); panel.hidden=!panel.hidden }</script>`, async (page) => {
     const collector = createBrowserAccessibilityCollector(page, requiredContract())
@@ -262,6 +352,15 @@ test("invalid scopes are inconclusive rather than false passes", async () => {
     const scan = await createBrowserAccessibilityCollector(page, contract).scan({ phase: "initial" })
     assert.equal(scan.status, "inconclusive")
     assert.equal(scan.diagnostics[0]?.code, "browser_accessibility_scope_invalid")
+  })
+})
+
+test("valid include scopes that match no inspectable frame are inconclusive", async () => {
+  await withPage("<!doctype html><button>Pass</button>", async (page) => {
+    const contract = browserAccessibilityContract({ includeScopes: ["#missing"], capabilities: { accessibilityTree: "disabled" } })!
+    const scan = await createBrowserAccessibilityCollector(page, contract).scan({ phase: "initial" })
+    assert.equal(scan.status, "inconclusive")
+    assert(scan.diagnostics.some((diagnostic) => diagnostic.code === "browser_accessibility_scope_unmatched"))
   })
 })
 


### PR DESCRIPTION
## Summary
- enforce `includeScopes` and `excludeScopes` for focus-visible, attributable focus-loss, and dialog focus findings using the collector's existing scope matcher
- retain out-of-scope focus only as bounded transition or expected/actual context, while keeping finding targets scoped and frame-aware
- mark scans inconclusive when declared include scopes match no inspectable frame, and document selector, exclusion, frame, and cross-boundary semantics

## Scope semantics
Targets match when they are a declared include root or its descendant, or when no include scope is declared. Matching exclude roots and descendants always win over includes. Static accessible-name, keyboard-reachable, tab-order, and ARIA-state scans continue through the same matcher; focus and dialog findings now obey it too.

Focus loss is attributed to the in-scope element that lost focus rather than the out-of-scope document body. Dialog entry and restoration obligations are attributed to the scoped dialog, while trigger and destination focus may remain contextual. Dialog and focus identities include frame identity internally so equivalent structural locators in different same-origin frames do not collide.

Invalid selectors remain inconclusive. Valid include selectors that collectively match no inspectable frame now emit `browser_accessibility_scope_unmatched` and are inconclusive rather than silently passing. Uninspectable frames retain the existing explicit `browser_accessibility_frame_unsupported` diagnostic.

## Tests
Passed:
- `npm run build`
- `npm run test:browser-accessibility-oracles` (34 tests)
- `npm run test:adversarial-runtime` (16 tests)
- `npm run test:redaction`
- `npm run test:runtime-command-artifact-bounds`
- `npm run test:evidence-bundle-digest-and-recipe-artifact`
- `npm run test:schema-parity`
- `npm run test:runtime-contract-manifest`
- `npm run test:runtime-contract-package-exports`
- `git diff --check`

New browser fixtures cover inside/outside focus targets, nested exclude precedence, attributable focus loss, cross-boundary dialog focus and restoration, unmatched scopes, and same-origin frame filtering with preserved frame IDs. Existing replay, fingerprint, privacy, and artifact-bound assertions remain passing.

## Baseline failures
- `npm run test:public-api-contract` fails in untouched code because the expected public barrel list omits the already-exported `./browser-accessibility.js` introduced on `main`.
- `npm run check` passes production-boundary enforcement and then reaches an unrelated existing `command-registry-smoke` failure: `wordpress.collect-workload-result outputShape should mention outputSchema id`.

## Limitations
Cross-origin or otherwise unavailable frame DOM remains outside the collector's inspection capability and is reported diagnostically; this change does not add cross-origin access or retain additional sensitive target content.

Fixes #2069
