### PR TITLE
fix: align browser accessibility public contract

### DIFF
--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -159,6 +159,7 @@ assert.deepEqual(barrelExportModules(publicBarrel), [
   "./browser-artifact-lifecycle.js",
   "./browser-callback-contracts.js",
   "./browser-interaction.js",
+  "./browser-accessibility.js",
   "./browser-adaptive-exploration.js",
   "./browser-environment-matrix.js",
   "./browser-multi-actor-scenario-contracts.js",
@@ -243,6 +244,7 @@ assert.deepEqual(barrelExportModules(publicBarrel), [
 
 assert.deepEqual(barrelExportModules(contractsBarrel), [
   "./browser-probe-contract.js",
+  "./browser-accessibility.js",
   "./browser-multi-actor-scenario-contracts.js",
   "./browser-adaptive-exploration.js",
   "./browser-environment-matrix.js",

--- a/tests/runtime-contract-package-exports.test.ts
+++ b/tests/runtime-contract-package-exports.test.ts
@@ -8,6 +8,8 @@ import * as publicFacade from "@automattic/wp-codebox-core/public"
 for (const entrypoint of [core, contracts, publicFacade]) {
   assert.equal(typeof entrypoint.runtimeContractManifest, "function")
   assert.equal(typeof entrypoint.runtimeDescriptor, "function")
+  assert.equal(entrypoint.BROWSER_ACCESSIBILITY_SCHEMA, "wp-codebox/browser-accessibility/v1")
+  assert.equal(typeof entrypoint.browserAccessibilityContract, "function")
   const manifest = entrypoint.runtimeContractManifest()
   const descriptor = entrypoint.runtimeDescriptor()
 


### PR DESCRIPTION
## Summary
- add the intentional `browser-accessibility` module to the manually maintained public and contracts barrel expectations
- verify the accessibility schema and contract helper remain exported from the root compatibility barrel, curated public facade, and contracts facade
- preserve the package export map and public surface introduced by #2065 without adding new exports or infrastructure

`browser-accessibility` is intentional because #2065 added it to all three core facades alongside the adaptive browser contract and runtime-playground collector that consume it. This PR only restores contract-test parity with that existing surface.

## Testing
- `npm run build`
- `npm run test:public-api-contract`
- `npm run test:runtime-contract-manifest`
- `npm run test:runtime-contract-package-exports`
- `npm run test:schema-parity`
- `npm run test:browser-accessibility-oracles` (42 passed)
- `npm run test:release-package-coverage`
- `npm run check` (reaches the existing #1745 baseline failure in `command-registry-smoke`: `wordpress.collect-workload-result outputShape should mention outputSchema id`; production boundary enforcement and all preceding smoke checks pass)

Fixes #2075