### PR TITLE
Fix adaptive repeats for navigation links

### DIFF
--- a/packages/runtime-core/src/browser-adaptive-exploration.ts
+++ b/packages/runtime-core/src/browser-adaptive-exploration.ts
@@ -204,7 +204,8 @@ export function planBrowserAdaptiveStateActions(state: BrowserAdaptiveState, con
   const addClicks = (descriptor: BrowserActionCorpusDescriptor, submit: boolean) => {
     const selector = descriptor.selector
     add("click", descriptor, [{ kind: "click", selector }])
-    add("repeat", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])
+    const navigates = descriptor.kind === "link" && Boolean(descriptor.href)
+    if (!navigates) add("repeat", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])
     if (submit && descriptor.formId) {
       add("submit", descriptor, [{ kind: "click", selector }])
       add("double-submit", descriptor, [{ kind: "click", selector }, { kind: "click", selector }])

--- a/tests/browser-adaptive-exploration.test.ts
+++ b/tests/browser-adaptive-exploration.test.ts
@@ -103,7 +103,7 @@ test("adaptive contract normalizes every safety and exploration bound", () => {
       { id: "input", kind: "input", selector: "#field", type: "text", formId: "form", frameId: "document" },
       { id: "select", kind: "select", selector: "#choice", optionValues: ["one"], formId: "form", frameId: "document" },
       { id: "submit", kind: "button", selector: "#submit", type: "submit", formId: "form", frameId: "document" },
-      { id: "link", kind: "link", selector: "#link", frameId: "document" },
+      { id: "link", kind: "link", selector: "#link", href: "https://example.test/next", frameId: "document" },
     ],
     frames: [{ id: "document", url: "/fixture", scope: "document" }],
     visits: 1,
@@ -111,6 +111,39 @@ test("adaptive contract normalizes every safety and exploration bound", () => {
     loadingIndicators: 0,
   }, allFamilies)
   assert.deepEqual(new Set(planned.map((action) => action.family)), new Set(["click", "fill", "select", "submit", "keyboard", "back", "reload", "repeat", "double-submit"]))
+})
+
+test("adaptive planner repeats in-place controls but not navigation anchors", () => {
+  const contract = browserAdaptiveExplorationContract({ seed: "navigation-semantics", startUrl: "https://example.test/start" })
+  const descriptors = [
+    { id: "internal", kind: "link" as const, selector: "#internal", href: "https://example.test/next", frameId: "document" },
+    { id: "external", kind: "link" as const, selector: "#external", href: "https://outside.example/next", frameId: "document" },
+    { id: "hash", kind: "link" as const, selector: "#hash", href: "https://example.test/start#tab", role: "tab", frameId: "document" },
+    { id: "download", kind: "link" as const, selector: "#download", href: "https://example.test/report.pdf", frameId: "document" },
+    { id: "anchor-button", kind: "link" as const, selector: "#anchor-button", role: "button", frameId: "document" },
+    { id: "button", kind: "button" as const, selector: "#button", type: "button", frameId: "document" },
+    { id: "submit", kind: "button" as const, selector: "#submit", type: "submit", formId: "form", frameId: "document" },
+  ]
+  const state = {
+    digest: "state",
+    url: "https://example.test/start",
+    historyLength: 1,
+    historyStateDigest: "history",
+    descriptorDigest: "descriptors",
+    descriptors,
+    frames: [{ id: "document", url: "https://example.test/start", scope: "document" as const }],
+    visits: 1,
+    depth: 0,
+    loadingIndicators: 0,
+  }
+  const planned = planBrowserAdaptiveStateActions(state, contract)
+  const familiesFor = (id: string) => planned.filter((action) => action.descriptorId === id).map((action) => action.family)
+
+  for (const id of ["internal", "external", "hash", "download"]) assert.deepEqual(familiesFor(id), ["click"], id)
+  assert.deepEqual(familiesFor("anchor-button"), ["click", "repeat"])
+  assert.deepEqual(familiesFor("button"), ["click", "repeat"])
+  assert.deepEqual(familiesFor("submit"), ["click", "repeat", "submit", "double-submit"])
+  assert.deepEqual(planBrowserAdaptiveStateActions(state, contract), planned, "semantic filtering preserves deterministic action identity and order")
 })
 
 test("adaptive planner selects actions by HTML input type capability", () => {
@@ -188,6 +221,80 @@ test("planned input actions execute safely in a real browser", async () => {
     }
   } finally {
     await browser.close()
+  }
+})
+
+test("real-browser descriptors keep navigation single-click and in-place controls repeatable", async () => {
+  const browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+  try {
+    await page.addInitScript("globalThis.__name = value => value")
+    await page.setContent(`<!doctype html>
+      <style>a,button { display:block; width:180px; height:30px; margin:4px; }</style>
+      <a id="internal" href="/next">Internal</a>
+      <a id="external" href="https://outside.example/next">External</a>
+      <a id="hash" href="#tab" role="tab">Hash tab</a>
+      <a id="download" href="/report.pdf" download>Download</a>
+      <button id="button" type="button">Increment</button>
+      <form id="form"><button id="submit" type="submit">Submit</button></form>
+      <output id="count">0</output>
+      <script>
+        document.querySelector('#button').addEventListener('click', () => { document.querySelector('#count').textContent = String(Number(document.querySelector('#count').textContent) + 1) });
+        document.querySelector('#form').addEventListener('submit', (event) => event.preventDefault());
+      </script>`)
+    await page.evaluate("globalThis.__name = value => value")
+    const discovery = await discoverBrowserActionCorpusDescriptors(page)
+    const contract = browserAdaptiveExplorationContract({ seed: "browser-navigation-semantics", startUrl: page.url() })
+    const planned = planBrowserAdaptiveStateActions({
+      digest: "state",
+      url: page.url(),
+      historyLength: 1,
+      historyStateDigest: "history",
+      descriptorDigest: "descriptors",
+      descriptors: discovery.descriptors,
+      frames: [{ id: "document", url: page.url(), scope: "document" }],
+      visits: 1,
+      depth: 0,
+      loadingIndicators: 0,
+    }, contract)
+    const actionFor = (selector: string, family: string) => planned.find((action) => action.steps[0]?.selector === selector && action.family === family)
+
+    for (const selector of ["#internal", "#external", "#hash", "#download"]) {
+      assert(actionFor(selector, "click"), `${selector} remains single-clickable`)
+      assert(!actionFor(selector, "repeat"), `${selector} must not receive a repeat action`)
+    }
+    const repeat = actionFor("#button", "repeat")
+    assert(repeat)
+    for (const step of repeat.steps) await executeBrowserInteractionStep(page, step, page.url(), 2_000, async () => ({ path: "unused", isDefault: false }))
+    assert.equal(await page.locator("#count").textContent(), "2")
+    assert.equal(actionFor("#submit", "double-submit")?.steps.length, 2, "double-submit remains unchanged")
+  } finally {
+    await browser.close()
+  }
+})
+
+test("repeat-only exploration never schedules a detached navigation target", async () => {
+  let destinationRequests = 0
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://preview.invalid").pathname
+    response.setHeader("content-type", "text/html")
+    if (path === "/destination") destinationRequests += 1
+    response.end(path === "/" ? "<!doctype html><style>a{display:block;width:180px;height:30px}</style><a id='privacy' href='/destination'>Privacy Policy</a>" : "<!doctype html><h1>Destination</h1>")
+  })
+  const startUrl = await listenLocalHttpServer(server)
+  try {
+    const run = await runUrlFixture(startUrl, {
+      seed: "detached-navigation-repeat",
+      failOnFinding: false,
+      actionFamilies: ["repeat"],
+      budgets: { maxActions: 4, maxStates: 4, maxTransitions: 4, maxDurationMs: 10_000 },
+    })
+    const privacy = run.result.states[0]?.descriptors.find((descriptor) => descriptor.selector === "#privacy")
+    assert(privacy?.href.endsWith("/destination"))
+    assert.equal(run.result.transitions.length, 0)
+    assert.equal(destinationRequests, 0, "repeat planning must not issue a first or detached second navigation click")
+  } finally {
+    await closeHttpServer(server)
   }
 })
 


