### PR TITLE
Add deterministic browser geolocation contexts

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1549,6 +1549,19 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
   }
 
   if (step.command === "wordpress.browser-probe") {
+    const latitude = recipeStepArgValue(step.args ?? [], "geolocation-latitude")
+    const longitude = recipeStepArgValue(step.args ?? [], "geolocation-longitude")
+    const accuracy = recipeStepArgValue(step.args ?? [], "geolocation-accuracy")
+    const permission = recipeStepArgValue(step.args ?? [], "geolocation-permission")
+    if (Boolean(latitude) !== Boolean(longitude)) {
+      addIssue("incomplete-geolocation", `${path}.args`, "wordpress.browser-probe geolocation requires both geolocation-latitude and geolocation-longitude.")
+    }
+    if (accuracy && (!latitude || !longitude)) {
+      addIssue("incomplete-geolocation", `${path}.args`, "wordpress.browser-probe geolocation-accuracy requires geolocation-latitude and geolocation-longitude.")
+    }
+    if (permission && (!latitude || !longitude)) {
+      addIssue("incomplete-geolocation", `${path}.args`, "wordpress.browser-probe geolocation-permission requires geolocation-latitude and geolocation-longitude.")
+    }
     for (const assertion of (step.args ?? []).filter((arg) => arg.startsWith("assert=")).map((arg) => arg.slice("assert=".length).trim())) {
       const rawNormalized = assertion.startsWith("advisory:") ? assertion.slice("advisory:".length).trim() : assertion
       const frameSeparator = rawNormalized.startsWith("frame:") || rawNormalized.startsWith("frame-url:") ? rawNormalized.indexOf("|") : -1
@@ -1769,6 +1782,14 @@ function validateRecipeStepDescriptorArgRule(args: string[], rule: CommandArgVal
 
   if (rule.kind === "viewport") {
     if (!/^\d+x\d+$/i.test(raw)) {
+      addIssue(rule.code, issuePath, rule.message)
+    }
+    return
+  }
+
+  if (rule.kind === "number") {
+    const value = Number(raw)
+    if (!Number.isFinite(value) || value < rule.minimum || value > rule.maximum) {
       addIssue(rule.code, issuePath, rule.message)
     }
     return

--- a/packages/runtime-core/src/browser-environment-matrix.ts
+++ b/packages/runtime-core/src/browser-environment-matrix.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 
 import { stableJson, stripUndefined } from "./object-utils.js"
+import { browserGeolocation, type BrowserGeolocation } from "./browser-probe-contract.js"
 
 export const BROWSER_ENVIRONMENT_MATRIX_SCHEMA = "wp-codebox/browser-environment-matrix/v1" as const
 export const BROWSER_ENVIRONMENT_MATRIX_REPORT_SCHEMA = "wp-codebox/browser-environment-matrix-report/v1" as const
@@ -27,6 +28,7 @@ export interface BrowserEnvironment {
   cpuProfile?: string
   online?: boolean
   clock?: { mode: "realtime" | "fixed"; at?: string }
+  geolocation?: BrowserGeolocation
   capabilities?: Record<string, boolean | string | number>
 }
 
@@ -301,7 +303,7 @@ function normalizeDimension(dimension: BrowserEnvironmentDimension): BrowserEnvi
   const values = dimension.values.map((value) => {
     if (!safeId(value.id)) throw new Error(`Invalid browser environment value id in ${dimension.id}: ${value.id}`)
     validateEnvironment(value.environment)
-    return { id: value.id, environment: canonicalEnvironment(value.environment), requiredCapabilities: uniqueSorted(value.requiredCapabilities ?? []), optionalCapabilities: uniqueSorted(value.optionalCapabilities ?? []) }
+    return { id: value.id, environment: canonicalEnvironment(value.environment), requiredCapabilities: uniqueSorted([...(value.requiredCapabilities ?? []), ...(value.environment.geolocation ? ["browser.environment.geolocation"] : [])]), optionalCapabilities: uniqueSorted(value.optionalCapabilities ?? []) }
   }).sort((left, right) => left.id.localeCompare(right.id) || stableJson(left.environment).localeCompare(stableJson(right.environment)))
   if (new Set(values.map(({ id }) => id)).size !== values.length) throw new Error(`Browser environment value ids must be unique in ${dimension.id}.`)
   return { id: dimension.id, values }
@@ -325,7 +327,7 @@ function validateEnvironment(environment: BrowserEnvironment): void {
 }
 
 function canonicalEnvironment(environment: BrowserEnvironment): BrowserEnvironment {
-  return JSON.parse(stableJson(JSON.parse(JSON.stringify(environment)))) as BrowserEnvironment
+  return JSON.parse(stableJson(JSON.parse(JSON.stringify({ ...environment, ...(environment.geolocation ? { geolocation: browserGeolocation(environment.geolocation) } : {}) })))) as BrowserEnvironment
 }
 
 function mergeEnvironment(left: BrowserEnvironment, right: BrowserEnvironment): BrowserEnvironment {

--- a/packages/runtime-core/src/browser-probe-contract.ts
+++ b/packages/runtime-core/src/browser-probe-contract.ts
@@ -17,6 +17,37 @@ export const BROWSER_PROBE_BROWSER_VALUES = ["chromium"] as const
 export const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "websocket", "performance", "memory", "screenshot"] as const
 export const BROWSER_PROBE_CHROMIUM_PROFILE_IDS = ["desktop-chrome", "mobile-chrome", "low-end-mobile-slow-4g"] as const
 export const BROWSER_PROBE_THROTTLE_PROFILE_IDS = ["low-end-mobile-slow-4g"] as const
+export const BROWSER_GEOLOCATION_PERMISSION_STATES = ["granted", "denied", "prompt"] as const
+export const BROWSER_GEOLOCATION_PERMISSION_ALIASES = ["default"] as const
+export const BROWSER_GEOLOCATION_MAX_ACCURACY_METERS = 1_000_000
+
+export type BrowserGeolocationPermissionState = (typeof BROWSER_GEOLOCATION_PERMISSION_STATES)[number]
+
+export interface BrowserGeolocation {
+  latitude: number
+  longitude: number
+  accuracy?: number
+  permission: BrowserGeolocationPermissionState
+}
+
+export function normalizeBrowserGeolocationPermissionState(value: string): BrowserGeolocationPermissionState {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === "default") return "prompt"
+  if ((BROWSER_GEOLOCATION_PERMISSION_STATES as readonly string[]).includes(normalized)) return normalized as BrowserGeolocationPermissionState
+  throw new Error(`Browser geolocation permission must be ${[...BROWSER_GEOLOCATION_PERMISSION_STATES, ...BROWSER_GEOLOCATION_PERMISSION_ALIASES].join(", ")}: ${value}`)
+}
+
+export function browserGeolocation(input: Omit<BrowserGeolocation, "permission"> & { permission?: BrowserGeolocationPermissionState | "default" }): BrowserGeolocation {
+  if (!Number.isFinite(input.latitude) || input.latitude < -90 || input.latitude > 90) throw new Error("Browser geolocation latitude must be a finite number between -90 and 90.")
+  if (!Number.isFinite(input.longitude) || input.longitude < -180 || input.longitude > 180) throw new Error("Browser geolocation longitude must be a finite number between -180 and 180.")
+  if (input.accuracy !== undefined && (!Number.isFinite(input.accuracy) || input.accuracy < 0 || input.accuracy > BROWSER_GEOLOCATION_MAX_ACCURACY_METERS)) throw new Error(`Browser geolocation accuracy must be a finite number between 0 and ${BROWSER_GEOLOCATION_MAX_ACCURACY_METERS}.`)
+  return {
+    latitude: input.latitude,
+    longitude: input.longitude,
+    ...(input.accuracy !== undefined ? { accuracy: input.accuracy } : {}),
+    permission: normalizeBrowserGeolocationPermissionState(input.permission ?? "prompt"),
+  }
+}
 
 export const BROWSER_PROBE_PROFILES: Record<(typeof BROWSER_PROBE_CHROMIUM_PROFILE_IDS)[number], BrowserProbeProfileDefinition> = {
   "desktop-chrome": {
@@ -49,6 +80,10 @@ export const BROWSER_PROBE_ACCEPTED_ARGS: BrowserProbeAcceptedArg[] = [
   { name: "timezone", description: "Optional browser context timezone.", format: "IANA timezone, e.g. America/New_York" },
   { name: "user-agent", description: "Optional browser context user agent override.", format: "string" },
   { name: "permissions", description: "Comma-separated browser permissions to grant to the context.", format: "comma-separated permission names" },
+  { name: "geolocation-latitude", description: "Browser context geolocation latitude.", format: "finite number from -90 to 90" },
+  { name: "geolocation-longitude", description: "Browser context geolocation longitude.", format: "finite number from -180 to 180" },
+  { name: "geolocation-accuracy", description: "Optional browser context geolocation accuracy in meters.", format: `finite number from 0 to ${BROWSER_GEOLOCATION_MAX_ACCURACY_METERS}` },
+  { name: "geolocation-permission", description: "Explicit browser context geolocation permission state. default is normalized to prompt.", format: [...BROWSER_GEOLOCATION_PERMISSION_STATES, ...BROWSER_GEOLOCATION_PERMISSION_ALIASES].join("|") },
   { name: "throttle", description: "Optional Chromium/CDP throttle profile, or none.", format: `none|${BROWSER_PROBE_THROTTLE_PROFILE_IDS.join("|")}` },
   { name: "auth", description: "Optional in-memory browser authentication mode. Use wordpress-admin to bootstrap WordPress admin cookies from PHP without writing token-bearing storage-state artifacts.", format: "wordpress-admin" },
   { name: "auth-user-id", description: "WordPress user ID used with auth=wordpress-admin; defaults to 1.", format: "positive integer" },

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -1,4 +1,4 @@
-import { BROWSER_PROBE_ACCEPTED_ARGS, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS } from "./browser-probe-contract.js"
+import { BROWSER_GEOLOCATION_MAX_ACCURACY_METERS, BROWSER_GEOLOCATION_PERMISSION_ALIASES, BROWSER_GEOLOCATION_PERMISSION_STATES, BROWSER_PROBE_ACCEPTED_ARGS, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS } from "./browser-probe-contract.js"
 import { WORDPRESS_PAGE_LOAD_RESULT_JSON_SCHEMA, WORDPRESS_PAGE_LOAD_RESULT_SCHEMA } from "./wordpress-page-load-contracts.js"
 import { WORDPRESS_DB_RESULT_JSON_SCHEMA, WORDPRESS_DB_RESULT_SCHEMA } from "./wordpress-db-contracts.js"
 import { WORDPRESS_CRUD_RESULT_JSON_SCHEMA, WORDPRESS_CRUD_RESULT_SCHEMA } from "./wordpress-crud-contracts.js"
@@ -67,6 +67,7 @@ export type CommandArgValidationDescriptor =
   | { name: string; kind: "duration"; code: string; message: string }
   | { name: string; kind: "positive-integer"; code: string; message: string }
   | { name: string; kind: "viewport"; code: string; message: string }
+  | { name: string; kind: "number"; minimum: number; maximum: number; code: string; message: string }
   | { name: string; kind: "enum"; values: readonly string[]; prefixes?: readonly string[]; code: string; message: string }
   | { name: string; kind: "comma-list-enum"; values: readonly string[]; code: string; message: string }
 
@@ -127,6 +128,10 @@ const browserProbeValidation: CommandValidationDescriptor = {
     { name: "throttle", kind: "enum", values: ["none", ...BROWSER_PROBE_THROTTLE_PROFILE_IDS], code: "invalid-throttle", message: "wordpress.browser-probe throttle is unsupported" },
     { name: "browser", kind: "enum", values: BROWSER_PROBE_BROWSER_VALUES, code: "invalid-browser", message: `wordpress.browser-probe browser must be ${BROWSER_PROBE_BROWSER_VALUES.join(" or ")}.` },
     { name: "viewport", kind: "viewport", code: "invalid-viewport", message: "wordpress.browser-probe viewport must use <width>x<height>, for example 390x844." },
+    { name: "geolocation-latitude", kind: "number", minimum: -90, maximum: 90, code: "invalid-geolocation-latitude", message: "wordpress.browser-probe geolocation-latitude must be a finite number from -90 to 90." },
+    { name: "geolocation-longitude", kind: "number", minimum: -180, maximum: 180, code: "invalid-geolocation-longitude", message: "wordpress.browser-probe geolocation-longitude must be a finite number from -180 to 180." },
+    { name: "geolocation-accuracy", kind: "number", minimum: 0, maximum: BROWSER_GEOLOCATION_MAX_ACCURACY_METERS, code: "invalid-geolocation-accuracy", message: `wordpress.browser-probe geolocation-accuracy must be a finite number from 0 to ${BROWSER_GEOLOCATION_MAX_ACCURACY_METERS}.` },
+    { name: "geolocation-permission", kind: "enum", values: [...BROWSER_GEOLOCATION_PERMISSION_STATES, ...BROWSER_GEOLOCATION_PERMISSION_ALIASES], code: "invalid-geolocation-permission", message: "wordpress.browser-probe geolocation-permission must be granted, denied, prompt, or default." },
     { name: "capture", kind: "comma-list-enum", values: BROWSER_PROBE_CAPTURE_VALUES, code: "invalid-capture", message: "wordpress.browser-probe capture does not support" },
   ],
 }

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import { artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactReviewBrowserSummary } from "@automattic/wp-codebox-core"
+import { artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactReviewBrowserSummary, type BrowserGeolocation } from "@automattic/wp-codebox-core"
 import type { PlaygroundPreviewProxyDiagnostics } from "./preview-server.js"
 import type { Request } from "playwright"
 
@@ -353,6 +353,8 @@ export interface BrowserProbeReviewSummary {
     throttle: string | null
     waitFor: string
     durationMs: number
+    context?: BrowserProbeContextDetails
+    capabilities?: BrowserProbeCapabilityDiagnostics
   }
   timings: {
     startedAt: string
@@ -461,6 +463,21 @@ export interface BrowserProbeCapabilityDiagnostics {
     available: boolean
   }
   permissions: Record<string, BrowserProbePermissionState>
+  geolocation?: {
+    requested: BrowserGeolocation
+    effective: {
+      latitude: number
+      longitude: number
+      accuracy?: number
+      permission: BrowserProbePermissionState["state"]
+    }
+    support: {
+      coordinates: "supported" | "unsupported"
+      permission: "supported" | "unsupported"
+      unavailable: "unsupported"
+      reason: string
+    }
+  }
 }
 
 export interface BrowserProbePermissionState {
@@ -508,6 +525,7 @@ export interface BrowserProbeContextDetails {
     device?: string
     locale?: string
     permissions?: string[]
+    geolocation?: BrowserGeolocation
     profile?: string
     throttle?: string
     timezone?: string
@@ -522,6 +540,7 @@ export interface BrowserProbeContextDetails {
     device?: string
     locale?: string
     permissions?: string[]
+    geolocation?: BrowserGeolocation
     profile?: string
     throttle?: string
     timezone?: string

--- a/packages/runtime-playground/src/browser-environment-matrix.ts
+++ b/packages/runtime-playground/src/browser-environment-matrix.ts
@@ -31,6 +31,7 @@ export const PLAYWRIGHT_BROWSER_ENVIRONMENT_CAPABILITIES = [
   "browser.environment.cpu-profile",
   "browser.environment.online-state",
   "browser.environment.clock",
+  "browser.environment.geolocation",
   "browser.environment.capability-state",
 ] as const
 
@@ -83,6 +84,11 @@ export async function resolvePlaywrightBrowserEnvironment(cell: BrowserEnvironme
   if (requested.timezone) exact("browser.environment.timezone")
   if (requested.online !== undefined) exact("browser.environment.online-state")
   if (requested.clock) exact("browser.environment.clock")
+  if (requested.geolocation) {
+    requested.geolocation.permission !== "denied" || browser.browserType().name() === "chromium"
+      ? exact("browser.environment.geolocation")
+      : unsupported("browser.environment.geolocation", "This provider cannot express an explicit denied geolocation permission without Chromium browser permission controls.")
+  }
   if (requested.capabilities) exact("browser.environment.capability-state")
   if (requested.zoom !== undefined) emulated("browser.environment.zoom", "Applied as page scale through the browser debugging protocol; OS-level zoom and browser chrome are outside the page context.")
   if (requested.networkProfile) options.networkProfiles?.[requested.networkProfile] ? emulated("browser.environment.network-profile", "Latency and throughput are applied through the browser debugging protocol.") : unsupported("browser.environment.network-profile", `Unknown network profile: ${requested.networkProfile}`)
@@ -114,11 +120,22 @@ export async function createPlaywrightBrowserEnvironmentContext(browser: Browser
     ...(environment.forcedColors ? { forcedColors: environment.forcedColors } : {}),
     ...(environment.contrast ? { contrast: environment.contrast } : {}),
     ...(environment.online !== undefined ? { offline: !environment.online } : {}),
+    ...(environment.geolocation ? { geolocation: { latitude: environment.geolocation.latitude, longitude: environment.geolocation.longitude, ...(environment.geolocation.accuracy !== undefined ? { accuracy: environment.geolocation.accuracy } : {}) } } : {}),
+    ...(environment.geolocation?.permission === "granted" ? { permissions: ["geolocation"] } : {}),
   }
   const context = await browser.newContext(contextOptions)
   const page = await context.newPage()
+  const geolocationPermissionCleanup = environment.geolocation?.permission === "denied" ? await applyPlaywrightGeolocationPermission(page, "denied") : undefined
   await applyPlaywrightPageEnvironment(page, environment, options)
-  return { context, page, close: () => context.close() }
+  return { context, page, close: async () => { await geolocationPermissionCleanup?.(); await context.close() } }
+}
+
+export async function applyPlaywrightGeolocationPermission(page: Page, state: "denied"): Promise<() => Promise<void>> {
+  if (page.context().browser()?.browserType().name() !== "chromium") throw new Error("Explicit denied geolocation permission is unsupported by this browser provider.")
+  const session = await page.context().newCDPSession(page)
+  const { targetInfo } = await session.send("Target.getTargetInfo")
+  await session.send("Browser.setPermission", { permission: { name: "geolocation" }, setting: state, browserContextId: targetInfo.browserContextId })
+  return () => session.detach().catch(() => undefined)
 }
 
 export async function applyPlaywrightPageEnvironment(page: Page, environment: BrowserEnvironment, options: PlaywrightBrowserEnvironmentOptions = {}): Promise<void> {

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -1,4 +1,4 @@
-import { BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, browserGeolocation, type BrowserGeolocationPermissionState, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js"
 import type { BrowserArtifactFiles, BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserProbeWebSocketRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
@@ -13,8 +13,9 @@ import type { PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { browserAuthRequest, browserProbeWaterfallArtifact, browserProbeWebSocketArtifact, browserRedirectDiagnosticsArtifact, browserRequestCoverageArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, createBrowserProbeProgressTracker, fileSha256, installWordPressAdminAuthCookies, now, sha256, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
 import { BrowserProbeSessionResultBuilder, browserProbeCaptureSelection } from "./browser-probe-session-result-builder.js"
+import { applyPlaywrightGeolocationPermission } from "./browser-environment-matrix.js"
 
-const BROWSER_PROBE_PROFILE_OVERRIDES = new Set(["browser", "device", "locale", "permissions", "throttle", "timezone", "user-agent", "viewport"])
+const BROWSER_PROBE_PROFILE_OVERRIDES = new Set(["browser", "device", "geolocation-accuracy", "geolocation-latitude", "geolocation-longitude", "geolocation-permission", "locale", "permissions", "throttle", "timezone", "user-agent", "viewport"])
 
 export interface BrowserProbeRunPlan {
   url: string
@@ -281,6 +282,7 @@ export async function runSingleBrowserProbeCommand({
   let contextDetails: BrowserProbeContextDetails | undefined
   let authSummary: BrowserProbeAuthSummary | undefined
   let capabilityDiagnostics: BrowserProbeCapabilityDiagnostics | undefined
+  let geolocationPermissionCleanup: (() => Promise<void>) | undefined
   let assertionResults: import("./browser-artifacts.js").BrowserStepAssertion[] = []
   let pendingError: Error | undefined
   let artifact: BrowserProbeArtifact | undefined
@@ -299,22 +301,25 @@ export async function runSingleBrowserProbeCommand({
       abortHandler()
       throw pendingError
     }
-    context = browserPreviewNeedsContextRouting(networkPolicy) || !!storageStateImport || requestedContext.device || requestedContext.locale || requestedContext.timezone || requestedContext.userAgent || (requestedContext.permissions?.length ?? 0) > 0
+    const contextPermissions = browserProbeContextPermissions(requestedContext)
+    context = browserPreviewNeedsContextRouting(networkPolicy) || !!storageStateImport || requestedContext.device || requestedContext.geolocation || requestedContext.locale || requestedContext.timezone || requestedContext.userAgent || contextPermissions.length > 0
       ? await browser.newContext({
         ...(deviceProfile ?? {}),
         ...(storageStateImport ? { storageState: storageStateImport.storageState } : {}),
         ...(requestedContext.locale ? { locale: requestedContext.locale } : {}),
         ...(requestedContext.timezone ? { timezoneId: requestedContext.timezone } : {}),
         ...(requestedContext.userAgent ? { userAgent: requestedContext.userAgent } : {}),
+        ...(requestedContext.geolocation ? { geolocation: { latitude: requestedContext.geolocation.latitude, longitude: requestedContext.geolocation.longitude, ...(requestedContext.geolocation.accuracy !== undefined ? { accuracy: requestedContext.geolocation.accuracy } : {}) } } : {}),
       })
       : null
-    if (context && requestedContext.permissions && requestedContext.permissions.length > 0) {
-      await context.grantPermissions(requestedContext.permissions)
+    if (context && contextPermissions.length > 0) {
+      await context.grantPermissions(contextPermissions)
     }
     if (context && browserPreviewNeedsContextRouting(networkPolicy)) {
       await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin, routeTracker)
     }
     page = context ? await context.newPage() : await browser.newPage()
+    if (requestedContext.geolocation?.permission === "denied") geolocationPermissionCleanup = await applyPlaywrightGeolocationPermission(page, "denied")
     if (onProgress) {
       await page.exposeFunction("__wpCodeboxProbeCheckpointEvent", (checkpoint: unknown) => {
         const normalized = normalizeBrowserProbeScriptCheckpoint(checkpoint)
@@ -363,8 +368,8 @@ export async function runSingleBrowserProbeCommand({
       }
     }
     viewport = await browserProbeViewport(page)
-    contextDetails = await browserProbeContextDetails(page, requestedContext, viewport)
-    capabilityDiagnostics = await browserProbeCapabilityDiagnostics(page, viewport)
+    capabilityDiagnostics = await browserProbeCapabilityDiagnostics(page, viewport, requestedContext.geolocation)
+    contextDetails = await browserProbeContextDetails(page, requestedContext, viewport, contextPermissions, capabilityDiagnostics)
     attachBrowserCaptureListeners({
       captureConsole: captureSelection.console,
       captureErrors: captureSelection.errors,
@@ -496,6 +501,7 @@ export async function runSingleBrowserProbeCommand({
       }
     }
     await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
+    await geolocationPermissionCleanup?.()
     await browser.close()
     if (captureSelection.console) {
       await artifactSession.writeJsonLines("console", "console.jsonl", consoleMessages)
@@ -787,11 +793,13 @@ function browserProbeContextRequest(args: string[], viewport: { width: number; h
   const permissions = commaListArg(args, "permissions")
   const timezone = argValue(args, "timezone")?.trim()
   const userAgent = argValue(args, "user-agent")?.trim()
+  const geolocation = browserProbeGeolocation(args)
   return {
     ...(browser ? { browser } : {}),
     ...(device ? { device } : {}),
     ...(locale ? { locale } : {}),
     ...(permissions.length > 0 ? { permissions } : {}),
+    ...(geolocation ? { geolocation } : {}),
     ...(profileId ? { profile: profileId } : {}),
     ...(throttleProfileId ? { throttle: throttleProfileId } : {}),
     ...(timezone ? { timezone } : {}),
@@ -800,7 +808,29 @@ function browserProbeContextRequest(args: string[], viewport: { width: number; h
   }
 }
 
-async function browserProbeContextDetails(page: import("playwright").Page, requested: BrowserProbeContextDetails["requested"], viewport: BrowserProbeViewport | null): Promise<BrowserProbeContextDetails> {
+function browserProbeGeolocation(args: string[]): BrowserProbeContextDetails["requested"]["geolocation"] {
+  const latitudeRaw = argValue(args, "geolocation-latitude")?.trim()
+  const longitudeRaw = argValue(args, "geolocation-longitude")?.trim()
+  const accuracyRaw = argValue(args, "geolocation-accuracy")?.trim()
+  const permissionRaw = argValue(args, "geolocation-permission")?.trim()
+  if (!latitudeRaw && !longitudeRaw && !accuracyRaw && !permissionRaw) return undefined
+  if (!latitudeRaw || !longitudeRaw) throw new Error("wordpress.browser-probe geolocation requires both geolocation-latitude and geolocation-longitude.")
+  return browserGeolocation({
+    latitude: Number(latitudeRaw),
+    longitude: Number(longitudeRaw),
+    ...(accuracyRaw ? { accuracy: Number(accuracyRaw) } : {}),
+    permission: (permissionRaw ?? "prompt") as BrowserGeolocationPermissionState | "default",
+  })
+}
+
+function browserProbeContextPermissions(requested: BrowserProbeContextDetails["requested"]): string[] {
+  const permissions = requested.permissions ?? []
+  if (!requested.geolocation) return permissions
+  const withoutGeolocation = permissions.filter((permission) => permission !== "geolocation")
+  return requested.geolocation.permission === "granted" ? [...new Set([...withoutGeolocation, "geolocation"])] : withoutGeolocation
+}
+
+async function browserProbeContextDetails(page: import("playwright").Page, requested: BrowserProbeContextDetails["requested"], viewport: BrowserProbeViewport | null, permissions: string[], capabilities: BrowserProbeCapabilityDiagnostics): Promise<BrowserProbeContextDetails> {
   const effective = await page.evaluate(() => ({
     locale: navigator.language || undefined,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || undefined,
@@ -812,7 +842,8 @@ async function browserProbeContextDetails(page: import("playwright").Page, reque
       ...(requested.browser ? { browser: requested.browser } : {}),
       ...(requested.device ? { device: requested.device } : {}),
       ...(effective.locale ? { locale: effective.locale } : {}),
-      ...(requested.permissions ? { permissions: requested.permissions } : {}),
+      ...(requested.permissions || permissions.length > 0 ? { permissions } : {}),
+      ...(requested.geolocation ? { geolocation: { ...requested.geolocation, permission: capabilities.geolocation?.effective.permission === "granted" || capabilities.geolocation?.effective.permission === "denied" || capabilities.geolocation?.effective.permission === "prompt" ? capabilities.geolocation.effective.permission : requested.geolocation.permission } } : {}),
       ...(requested.profile ? { profile: requested.profile } : {}),
       ...(requested.throttle ? { throttle: requested.throttle } : {}),
       ...(effective.timezone ? { timezone: effective.timezone } : {}),
@@ -822,7 +853,7 @@ async function browserProbeContextDetails(page: import("playwright").Page, reque
   }
 }
 
-async function browserProbeCapabilityDiagnostics(page: import("playwright").Page, viewport: BrowserProbeViewport | null): Promise<BrowserProbeCapabilityDiagnostics> {
+async function browserProbeCapabilityDiagnostics(page: import("playwright").Page, viewport: BrowserProbeViewport | null, requestedGeolocation: BrowserProbeContextDetails["requested"]["geolocation"]): Promise<BrowserProbeCapabilityDiagnostics> {
   const fallback: BrowserProbeCapabilityDiagnostics = {
     secureContext: false,
     userAgent: viewport?.userAgent ?? "",
@@ -830,9 +861,14 @@ async function browserProbeCapabilityDiagnostics(page: import("playwright").Page
     maxTouchPoints: 0,
     paymentRequest: { available: false },
     permissions: {},
+    ...(requestedGeolocation ? { geolocation: {
+      requested: requestedGeolocation,
+      effective: { latitude: requestedGeolocation.latitude, longitude: requestedGeolocation.longitude, ...(requestedGeolocation.accuracy !== undefined ? { accuracy: requestedGeolocation.accuracy } : {}), permission: "unsupported" },
+      support: { coordinates: "unsupported", permission: "unsupported", unavailable: "unsupported", reason: "Browser capability diagnostics were unavailable." },
+    } } : {}),
   }
 
-  return page.evaluate(async (probeViewport) => {
+  return page.evaluate(async ({ probeViewport, requestedGeolocation }) => {
     const resolvedOptions = Intl.DateTimeFormat().resolvedOptions()
     const permissionNames = ["clipboard-read", "clipboard-write", "geolocation", "notifications", "payment-handler"]
     const permissions: BrowserProbeCapabilityDiagnostics["permissions"] = {}
@@ -858,6 +894,7 @@ async function browserProbeCapabilityDiagnostics(page: import("playwright").Page
       }
     }
 
+    const geolocationPermission = permissions.geolocation?.state ?? "unsupported"
     return {
       secureContext: Boolean(window.isSecureContext),
       userAgent: navigator.userAgent || "",
@@ -875,8 +912,13 @@ async function browserProbeCapabilityDiagnostics(page: import("playwright").Page
       maxTouchPoints: typeof navigator.maxTouchPoints === "number" ? navigator.maxTouchPoints : 0,
       paymentRequest: { available: typeof (window as typeof window & { PaymentRequest?: unknown }).PaymentRequest === "function" },
       permissions,
+      ...(requestedGeolocation ? { geolocation: {
+        requested: requestedGeolocation,
+        effective: { latitude: requestedGeolocation.latitude, longitude: requestedGeolocation.longitude, ...(requestedGeolocation.accuracy !== undefined ? { accuracy: requestedGeolocation.accuracy } : {}), permission: geolocationPermission },
+        support: { coordinates: "supported" as const, permission: geolocationPermission === "unsupported" ? "unsupported" as const : "supported" as const, unavailable: "unsupported" as const, reason: "This provider supports browser-context coordinates and permission state, but cannot deterministically emulate unavailable position or timeout without page-level mocking." },
+      } } : {}),
     }
-  }, viewport).catch(() => fallback)
+  }, { probeViewport: viewport, requestedGeolocation }).catch(() => fallback)
 }
 
 function browserProbeCapabilityViewport(viewport: BrowserProbeViewport): BrowserProbeCapabilityDiagnostics["viewport"] {

--- a/packages/runtime-playground/src/browser-probe-session-result-builder.ts
+++ b/packages/runtime-playground/src/browser-probe-session-result-builder.ts
@@ -95,6 +95,8 @@ export class BrowserProbeSessionResultBuilder {
       capture: input.capture,
       checkpoints: input.checkpoints,
       consoleMessages: input.consoleMessages,
+      context: input.context,
+      capabilities: input.capabilities,
       durationMs: input.durationMs,
       errors: input.errors,
       files: browserProbeArtifactRefs(input.browserFilesDirectory, input.capture, {
@@ -273,6 +275,8 @@ function browserProbeReviewSummary(input: {
   capture: Set<string>
   checkpoints: BrowserProbeCheckpointRecord[]
   consoleMessages: Record<string, unknown>[]
+  context?: BrowserProbeContextDetails
+  capabilities?: BrowserProbeCapabilityDiagnostics
   durationMs: number
   errors: BrowserProbeErrorRecord[]
   files: Record<string, BrowserProbeArtifactRef>
@@ -325,6 +329,8 @@ function browserProbeReviewSummary(input: {
       throttle: input.throttle,
       waitFor: input.waitFor,
       durationMs: input.durationMs,
+      context: input.context,
+      capabilities: input.capabilities,
     },
     timings: {
       startedAt: input.startedAt,

--- a/scripts/browser-probe-contract-smoke.ts
+++ b/scripts/browser-probe-contract-smoke.ts
@@ -30,7 +30,7 @@ async function main(): Promise<void> {
   assert(browserProbe.acceptedArgs === BROWSER_PROBE_ACCEPTED_ARGS, "browser probe registry must use the shared accepted args definition")
 
   const acceptedArgNames = new Set(browserProbe.acceptedArgs.map((arg) => arg.name))
-  for (const name of ["browser", "profile", "profiles", "viewport", "throttle", "timezone", "user-agent", "permissions", "timeout", "stall-timeout", "observe"]) {
+  for (const name of ["browser", "profile", "profiles", "viewport", "throttle", "timezone", "user-agent", "permissions", "geolocation-latitude", "geolocation-longitude", "geolocation-accuracy", "geolocation-permission", "timeout", "stall-timeout", "observe"]) {
     assert(acceptedArgNames.has(name), `browser probe registry is missing arg: ${name}`)
   }
 
@@ -49,6 +49,7 @@ async function main(): Promise<void> {
   assert((await validationIssueCodes([`profiles=${BROWSER_PROBE_CHROMIUM_PROFILE_IDS.join(",")}`])).length === 0, "recipe validation must accept shared Chromium profile matrix values")
   assert((await validationIssueCodes([`throttle=${BROWSER_PROBE_THROTTLE_PROFILE_IDS[0]}`])).length === 0, "recipe validation must accept shared throttle profile value")
   assert((await validationIssueCodes([`capture=${BROWSER_PROBE_CAPTURE_VALUES.join(",")}`])).length === 0, "recipe validation must accept shared capture values")
+  assert((await validationIssueCodes(["geolocation-latitude=32.7765", "geolocation-longitude=-79.9311", "geolocation-accuracy=8", "geolocation-permission=default"])).length === 0, "recipe validation must accept canonical geolocation controls and the default alias")
 
   assert((await validationIssueCodes(["browser=webkit"])).includes("invalid-browser"), "recipe validation must reject non-runnable WebKit browser value")
   assert((await validationIssueCodes(["profile=desktop-webkit"])).includes("invalid-profile"), "recipe validation must reject non-runnable WebKit profile")

--- a/tests/browser-diagnostic-providers.test.ts
+++ b/tests/browser-diagnostic-providers.test.ts
@@ -41,6 +41,21 @@ assert.equal(genericResult.artifact.summary.wordpressDiagnostics, undefined)
 assert.equal(genericResult.review.wordpressDiagnostics, undefined)
 assert.doesNotMatch(genericResult.output, /wordpressDiagnostics/)
 
+const geolocation = { latitude: 32.7765, longitude: -79.9311, accuracy: 8, permission: "granted" as const }
+const geolocationCapabilities = {
+  secureContext: true,
+  userAgent: "fixture",
+  viewport: null,
+  maxTouchPoints: 0,
+  paymentRequest: { available: false },
+  permissions: { geolocation: { state: "granted" as const } },
+  geolocation: { requested: geolocation, effective: geolocation, support: { coordinates: "supported" as const, permission: "supported" as const, unavailable: "unsupported" as const, reason: "fixture" } },
+}
+const geolocationResult = new BrowserProbeSessionResultBuilder().compose({ ...baseInput(), context: { requested: { geolocation }, effective: { geolocation, viewport: null } }, capabilities: geolocationCapabilities })
+assert.deepEqual(geolocationResult.review.profile.context?.requested.geolocation, geolocation)
+assert.deepEqual(geolocationResult.review.profile.capabilities?.geolocation, geolocationCapabilities.geolocation)
+assert.deepEqual((geolocationResult.summary.context as { requested: { geolocation: unknown } }).requested.geolocation, geolocation)
+
 const wordpressSummary: BrowserWordPressDiagnosticsSummary = {
   status: "captured",
   artifact: "files/browser/wordpress-diagnostics.json",

--- a/tests/browser-environment-matrix.browser.test.ts
+++ b/tests/browser-environment-matrix.browser.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
 import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { createServer } from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import test from "node:test"
@@ -7,7 +8,7 @@ import test from "node:test"
 import { chromium } from "playwright"
 
 import { browserEnvironmentMatrix } from "../packages/runtime-core/src/browser-environment-matrix.js"
-import { runPlaywrightBrowserEnvironmentMatrix } from "../packages/runtime-playground/src/browser-environment-matrix.js"
+import { createPlaywrightBrowserEnvironmentContext, resolvePlaywrightBrowserEnvironment, runPlaywrightBrowserEnvironmentMatrix } from "../packages/runtime-playground/src/browser-environment-matrix.js"
 
 test("real browser matrix applies viewport, media, locale, timezone, touch, zoom, and throttling", async () => {
   const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-browser-matrix-"))
@@ -78,6 +79,84 @@ test("real browser matrix refuses a colliding run artifact namespace", async () 
     await assert.rejects(run(), (error: NodeJS.ErrnoException) => error.code === "EEXIST")
   } finally {
     await browser.close()
+    await rm(artifactRoot, { recursive: true, force: true })
+  }
+})
+
+test("real browser contexts apply and isolate granted, denied, and prompt geolocation", async () => {
+  const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-browser-geolocation-"))
+  const browser = await chromium.launch({ headless: true })
+  const server = createServer((_request, response) => response.end("geolocation"))
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  assert(address && typeof address === "object")
+  const url = `http://127.0.0.1:${address.port}`
+  const observed: Array<{ cell: string; requested: string; permission: string; latitude?: number; longitude?: number; accuracy?: number; error?: number }> = []
+  try {
+    const matrix = browserEnvironmentMatrix({
+      id: "geolocation",
+      seed: "geolocation-seed",
+      dimensions: [{ id: "location", values: [
+        { id: "denied", environment: { geolocation: { latitude: 40.7128, longitude: -74.006, permission: "denied" } }, requiredCapabilities: ["browser.environment.geolocation"] },
+        { id: "granted", environment: { geolocation: { latitude: 32.7765, longitude: -79.9311, accuracy: 9, permission: "granted" } }, requiredCapabilities: ["browser.environment.geolocation"] },
+        { id: "prompt", environment: { geolocation: { latitude: 51.5072, longitude: -0.1276, permission: "prompt" } }, requiredCapabilities: ["browser.environment.geolocation"] },
+      ] }],
+      limits: { maxCells: 3, maxDurationMs: 30_000, maxCellDurationMs: 10_000, maxArtifactBytes: 1_048_576 },
+    })
+    const report = await runPlaywrightBrowserEnvironmentMatrix({ matrix, runId: "states", artifactRoot, browser, execute: async ({ page, cell, resolved }) => {
+      await page.goto(url)
+      observed.push(await page.evaluate(async ({ cell, requested }) => {
+        const permission = (await navigator.permissions.query({ name: "geolocation" })).state
+        if (permission === "prompt") return { cell, requested, permission }
+        return await new Promise((resolve) => navigator.geolocation.getCurrentPosition(
+          ({ coords }) => resolve({ cell, requested, permission, latitude: coords.latitude, longitude: coords.longitude, accuracy: coords.accuracy }),
+          ({ code }) => resolve({ cell, requested, permission, error: code }),
+          { timeout: 1_000 },
+        ))
+      }, { cell: cell.selections.location!, requested: resolved.effective.geolocation!.permission }))
+      return { status: "passed" }
+    } })
+    assert.equal(report.status, "passed")
+    assert.deepEqual(observed, [
+      { cell: "denied", requested: "denied", permission: "denied", error: 1 },
+      { cell: "granted", requested: "granted", permission: "granted", latitude: 32.7765, longitude: -79.9311, accuracy: 9 },
+      { cell: "prompt", requested: "prompt", permission: "prompt" },
+    ])
+
+    const cells = matrix.dimensions[0]!.values.slice(1).map((value, index) => ({ id: value.id, index, seed: value.id, selections: { location: value.id }, requested: value.environment, requiredCapabilities: [], optionalCapabilities: [] }))
+    const parallel = await Promise.all(cells.map(async (cell) => {
+      const resolved = await resolvePlaywrightBrowserEnvironment(cell, browser)
+      const runtime = await createPlaywrightBrowserEnvironmentContext(browser, resolved)
+      try {
+        await runtime.page.goto(url)
+        return await runtime.page.evaluate(async () => ({ permission: (await navigator.permissions.query({ name: "geolocation" })).state, result: await new Promise((resolve) => navigator.geolocation.getCurrentPosition(({ coords }) => resolve([coords.latitude, coords.longitude]), ({ code }) => resolve(code), { timeout: 500 })) }))
+      } finally {
+        await runtime.close()
+      }
+    }))
+    assert.deepEqual(parallel, [
+      { permission: "granted", result: [32.7765, -79.9311] },
+      { permission: "prompt", result: 1 },
+    ])
+  } finally {
+    await browser.close()
+    server.close()
+    await rm(artifactRoot, { recursive: true, force: true })
+  }
+})
+
+test("unsupported denied permission is reported by provider capability resolution", async () => {
+  const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-browser-geolocation-unsupported-"))
+  const matrix = browserEnvironmentMatrix({ id: "unsupported-geolocation", seed: "seed", dimensions: [{ id: "location", values: [{ id: "denied", environment: { geolocation: { latitude: 0, longitude: 0, permission: "denied" } } }] }] })
+  const [cell] = (await import("../packages/runtime-core/src/browser-environment-matrix.js")).expandBrowserEnvironmentMatrix(matrix)
+  const provider = { browserType: () => ({ name: () => "firefox" }), version: () => "fixture" } as unknown as import("playwright").Browser
+  const resolved = await resolvePlaywrightBrowserEnvironment(cell!, provider)
+  assert.deepEqual(resolved.capabilities.find(({ id }) => id === "browser.environment.geolocation"), { id: "browser.environment.geolocation", fidelity: "unsupported", reason: "This provider cannot express an explicit denied geolocation permission without Chromium browser permission controls." })
+  try {
+    const report = await runPlaywrightBrowserEnvironmentMatrix({ matrix, runId: "unsupported", artifactRoot, browser: provider, execute: async () => { throw new Error("unsupported cells must not execute") } })
+    assert.equal(report.cells[0]?.status, "error")
+    assert.deepEqual(report.cells[0]?.unsupported, ["browser.environment.geolocation"])
+  } finally {
     await rm(artifactRoot, { recursive: true, force: true })
   }
 })

--- a/tests/browser-environment-matrix.test.ts
+++ b/tests/browser-environment-matrix.test.ts
@@ -9,6 +9,7 @@ import {
   type BrowserEnvironmentMatrix,
   type ResolvedBrowserEnvironment,
 } from "../packages/runtime-core/src/browser-environment-matrix.js"
+import { browserGeolocation } from "../packages/runtime-core/src/browser-probe-contract.js"
 
 const limits = { maxCells: 16, maxDurationMs: 16_000, maxCellDurationMs: 1_000, maxArtifactBytes: 1024 }
 
@@ -57,6 +58,31 @@ test("environment dimensions merge independent capability state", () => {
     { id: "second", values: [{ id: "second", environment: { capabilities: { beta: "enabled" } } }] },
   ]))
   assert.deepEqual(cell?.requested.capabilities, { alpha: true, beta: "enabled" })
+})
+
+test("geolocation is canonical, validated, and included in cell and replay identity", async () => {
+  assert.deepEqual(browserGeolocation({ latitude: 32.7765, longitude: -79.9311, accuracy: 12, permission: "default" }), { latitude: 32.7765, longitude: -79.9311, accuracy: 12, permission: "prompt" })
+  for (const geolocation of [
+    { latitude: -91, longitude: 0, permission: "prompt" as const },
+    { latitude: 0, longitude: 181, permission: "prompt" as const },
+    { latitude: Number.NaN, longitude: 0, permission: "prompt" as const },
+    { latitude: 0, longitude: Number.POSITIVE_INFINITY, permission: "prompt" as const },
+    { latitude: 0, longitude: 0, accuracy: -1, permission: "prompt" as const },
+    { latitude: 0, longitude: 0, accuracy: 1_000_001, permission: "prompt" as const },
+  ]) assert.throws(() => browserGeolocation(geolocation), /Browser geolocation/)
+
+  const matrix = fixtureMatrix([{ id: "location", values: [
+    { id: "first", environment: { geolocation: { latitude: 32.7765, longitude: -79.9311, accuracy: 12, permission: "granted" } } },
+    { id: "second", environment: { geolocation: { latitude: 40.7128, longitude: -74.006, permission: "denied" } } },
+  ] }])
+  const cells = expandBrowserEnvironmentMatrix(matrix)
+  assert.notEqual(cells[0]?.id, cells[1]?.id)
+  assert.notEqual(cells[0]?.seed, cells[1]?.seed)
+  const repeated = expandBrowserEnvironmentMatrix(matrix)
+  assert.deepEqual(cells, repeated)
+  const report = await runBrowserEnvironmentMatrix(matrix, { runId: "geolocation", resolve: resolveAll, execute: async () => ({ status: "passed" }) })
+  assert.deepEqual(report.cells.map(({ requested }) => requested.geolocation), cells.map(({ requested }) => requested.geolocation))
+  assert.deepEqual(report.cells.map(({ replay }) => replay.requested.geolocation), cells.map(({ requested }) => requested.geolocation))
 })
 
 test("matrix cells use isolated run and cell artifact namespaces", async () => {
@@ -151,5 +177,6 @@ function resolveAll(cell: { requested: BrowserEnvironmentMatrix["dimensions"][nu
     { id: "browser.environment.viewport", fidelity: "exact" },
     { id: "browser.environment.reduced-motion", fidelity: "exact" },
     { id: "browser.environment.color-scheme", fidelity: "exact" },
+    { id: "browser.environment.geolocation", fidelity: "exact" },
   ] }
 }

--- a/tests/recipe-validation-descriptors.test.ts
+++ b/tests/recipe-validation-descriptors.test.ts
@@ -43,4 +43,19 @@ await withTempDir("wp-codebox-recipe-validation-descriptors-", async (recipeDire
   ])
 })
 
+await withTempDir("wp-codebox-recipe-geolocation-validation-", async (recipeDirectory) => {
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    workflow: { steps: [
+      { command: "wordpress.browser-probe", args: ["url=/", "geolocation-latitude=NaN", "geolocation-longitude=181", "geolocation-accuracy=-1", "geolocation-permission=maybe"] },
+      { command: "wordpress.browser-probe", args: ["url=/", "geolocation-latitude=32.7765", "geolocation-permission=granted"] },
+      { command: "wordpress.browser-probe", args: ["url=/", "geolocation-latitude=32.7765", "geolocation-longitude=-79.9311", "geolocation-accuracy=8", "geolocation-permission=default"] },
+    ] },
+  }
+  const issues = await validateWorkspaceRecipeSemantics(recipe, join(recipeDirectory, "recipe.json"))
+  assert.deepEqual(issues.filter(({ path }) => path === "$.workflow.steps[0].args").map(({ code }) => code), ["invalid-geolocation-latitude", "invalid-geolocation-longitude", "invalid-geolocation-accuracy", "invalid-geolocation-permission"])
+  assert.deepEqual(issues.filter(({ path }) => path === "$.workflow.steps[1].args").map(({ code }) => code), ["incomplete-geolocation", "incomplete-geolocation"])
+  assert.deepEqual(issues.filter(({ path }) => path === "$.workflow.steps[2].args"), [])
+})
+
 console.log("recipe validation descriptors ok")


### PR DESCRIPTION
## Summary

- add canonical browser geolocation coordinates, optional accuracy, and explicit `granted`, `denied`, or `prompt` permission state to browser probes and environment matrices
- preserve requested/effective geolocation in capability diagnostics, review artifacts, matrix cell identity, fingerprints, and replay while isolating every state in a fresh browser context
- validate recipe and runtime inputs before context creation and report unsupported provider behavior as structured unsupported/inconclusive evidence

## Contract

Browser probes accept `geolocation-latitude`, `geolocation-longitude`, optional `geolocation-accuracy`, and `geolocation-permission`. `default` is normalized once to canonical `prompt`. Latitude is bounded to `[-90, 90]`, longitude to `[-180, 180]`, and finite accuracy to `[0, 1000000]` meters before Playwright context mutation.

The existing `permissions=` behavior remains compatible. When the explicit geolocation contract is present, it owns only the `geolocation` permission while preserving unrelated permission grants.

Environment matrices carry the same canonical `geolocation` object. It is included automatically in stable cell identity, seeds, finding fingerprints, reports, and replay inputs. Existing per-cell fresh-context creation and close behavior provides coordinate and permission isolation without parallel state machinery.

## Playwright semantics

Playwright coordinates are applied through `browser.newContext({ geolocation })`; granted state uses the real context permission grant. Omitting a grant or calling `clearPermissions()` resets Chromium to prompt/default and cannot represent an explicit denial. Chromium denial therefore uses `Browser.setPermission` scoped to the Playwright context's `browserContextId`, with the protocol session retained for that context's lifetime. Non-Chromium providers report the required geolocation capability as unsupported rather than executing a false pass.

`BrowserContext.setGeolocation()` and context geolocation options both update real browser coordinates, but neither models unavailable position or timeout. Capability diagnostics explicitly report deterministic unavailable/timeout behavior as unsupported instead of monkey-patching `navigator.geolocation`.

## Diagnostics and artifacts

- requested and effective coordinates, accuracy, and permission state are emitted in browser context details
- capability diagnostics distinguish coordinate support, permission support, and unsupported unavailable/timeout behavior
- browser review artifacts retain the context and capability evidence
- matrix reports and replay preserve canonical requested/effective state and provider fidelity

## Verification

Passed:

- `npm run build`
- `npm run test:browser-environment-matrix`
- `npm run test:recipe-validation-descriptors`
- `npm run test:browser-diagnostic-providers`
- `npm run test:schema-parity`
- `npm run test:runtime-contract-manifest`
- `npm run test:public-api-contract`
- `npx tsx scripts/browser-probe-contract-smoke.ts`
- `npm run test:production-boundary-enforcement`
- `git diff --check`

The real Chromium matrix smoke verifies exact granted coordinates and accuracy through `navigator.geolocation`, deterministic denied error code 1, distinguishable prompt/default state, sequential isolation, and parallel context isolation.

`npm run check` reaches an unrelated baseline failure in `scripts/command-registry-smoke.ts`: `wordpress.collect-workload-result outputShape should mention outputSchema id`. The same failure occurs before geolocation-specific smoke execution; no test was weakened.

No dependency installation, duplicate dependency tree, broad generated artifact, changelog, or version change was produced.

Fixes #2084