### PR TITLE
Fix native Space scrolling in focus oracle

### DIFF
--- a/packages/runtime-core/src/browser-accessibility.ts
+++ b/packages/runtime-core/src/browser-accessibility.ts
@@ -84,7 +84,7 @@ export interface BrowserAccessibilityScan {
   actionId?: string
   findings: BrowserAccessibilityFinding[]
   accessibilityTree?: { status: "captured" | "unsupported" | "inconclusive"; snapshot?: string; reason?: string; truncated?: boolean }
-  diagnostics: Array<{ code: string; message: string }>
+  diagnostics: Array<{ code: string; message: string; metadata?: Record<string, unknown> }>
   artifacts?: { screenshot?: string; domSnapshot?: string }
 }
 

--- a/packages/runtime-playground/src/browser-accessibility-collector.ts
+++ b/packages/runtime-playground/src/browser-accessibility-collector.ts
@@ -17,7 +17,8 @@ interface PageAccessibilityState {
   active: ElementEvidence
   dialogs: ElementEvidence[]
   findings: Array<Omit<BrowserAccessibilityFinding, "fingerprint" | "stateDigest" | "transitionId" | "actionId">>
-  diagnostics: Array<{ code: string; message: string }>
+  diagnostics: Array<{ code: string; message: string; metadata?: Record<string, unknown> }>
+  nativeKeyboardScroll?: NativeKeyboardScrollEvidence
 }
 
 interface ElementEvidence {
@@ -26,9 +27,22 @@ interface ElementEvidence {
   tag: string
   role?: string
   visible: boolean
+  rendered: boolean
   insideDialog: boolean
   states?: BrowserAccessibilityFinding["target"]["states"]
   box?: BrowserAccessibilityFinding["target"]["box"]
+}
+
+interface NativeKeyboardScrollEvidence {
+  target: ElementEvidence
+  activeElementRetained: boolean
+  defaultPrevented: boolean
+  eventCompleted: boolean
+  synchronousScroll: boolean
+  scroll: { fromX: number; fromY: number; toX: number; toY: number }
+  boxBefore: NonNullable<ElementEvidence["box"]>
+  visibleBefore: boolean
+  inertBefore: boolean
 }
 
 export function createBrowserAccessibilityCollector(page: Page, contract: BrowserAccessibilityContract): BrowserAccessibilityCollector {
@@ -46,6 +60,7 @@ export function createBrowserAccessibilityCollector(page: Page, contract: Browse
     async beforeAction(action) {
       currentAction = action
       before = await inspectPage(page, contract)
+      await beginNativeKeyboardScrollObservation(page, action)
     },
     async scan(input) {
       if (scanAttempts >= contract.budgets.maxScans) {
@@ -58,7 +73,26 @@ export function createBrowserAccessibilityCollector(page: Page, contract: Browse
       const findings = [...state.findings]
       const action = input.action ?? currentAction
 
-      if (contract.ruleTags.includes("focus-loss") && action && state.url === before?.url && state.active.locator === "body" && before.active.locator !== "body") {
+      if (action && state.nativeKeyboardScroll && isNativeGeneratedSpaceScroll(action, state)) {
+        const index = findings.findIndex((item) => item.code === "browser-focused-element-hidden" && item.target.frameId === state.active.frameId && item.target.locator === state.active.locator)
+        if (index >= 0) {
+          findings.splice(index, 1)
+          const scroll = state.nativeKeyboardScroll.scroll
+          state.diagnostics.push({
+            code: "browser_focus_visibility_native_keyboard_scroll_suppressed",
+            message: "Offscreen focus was retained after an uncanceled generated Space action produced native page scrolling.",
+            metadata: {
+              actionId: action.id,
+              target: state.active.locator,
+              scrollDelta: { x: scroll.toX - scroll.fromX, y: scroll.toY - scroll.fromY },
+              activeElementRetained: true,
+            },
+          })
+        }
+      }
+
+      const interactionTarget = state.nativeKeyboardScroll?.target.locator ?? before?.active.locator
+      if (contract.ruleTags.includes("focus-loss") && action && state.url === before?.url && state.active.locator === "body" && interactionTarget && interactionTarget !== "body") {
         findings.push(finding("focus", "focus-loss", "browser-focus-lost", "serious", "focus-lost-to-document", state.active, "an interaction target", "document body"))
       }
 
@@ -173,6 +207,7 @@ async function inspectPage(page: Page, contract: BrowserAccessibilityContract): 
     dialogs: states.flatMap((state) => state.dialogs),
     findings: states.flatMap((state) => state.findings).slice(0, contract.budgets.maxViolationsPerScan * contract.budgets.maxTargetsPerViolation),
     diagnostics: [...states.flatMap((state) => state.diagnostics), ...diagnostics],
+    nativeKeyboardScroll: focused?.nativeKeyboardScroll ?? main?.nativeKeyboardScroll,
   }
 }
 
@@ -213,7 +248,7 @@ async function inspectFrame(frame: Frame, frameId: string, contract: BrowserAcce
         return value === null ? [] : [[name, value.slice(0, 120)]]
       }))
       if (target.closest("[inert]")) states.inert = "true"
-      return { locator: path(target), frameId, tag: target.tagName.toLowerCase(), role: role(target), visible: visible(target), insideDialog: Boolean(target.closest("dialog,[role='dialog'],[role='alertdialog']")), states, box: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height), viewportWidth: innerWidth, viewportHeight: innerHeight } }
+      return { locator: path(target), frameId, tag: target.tagName.toLowerCase(), role: role(target), visible: visible(target), rendered: rendered(target), insideDialog: Boolean(target.closest("dialog,[role='dialog'],[role='alertdialog']")), states, box: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height), viewportWidth: innerWidth, viewportHeight: innerHeight } }
     }
     const invalidScopes = [...includeScopes, ...excludeScopes].filter((selector) => { try { document.querySelector(selector); return false } catch { return true } })
     const inScope = (element: Element) => {
@@ -284,8 +319,95 @@ async function inspectFrame(frame: Frame, frameId: string, contract: BrowserAcce
       try { nativeModal = element.matches(":modal") } catch { nativeModal = element.tagName === "DIALOG" && (element as HTMLDialogElement).open }
       return (nativeModal || element.getAttribute("aria-modal") === "true") && visible(element) && inScope(element)
     }).map(evidence)