### PR DESCRIPTION
## Summary

- classify adaptive descriptors with `kind: link` and a populated `href` as navigation, so they receive a single `click` but no generated `repeat`
- retain `repeat` for in-place controls, including non-navigational link-shaped descriptors without `href`, and leave `double-submit` unchanged
- add planner and real-browser coverage for internal, external, hash/tab, download, in-place button, submit, and detached-navigation cases

## Semantics and compatibility

Discovery already distinguishes anchors through `kind: link` and resolves their navigational target into `href`; the planner now consumes that existing contract rather than adding URL or selector heuristics. A link-shaped descriptor without `href` remains eligible for repeat as an explicit non-navigation control contract. Anchors with any navigational `href`, including hashes and downloads, are conservatively not repeated even if script behavior could intercept the click.

The filter only changes adaptive action generation. Ordinary click action IDs and ordering are unchanged, existing controls retain their repeat IDs, submit and double-submit planning is unchanged, and explicit caller-authored steps/action corpora plus stored replay actions continue to execute unchanged. State digests, routing checks, budgets, evidence, and minimization are not modified.

## Tests

Passed:

- `npm run build`
- `npx tsx --test tests/browser-adaptive-exploration.test.ts` (16/16)
- `npm run test:browser-accessibility-oracles` (42/42; includes adaptive and routed-navigation coverage)
- `npm run test:adversarial-runtime` (16/16)
- `npm run test:schema-parity`
- `git diff --check`

The deterministic planner assertion verifies identical action identity/order, existing graph/replay tests pass, and a server-backed fixture proves repeat-only exploration never requests the destination or attempts a detached second click.

## Baseline failures

- `npm run test:public-api-contract` fails on current `origin/main` because the expected module list omits the existing `browser-accessibility.js` export; tracked in #2075.
- `npm run check` reaches the existing `wordpress.collect-workload-result` output-shape mismatch; tracked in #1745.

Fixes #2074