-    return { url: location.href, focusedDocument: document.hasFocus(), active, dialogs, findings, diagnostics: invalidScopes.length > 0 ? [{ code: "browser_accessibility_scope_invalid", message: "One or more accessibility scope selectors were invalid; the scan is inconclusive." }] : [] }
+    const observed = (globalThis as typeof globalThis & { __wpCodeboxNativeKeyboardScroll?: { active?: Element; defaultPrevented: boolean; eventCompleted: boolean; synchronousScroll: boolean; fromX: number; fromY: number; boxBefore: NonNullable<ElementEvidence["box"]>; visibleBefore: boolean; inertBefore: boolean } }).__wpCodeboxNativeKeyboardScroll
+    const nativeKeyboardScroll = observed ? {
+      target: evidence(observed.active ?? null),
+      activeElementRetained: observed.active === document.activeElement,
+      defaultPrevented: observed.defaultPrevented,
+      eventCompleted: observed.eventCompleted,
+      synchronousScroll: observed.synchronousScroll,
+      scroll: { fromX: observed.fromX, fromY: observed.fromY, toX: scrollX, toY: scrollY },
+      boxBefore: observed.boxBefore,
+      visibleBefore: observed.visibleBefore,
+      inertBefore: observed.inertBefore,
+    } : undefined
+    return { url: location.href, focusedDocument: document.hasFocus(), active, dialogs, findings, diagnostics: invalidScopes.length > 0 ? [{ code: "browser_accessibility_scope_invalid", message: "One or more accessibility scope selectors were invalid; the scan is inconclusive." }] : [], nativeKeyboardScroll }
   }, { includeScopes: contract.includeScopes, excludeScopes: contract.excludeScopes, rules: contract.ruleTags, maxTargets: contract.budgets.maxViolationsPerScan * contract.budgets.maxTargetsPerViolation, frameId })
+}
+
+async function beginNativeKeyboardScrollObservation(page: Page, action: BrowserAdaptiveAction): Promise<void> {
+  if (!isGeneratedDocumentSpaceAction(action)) return
+  await page.evaluate(() => {
+    type Observation = { active?: Element; defaultPrevented: boolean; eventCompleted: boolean; synchronousScroll: boolean; fromX: number; fromY: number; boxBefore: { x: number; y: number; width: number; height: number; viewportWidth: number; viewportHeight: number }; visibleBefore: boolean; inertBefore: boolean }
+    const target = globalThis as typeof globalThis & { __wpCodeboxNativeKeyboardScroll?: Observation; __wpCodeboxNativeKeyboardScrollInstalled?: boolean }
+    target.__wpCodeboxNativeKeyboardScroll = undefined
+    if (target.__wpCodeboxNativeKeyboardScrollInstalled) return
+    target.__wpCodeboxNativeKeyboardScrollInstalled = true
+    addEventListener("keydown", (event) => {
+      if (event.key !== " " || !document.activeElement) return
+      const rect = document.activeElement.getBoundingClientRect()
+      const style = getComputedStyle(document.activeElement)
+      const hiddenAncestor = document.activeElement.closest("[hidden],[inert],[aria-hidden='true']")
+      target.__wpCodeboxNativeKeyboardScroll = {
+        active: document.activeElement,
+        defaultPrevented: event.defaultPrevented,
+        eventCompleted: false,
+        synchronousScroll: false,
+        fromX: scrollX,
+        fromY: scrollY,
+        boxBefore: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height), viewportWidth: innerWidth, viewportHeight: innerHeight },
+        visibleBefore: !hiddenAncestor && rect.width > 0 && rect.height > 0 && style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0" && rect.bottom > 0 && rect.right > 0 && rect.top < innerHeight && rect.left < innerWidth,
+        inertBefore: Boolean(document.activeElement.closest("[inert]")),
+      }
+    }, true)
+    addEventListener("keydown", (event) => {
+      const observed = target.__wpCodeboxNativeKeyboardScroll
+      if (event.key !== " " || !observed) return
+      observed.defaultPrevented = event.defaultPrevented
+      observed.synchronousScroll ||= scrollX !== observed.fromX || scrollY !== observed.fromY
+    })
+    addEventListener("keyup", (event) => {
+      const observed = target.__wpCodeboxNativeKeyboardScroll
+      if (event.key !== " " || !observed) return
+      observed.defaultPrevented ||= event.defaultPrevented
+      observed.synchronousScroll ||= scrollX !== observed.fromX || scrollY !== observed.fromY
+      observed.eventCompleted = true
+    })
+  })
+}
+
+function isGeneratedDocumentSpaceAction(action: BrowserAdaptiveAction): boolean {
+  if (action.family !== "keyboard" || action.frameId !== "document" || action.descriptorId || action.descriptor) return false
+  const keys = action.steps.map((step) => step.kind === "press" && !step.selector ? String(step.key ?? "") : "")
+  return keys.length > 0 && keys.every(Boolean) && keys.at(-1) === "Space" && action.id === `keyboard:document:${keys.join(">")}`
+}
+
+function isNativeGeneratedSpaceScroll(action: BrowserAdaptiveAction, state: PageAccessibilityState): boolean {
+  const observed = state.nativeKeyboardScroll
+  const before = observed?.boxBefore
+  const after = state.active.box
+  if (!observed || !before || !after || !isGeneratedDocumentSpaceAction(action)) return false
+  const deltaX = observed.scroll.toX - observed.scroll.fromX
+  const deltaY = observed.scroll.toY - observed.scroll.fromY
+  const geometryTolerance = 2
+  return observed.eventCompleted
+    && !observed.defaultPrevented
+    && !observed.synchronousScroll
+    && observed.activeElementRetained
+    && observed.target.locator === state.active.locator
+    && observed.target.frameId === state.active.frameId
+    && observed.target.tag === "a"
+    && observed.target.role === "link"
+    && observed.visibleBefore
+    && !observed.inertBefore
+    && state.active.rendered
+    && state.active.states?.inert !== "true"
+    && deltaY > 0
+    && Math.abs(deltaX) <= geometryTolerance
+    && Math.abs((after.x - before.x) + deltaX) <= geometryTolerance
+    && Math.abs((after.y - before.y) + deltaY) <= geometryTolerance
+    && Math.abs(after.width - before.width) <= geometryTolerance
+    && Math.abs(after.height - before.height) <= geometryTolerance
 }
 
 async function accessibilityTree(page: Page, contract: BrowserAccessibilityContract): Promise<NonNullable<BrowserAccessibilityScan["accessibilityTree"]>> {

--- a/tests/browser-accessibility-oracles.test.ts
+++ b/tests/browser-accessibility-oracles.test.ts
@@ -98,6 +98,90 @@ test("navigation focus reset and below-fold expanded content do not false-positi
   })
 })
 
+for (const viewport of [{ width: 1280, height: 900 }, { width: 390, height: 844 }]) {
+  test(`native Tab+Space page scrolling retains link focus without a hidden-focus finding at ${viewport.width}x${viewport.height}`, async () => {
+    await withPage("<!doctype html><a href='#target'>First link</a><div style='height:3000px'></div><div id='target'>Target</div>", async (page) => {
+      await page.setViewportSize(viewport)
+      const collector = createBrowserAccessibilityCollector(page, requiredContract())
+      const keyboard = keyboardAction("Tab", "Space")
+      await collector.beforeAction(keyboard)
+      await page.keyboard.press("Tab")
+      await page.keyboard.press("Space")
+      await page.waitForTimeout(500)
+      const scan = await collector.scan({ phase: "novel-state", action: keyboard })
+      assert(!scan.findings.some((finding) => finding.code === "browser-focused-element-hidden"))
+      const diagnostic = scan.diagnostics.find((item) => item.code === "browser_focus_visibility_native_keyboard_scroll_suppressed")
+      assert(diagnostic)
+      assert.equal(diagnostic.metadata?.actionId, keyboard.id)
+      assert.equal(diagnostic.metadata?.activeElementRetained, true)
+      assert(Number((diagnostic.metadata?.scrollDelta as { y?: number })?.y) > 0)
+
+      if (viewport.width === 1280) {
+        await collector.reset()
+        await page.reload({ waitUntil: "load" })
+        await collector.beforeAction(keyboard)
+        await page.keyboard.press("Tab")
+        await page.keyboard.press("Space")
+        await page.waitForTimeout(500)
+        const replay = await collector.scan({ phase: "replay", action: keyboard, record: false })
+        assert(!replay.findings.some((finding) => finding.code === "browser-focused-element-hidden"))
+        assert(replay.diagnostics.some((item) => item.code === "browser_focus_visibility_native_keyboard_scroll_suppressed"))
+      }
+    })
+  })
+}
+
+test("activation keys, application concealment, script scrolling, and clipped focus are not exempted", async () => {
+  await withPage("<!doctype html><a id='link' href='#target'>Link</a><button id='button'>Button</button><output>0</output><div style='height:3000px'></div><div id='target'>Target</div><script>document.querySelector('a').onclick=()=>document.querySelector('output').value='1'</script>", async (page) => {
+    const collector = createBrowserAccessibilityCollector(page, requiredContract())
+
+    const enter = keyboardAction("Tab", "Enter")
+    await collector.beforeAction(enter)
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Enter")
+    assert.equal(await page.locator("output").textContent(), "1")
+    assert(!((await collector.scan({ phase: "novel-state", action: enter })).diagnostics.some((item) => item.code === "browser_focus_visibility_native_keyboard_scroll_suppressed")))
+
+    await page.goto(`data:text/html;charset=utf-8,${encodeURIComponent("<!doctype html><button>Button</button><output>0</output><div style='height:3000px'></div><script>document.querySelector('button').onclick=()=>document.querySelector('output').value='1'</script>")}`)
+    const buttonSpace = keyboardAction("Tab", "Space")
+    await collector.beforeAction(buttonSpace)
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Space")
+    assert.equal(await page.evaluate(() => scrollY), 0)
+    assert.equal(await page.locator("output").textContent(), "1")
+    assert(!((await collector.scan({ phase: "novel-state", action: buttonSpace })).diagnostics.some((item) => item.code === "browser_focus_visibility_native_keyboard_scroll_suppressed")))
+
+    await page.goto(`data:text/html;charset=utf-8,${encodeURIComponent("<!doctype html><a href='#'>Link</a><div style='height:3000px'></div><script>addEventListener('keyup',event=>{ if(event.key===' ') document.querySelector('a').style.opacity='0' })</script>")}`)
+    const concealed = keyboardAction("Tab", "Space")
+    await collector.beforeAction(concealed)
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Space")
+    await page.waitForTimeout(500)
+    assert((await collector.scan({ phase: "novel-state", action: concealed })).findings.some((finding) => finding.code === "browser-focused-element-hidden"))
+
+    await page.goto(`data:text/html;charset=utf-8,${encodeURIComponent("<!doctype html><main><a href='#'>Link</a></main><div style='height:3000px'></div><script>addEventListener('keyup',event=>{ if(event.key===' ') document.querySelector('main').inert=true })</script>")}`)
+    const inerted = keyboardAction("Tab", "Space")
+    await collector.beforeAction(inerted)
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Space")
+    await page.waitForTimeout(500)
+    const inertedScan = await collector.scan({ phase: "novel-state", action: inerted })
+    assert(inertedScan.findings.some((finding) => finding.code === "browser-focused-element-hidden" || finding.code === "browser-focus-lost"))
+
+    await page.goto(`data:text/html;charset=utf-8,${encodeURIComponent("<!doctype html><a href='#'>Link</a><div style='height:3000px'></div><script>addEventListener('keydown',event=>{ if(event.key===' ') scrollBy(0,300) })</script>")}`)
+    const scripted = keyboardAction("Tab", "Space")
+    await collector.beforeAction(scripted)
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Space")
+    await page.waitForTimeout(500)
+    assert((await collector.scan({ phase: "novel-state", action: scripted })).findings.some((finding) => finding.code === "browser-focused-element-hidden"))
+
+    await page.goto(`data:text/html;charset=utf-8,${encodeURIComponent("<!doctype html><a style='position:absolute;left:-5000px' href='#'>Clipped</a>")}`)
+    await page.locator("a").focus()
+    assert((await collector.scan({ phase: "novel-state", action: keyboardAction("Tab") })).findings.some((finding) => finding.code === "browser-focused-element-hidden"))
+  })
+})
+
 test("controls without nameable content and broken relationships are classified", async () => {
   await withPage("<!doctype html><select><option>Choose</option></select><button aria-controls='missing' aria-expanded='sometimes'>Toggle</button><div role='buton'>Typo</div>", async (page) => {
     const scan = await createBrowserAccessibilityCollector(page, requiredContract()).scan({ phase: "initial" })
@@ -276,6 +360,10 @@ function requiredContract() {
 
 function action(id: string, selector: string): BrowserAdaptiveAction {
   return { id, family: "click", frameId: "document", steps: [{ kind: "click", selector }] }
+}
+
+function keyboardAction(...keys: string[]): BrowserAdaptiveAction {
+  return { id: `keyboard:document:${keys.join(">")}`, family: "keyboard", frameId: "document", steps: keys.map((key) => ({ kind: "press", key })) }
 }
 
 async function withPage<T>(html: string, callback: (page: Page) => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
- distinguish Chromium's native Space page-down behavior from application-caused focused-element concealment
- suppress `browser-focused-element-hidden` only when bounded transition evidence proves an uncanceled generated document Space action retained focus on the same initially visible link and the element geometry moved exactly with the viewport
- retain serious findings for focus loss, inert/hidden content, application movement, explicit script scrolling, and genuinely offscreen targets

## Browser Semantic
On a focused normal link, Chromium does not activate the link for Space. It scrolls the document down by roughly one viewport while retaining focus, which moves the link's viewport-relative box offscreen. Buttons instead activate on Space without page scrolling, and links activate on Enter.

## Suppression Predicate
The collector records bounded key-transition context only for canonical generated document keyboard actions ending in Space. Suppression requires all of the following:

- canonical generated action identity with no descriptor or selector target
- completed, uncanceled Space key dispatch with no synchronous application scroll
- a visible, rendered, non-inert link at Space keydown
- the same active element after stabilization
- positive vertical viewport movement with no horizontal movement
- unchanged target dimensions and target box movement equal and opposite to the viewport scroll delta
- a still-rendered, non-inert target after the action

A bounded scan diagnostic records the action ID, normalized locator, scroll delta, and active-element continuity. Finding fingerprints remain unchanged because suppression context is not fingerprint input. Replay uses the same action instrumentation and predicate, including unrecorded minimization scans.

## False-Negative Safeguards
- Enter link activation and button Space activation do not enter the suppression path.
- Synchronous script scrolling marks the transition as application-produced.
- Opacity concealment, geometry changes, inert transitions, and focus loss fail the predicate and remain serious findings.
- Existing dialog focus, tab order, focus restoration, inaccessible target, capability, and artifact-bound behavior remains covered by the focused and adversarial suites.

## Tests
Passing:

- `npm run build`
- `npm run test:browser-accessibility-oracles` (32 tests)
- `npm run test:adversarial-runtime` (16 tests)
- `npm run test:redaction`
- `npm run test:runtime-command-artifact-bounds`
- `npm run test:schema-parity`
- `npm run test:runtime-contract-package-exports`

Coverage includes desktop 1280x900 and mobile 390x844 Tab+Space behavior, replay, Enter activation, button Space activation, application concealment, inert focus loss, explicit script scrolling, and genuinely offscreen focus.

## Unrelated Baselines
- `npm run test:public-api-contract` fails because the expected dist module list omits the already-exported `browser-accessibility.js`; this PR does not modify the export or contract test files.
- `npm run check` passes production-boundary enforcement and the initial smoke commands, then stops at the pre-existing `command-registry-smoke` assertion that `wordpress.collect-workload-result` should mention an output schema ID; this PR does not modify command registry files.

Fixes #2068