### PR TITLE
fix: distinguish policy blocks from browser failures

### DIFF
--- a/packages/runtime-core/src/browser-adaptive-exploration.ts
+++ b/packages/runtime-core/src/browser-adaptive-exploration.ts
@@ -32,6 +32,7 @@ export interface BrowserAdaptiveExplorationContract {
   revisitPolicy: { maxStateVisits: number; maxActionVisits: number }
   descriptorLimits: { maxPerState: number; maxDiagnostics: number; maxTextLength: number }
   stabilization: { pollIntervalMs: number; quietWindowMs: number; maxWaitMs: number; maxMutationRecords: number }
+  oraclePolicy: { policyBlocks: "evidence" | "finding" }
   failOnFinding: boolean
   accessibility?: BrowserAccessibilityContract
   metadata?: Record<string, unknown>
@@ -84,10 +85,21 @@ export interface BrowserAdaptiveTransition {
     loadingBefore: number
     loadingAfter: number
     oracleFingerprints: string[]
+    networkFailures?: BrowserAdaptiveNetworkFailure[]
     accessibilityFindingFingerprints?: string[]
   }
   status: "ok" | "revisited" | "rejected" | "error" | "cancelled"
   diagnostic?: { code: string; message: string }
+}
+
+export interface BrowserAdaptiveNetworkFailure {
+  url: string
+  host?: string
+  urlClassification: "same-origin" | "external" | "invalid"
+  policyDecision: "blocked" | "allowed" | "recorded" | "unknown"
+  policyReason: string
+  failure?: string
+  oracleFinding: boolean
 }
 
 export interface BrowserAdaptiveFinding {
@@ -142,6 +154,7 @@ export function browserAdaptiveExplorationContract(input: Record<string, unknown
   const revisit = object(input.revisitPolicy ?? input.revisit_policy)
   const descriptors = object(input.descriptorLimits ?? input.descriptor_limits)
   const stabilization = object(input.stabilization)
+  const oraclePolicy = object(input.oraclePolicy ?? input.oracle_policy)
   const reset = object(input.resetPolicy ?? input.reset_policy)
   const accessibility = browserAccessibilityContract(input.accessibility)
   const families = Array.isArray(input.actionFamilies ?? input.action_families)
@@ -179,6 +192,7 @@ export function browserAdaptiveExplorationContract(input: Record<string, unknown
       maxWaitMs: integer(stabilization.maxWaitMs ?? stabilization.max_wait_ms, 3_000, 50, 60_000),
       maxMutationRecords: integer(stabilization.maxMutationRecords ?? stabilization.max_mutation_records, 100, 1, 5_000),
     },
+    oraclePolicy: { policyBlocks: (oraclePolicy.policyBlocks ?? oraclePolicy.policy_blocks) === "finding" ? "finding" as const : "evidence" as const },
     failOnFinding: input.failOnFinding !== false && input.fail_on_finding !== false,
     accessibility,
     metadata: isPlainObject(input.metadata) ? input.metadata : undefined,

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -240,6 +240,7 @@ export async function runBrowserActionsCommand({
           contract: adaptiveContract,
           observations: { consoleMessages, errors, network },
           navigationScope: topology.navigationScope,
+          networkPolicy: topology.networkPolicy,
           signal: spec.signal,
           accessibilityCollector: adaptiveContract.accessibility ? createBrowserAccessibilityCollector(page, adaptiveContract.accessibility) : undefined,
           onAccessibilityFindingEvidence: adaptiveContract.accessibility ? async (scan) => {

--- a/packages/runtime-playground/src/browser-adaptive-explorer.ts
+++ b/packages/runtime-playground/src/browser-adaptive-explorer.ts
@@ -9,6 +9,7 @@ import {
   type BrowserAdaptiveExplorationResult,
   type BrowserAdaptiveFinding,
   type BrowserAdaptiveFrameIdentity,
+  type BrowserAdaptiveNetworkFailure,
   type BrowserAdaptiveState,
   type BrowserAdaptiveTransition,
   type BrowserAccessibilityCollector,
@@ -18,7 +19,7 @@ import { stableJson } from "@automattic/wp-codebox-core/internals"
 import type { Frame, Page } from "playwright"
 
 import { discoverBrowserActionCorpusDescriptors } from "./browser-action-discovery.js"
-import type { BrowserPreviewNavigationScope } from "./browser-preview-routing.js"
+import { browserPreviewNetworkDecision, type BrowserPreviewNavigationScope, type BrowserPreviewNetworkPolicy } from "./browser-preview-routing.js"
 
 interface AdaptiveObservationSources {
   consoleMessages: object[]
@@ -52,6 +53,7 @@ export async function exploreAdaptiveBrowserStateMachine({
   signal,
   now = Date.now,
   navigationScope,
+  networkPolicy,
   accessibilityCollector,
   onAccessibilityFindingEvidence,
 }: {
@@ -62,6 +64,7 @@ export async function exploreAdaptiveBrowserStateMachine({
   signal?: AbortSignal
   now?: () => number
   navigationScope?: BrowserPreviewNavigationScope
+  networkPolicy?: BrowserPreviewNetworkPolicy
   accessibilityCollector?: BrowserAccessibilityCollector
   onAccessibilityFindingEvidence?: (scan: Awaited<ReturnType<BrowserAccessibilityCollector["scan"]>>) => Promise<{ screenshot?: string; domSnapshot?: string }>
 }): Promise<BrowserAdaptiveExplorationResult> {
@@ -138,9 +141,11 @@ export async function exploreAdaptiveBrowserStateMachine({
       const stabilized = await stabilizeAdaptiveState(page, contract, source.path.length + 1, now, navigationScope)
       appendDiagnostics(diagnostics, stabilized.diagnostics, contract.descriptorLimits.maxDiagnostics)
       const scopeRejection = stabilized.diagnostics.find((diagnostic) => diagnostic.code === "browser_adaptive_redirect_scope_escape_rejected")
-      const newConsoleErrors = consoleErrorMessages(observations.consoleMessages.slice(beforeConsole))
+      const newConsoleRecords = consoleErrorRecords(observations.consoleMessages.slice(beforeConsole))
+      const newConsoleErrors = newConsoleRecords.map(recordMessage)
       const newPageErrors = errorMessages(observations.errors.slice(beforeErrors))
-      const fingerprints = [...new Set([...newConsoleErrors, ...newPageErrors].map((message) => browserAdaptiveDigest("oracle", message)))].sort()
+      const oracleEvidence = adaptiveOracleEvidence(newConsoleRecords, observations.network.slice(beforeNetwork), newPageErrors, contract, networkPolicy)
+      const fingerprints = [...oracleEvidence.fingerprints]
       const existing = states.get(stabilized.state.digest)
       const newState = !existing
       const transitionId = `transition-${transitions.length}`
@@ -183,12 +188,13 @@ export async function exploreAdaptiveBrowserStateMachine({
           loadingBefore: source.state.loadingIndicators,
           loadingAfter: stabilized.loading,
           oracleFingerprints: fingerprints,
+          ...(oracleEvidence.networkFailures.length > 0 ? { networkFailures: oracleEvidence.networkFailures } : {}),
           ...(accessibilityFingerprints.length > 0 ? { accessibilityFindingFingerprints: accessibilityFingerprints } : {}),
         },
         status: actionError ? "error" : scopeRejection ? "rejected" : newState ? "ok" : "revisited",
         ...(actionError ? { diagnostic: { code: "browser_adaptive_action_error", message: actionError } } : scopeRejection ? { diagnostic: { code: scopeRejection.code, message: scopeRejection.message } } : {}),
       }
-      errors += newConsoleErrors.length + newPageErrors.length + (actionError ? 1 : 0)
+      errors += oracleEvidence.errorCount + (actionError ? 1 : 0)
       if (artifactBytes(states, [...transitions, transition], diagnostics, findings) + (accessibilityCollector ? Buffer.byteLength(stableJson(accessibilityCollector.evidence())) : 0) > adaptiveJsonArtifactBudget(contract, accessibilityCollector)) {
         if (replayableDestination && newState) states.delete(stabilized.state.digest)
         exhausted = "maxArtifactBytes"
@@ -231,7 +237,7 @@ export async function exploreAdaptiveBrowserStateMachine({
 
   if (findings.length > 0 && !signal?.aborted) {
     for (const finding of findings) {
-      const minimized = await minimizeAdaptiveFinding(page, baseUrl, contract, finding, observations, Math.max(0, contract.budgets.maxActions - actions), Math.max(0, (contract.accessibility?.budgets.maxKeyboardActions ?? Number.POSITIVE_INFINITY) - keyboardActions), started + contract.budgets.maxDurationMs, signal, now, navigationScope, accessibilityCollector)
+      const minimized = await minimizeAdaptiveFinding(page, baseUrl, contract, finding, observations, Math.max(0, contract.budgets.maxActions - actions), Math.max(0, (contract.accessibility?.budgets.maxKeyboardActions ?? Number.POSITIVE_INFINITY) - keyboardActions), started + contract.budgets.maxDurationMs, signal, now, navigationScope, networkPolicy, accessibilityCollector)
       actions += minimized.executed
       keyboardActions += minimized.keyboardExecuted
       finding.minimizedPath = minimized.path
@@ -491,7 +497,7 @@ async function restoreAdaptivePath(page: Page, baseUrl: string, contract: Browse
   }
 }
 
-async function minimizeAdaptiveFinding(page: Page, baseUrl: string, contract: BrowserAdaptiveExplorationContract, finding: BrowserAdaptiveFinding, observations: AdaptiveObservationSources, maximumActions: number, maximumKeyboardActions: number, deadline: number, signal?: AbortSignal, now: () => number = Date.now, navigationScope?: BrowserPreviewNavigationScope, accessibilityCollector?: BrowserAccessibilityCollector): Promise<{ path: BrowserAdaptiveAction[]; executed: number; keyboardExecuted: number; exhausted?: "maxActions" | "maxKeyboardActions" | "maxDurationMs" | "cancelled" }> {
+async function minimizeAdaptiveFinding(page: Page, baseUrl: string, contract: BrowserAdaptiveExplorationContract, finding: BrowserAdaptiveFinding, observations: AdaptiveObservationSources, maximumActions: number, maximumKeyboardActions: number, deadline: number, signal?: AbortSignal, now: () => number = Date.now, navigationScope?: BrowserPreviewNavigationScope, networkPolicy?: BrowserPreviewNetworkPolicy, accessibilityCollector?: BrowserAccessibilityCollector): Promise<{ path: BrowserAdaptiveAction[]; executed: number; keyboardExecuted: number; exhausted?: "maxActions" | "maxKeyboardActions" | "maxDurationMs" | "cancelled" }> {
   let current = [...finding.originalPath]
   let chunk = Math.max(1, Math.floor(current.length / 2))
   let executed = 0
@@ -507,10 +513,11 @@ async function minimizeAdaptiveFinding(page: Page, baseUrl: string, contract: Br
       if (keyboardExecuted + countKeyboardActions(candidate) > maximumKeyboardActions) { exhausted = "maxKeyboardActions"; break }
       const beforeConsole = observations.consoleMessages.length
       const beforeErrors = observations.errors.length
+      const beforeNetwork = observations.network.length
       const replay = await restoreAdaptivePath(page, baseUrl, contract, candidate, signal, navigationScope, accessibilityCollector)
       executed += replay.executed
       keyboardExecuted += replay.keyboardExecuted
-      const fingerprints = [...consoleErrorMessages(observations.consoleMessages.slice(beforeConsole)), ...errorMessages(observations.errors.slice(beforeErrors))].map((message) => browserAdaptiveDigest("oracle", message)).concat(replay.finalAccessibilityFingerprints)
+      const fingerprints = adaptiveOracleEvidence(consoleErrorRecords(observations.consoleMessages.slice(beforeConsole)), observations.network.slice(beforeNetwork), errorMessages(observations.errors.slice(beforeErrors)), contract, networkPolicy).fingerprints.concat(replay.finalAccessibilityFingerprints)
       if (replay.state && fingerprints.includes(finding.fingerprint) && (!finding.stateDigest || replay.state.digest === finding.stateDigest)) {
         current = candidate
         reduced = true
@@ -558,8 +565,47 @@ function rejectedTransition(state: BrowserAdaptiveState, action: BrowserAdaptive
   return { id: `transition-rejected-${browserAdaptiveDigest("action", `${state.digest}:${action.id}`).slice(0, 12)}`, sourceDigest: state.digest, action, sourceUrl: state.url, destinationUrl, history: { before: state.historyLength, after: state.historyLength, beforeStateDigest: state.historyStateDigest, afterStateDigest: state.historyStateDigest }, timing: { durationMs: 0, stabilizationMs: 0, polls: 0 }, novelty: { newState: false, newDescriptors: 0, mutationRecords: 0, mutationEvidenceTruncated: false }, observations: { networkEvents: 0, consoleErrors: [], pageErrors: [], loadingBefore: 0, loadingAfter: 0, oracleFingerprints: [] }, status: "rejected", diagnostic: { code, message } }
 }
 
-function consoleErrorMessages(records: object[]): string[] {
-  return records.map((record) => record as Record<string, unknown>).filter((record) => record.type === "error" || record.level === "error").map(recordMessage).filter(Boolean).slice(0, 100)
+function consoleErrorRecords(records: object[]): Record<string, unknown>[] {
+  return records.map((record) => record as Record<string, unknown>).filter((record) => record.type === "error" || record.level === "error").slice(0, 100)
+}
+
+function adaptiveOracleEvidence(consoleRecords: Record<string, unknown>[], networkRecords: object[], pageErrors: string[], contract: BrowserAdaptiveExplorationContract, networkPolicy?: BrowserPreviewNetworkPolicy): { fingerprints: string[]; networkFailures: BrowserAdaptiveNetworkFailure[]; errorCount: number } {
+  const failures = networkRecords.map((record) => record as Record<string, unknown>).filter((record) => record.type === "requestfailed")
+  const networkFailures = failures.map((record): BrowserAdaptiveNetworkFailure => {
+    const url = typeof record.url === "string" ? record.url : ""
+    const decision = networkPolicy ? browserPreviewNetworkDecision(url, networkPolicy) : { url, urlClassification: "invalid" as const, policyDecision: "unknown" as const, policyReason: "network-policy-unavailable" }
+    const failure = networkFailureMessage(record)
+    const expectedBlock = decision.policyDecision === "blocked" && /ERR_BLOCKED_BY_CLIENT|blockedbyclient/i.test(failure)
+    return { ...decision, ...(failure ? { failure } : {}), oracleFinding: !expectedBlock || contract.oraclePolicy.policyBlocks === "finding" }
+  })
+  const expectedBlockUrls = networkFailures.filter((failure) => !failure.oracleFinding).map((failure) => failure.url)
+  const findingConsoleRecords = consoleRecords.filter((record) => {
+    if (!/ERR_BLOCKED_BY_CLIENT/i.test(recordMessage(record))) return true
+    const location = objectRecord(record.location)
+    const match = typeof location.url === "string" && location.url
+      ? expectedBlockUrls.indexOf(location.url)
+      : expectedBlockUrls.length > 0 ? 0 : -1
+    if (match < 0) return true
+    expectedBlockUrls.splice(match, 1)
+    return false
+  })
+  const consoleUrls = new Set(findingConsoleRecords.map((record) => objectRecord(record.location).url).filter((url): url is string => typeof url === "string"))
+  const networkMessages = networkFailures.filter((failure) => failure.oracleFinding && !consoleUrls.has(failure.url)).map((failure) => stableJson({ type: "requestfailed", url: failure.url, failure: failure.failure, urlClassification: failure.urlClassification, policyDecision: failure.policyDecision, policyReason: failure.policyReason }))
+  const messages = [...findingConsoleRecords.map(recordMessage), ...pageErrors, ...networkMessages]
+  return {
+    fingerprints: [...new Set(messages.map((message) => browserAdaptiveDigest("oracle", message)))].sort(),
+    networkFailures,
+    errorCount: findingConsoleRecords.length + pageErrors.length + networkMessages.length,
+  }
+}
+
+function networkFailureMessage(record: Record<string, unknown>): string {
+  const failure = objectRecord(record.failure)
+  return typeof failure.errorText === "string" ? failure.errorText : typeof record.failure === "string" ? record.failure : ""
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
 function errorMessages(records: object[]): string[] {

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -24,6 +24,14 @@ export interface BrowserPreviewNavigationDecision {
   reason: string
 }
 
+export interface BrowserPreviewNetworkDecision {
+  url: string
+  host?: string
+  urlClassification: "same-origin" | "external" | "invalid"
+  policyDecision: "blocked" | "allowed" | "recorded" | "unknown"
+  policyReason: string
+}
+
 export interface BrowserPreviewNavigationScope {
   resolve(href: string, documentUrl: string): BrowserPreviewNavigationDecision
   drainDiagnostics(): Array<{ code: string; message: string; metadata: Record<string, unknown> }>
@@ -230,6 +238,24 @@ export function browserPreviewNetworkPolicySummary(policy: BrowserPreviewNetwork
     blockedRequests: Object.values(hosts).reduce((total, stat) => total + stat.blocked, 0),
     hosts: policy.recordExternal ? hosts : Object.fromEntries(Object.entries(hosts).filter(([, stat]) => stat.blocked > 0 || stat.routed > 0)),
   }
+}
+
+export function browserPreviewNetworkDecision(url: string, policy: BrowserPreviewNetworkPolicy): BrowserPreviewNetworkDecision {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return { url, urlClassification: "invalid", policyDecision: "unknown", policyReason: "url-invalid" }
+  }
+  const host = normalizeBrowserPreviewHost(parsed.hostname)
+  const external = !policy.firstPartyHosts.has(host)
+  const evidence = { url, host, urlClassification: external ? "external" as const : "same-origin" as const }
+  if (policy.blockHosts.has(host)) return { ...evidence, policyDecision: "blocked", policyReason: "declared-block-host" }
+  if (policy.mode === "block" && external && !policy.allowHosts.has(host)) return { ...evidence, policyDecision: "blocked", policyReason: "external-host-blocked-by-policy" }
+  if (policy.allowHosts.has(host)) return { ...evidence, policyDecision: "allowed", policyReason: "declared-allow-host" }
+  if (!external) return { ...evidence, policyDecision: "allowed", policyReason: "first-party-host" }
+  if (policy.mode === "allow") return { ...evidence, policyDecision: "allowed", policyReason: "network-policy-allow" }
+  return { ...evidence, policyDecision: "recorded", policyReason: "network-policy-record" }
 }
 
 export async function routeBrowserPreviewPageNetwork(page: Page, policy: BrowserPreviewNetworkPolicy, previewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {

--- a/tests/browser-adaptive-exploration.test.ts
+++ b/tests/browser-adaptive-exploration.test.ts
@@ -11,6 +11,7 @@ import {
 import { getCommandDefinition } from "../packages/runtime-core/src/command-registry.js"
 import { discoverBrowserActionCorpusDescriptors } from "../packages/runtime-playground/src/browser-action-discovery.js"
 import { exploreAdaptiveBrowserStateMachine } from "../packages/runtime-playground/src/browser-adaptive-explorer.js"
+import { attachBrowserCaptureListeners } from "../packages/runtime-playground/src/browser-capture-session.js"
 import { executeBrowserInteractionStep } from "../packages/runtime-playground/src/browser-interactions.js"
 import { browserPreviewTopology, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import { closeHttpServer, listenLocalHttpServer } from "../packages/runtime-playground/src/preview-server.js"
@@ -91,6 +92,7 @@ test("adaptive contract normalizes every safety and exploration bound", () => {
   assert.equal(contract.revisitPolicy.maxStateVisits, 1)
   assert.equal(contract.descriptorLimits.maxTextLength, 64)
   assert.equal(contract.stabilization.pollIntervalMs, 10)
+  assert.deepEqual(contract.oraclePolicy, { policyBlocks: "evidence" })
 
   const allFamilies = browserAdaptiveExplorationContract({ seed: "families", startUrl: "/fixture" })
   const planned = planBrowserAdaptiveStateActions({
@@ -473,6 +475,67 @@ test("adaptive exploration follows routed canonical multisite links and rejects 
   }
 })
 
+test("declared network-policy blocks remain structured evidence without becoming findings", async () => {
+  const run = await runNetworkOracleFixture("block", "blocked")
+  const transition = run.result.transitions[0]
+  assert.equal(run.result.findings.length, 0)
+  assert.equal(run.result.summary.errors, 0)
+  assert(transition?.observations.consoleErrors.some((message) => message.includes("ERR_BLOCKED_BY_CLIENT")), "raw browser console evidence remains available")
+  assert.deepEqual(transition?.observations.networkFailures, [{
+    url: "http://assets.example.invalid/tile.png",
+    host: "assets.example.invalid",
+    urlClassification: "external",
+    policyDecision: "blocked",
+    policyReason: "external-host-blocked-by-policy",
+    failure: "net::ERR_BLOCKED_BY_CLIENT.Inspector",
+    oracleFinding: false,
+  }])
+  assert.deepEqual(transition?.observations.oracleFingerprints, [])
+})
+
+test("callers can opt policy blocks back into deterministic findings and replay", async () => {
+  const input = { oraclePolicy: { policyBlocks: "finding" } }
+  const first = await runNetworkOracleFixture("block", "blocked", input)
+  const second = await runNetworkOracleFixture("block", "blocked", input)
+  const finding = first.result.findings[0]
+  assert(finding)
+  assert.equal(first.result.transitions[0]?.observations.networkFailures?.[0]?.oracleFinding, true)
+  assert.equal(finding.fingerprint, second.result.findings[0]?.fingerprint)
+  assert.deepEqual(finding.minimizedPath, finding.originalPath)
+  assert.deepEqual(finding.replay.actions, finding.minimizedPath)
+  assert.equal(finding.replay.expectedFingerprint, finding.fingerprint)
+})
+
+test("allow and record policies do not explain unexpected same-origin request failures", async () => {
+  for (const mode of ["allow", "record"] as const) {
+    const run = await runNetworkOracleFixture(mode, "unexpected")
+    const failure = run.result.transitions[0]?.observations.networkFailures?.[0]
+    assert.equal(run.result.findings.length, 1, mode)
+    assert.equal(failure?.urlClassification, "same-origin", mode)
+    assert.equal(failure?.policyDecision, "allowed", mode)
+    assert.equal(failure?.policyReason, "first-party-host", mode)
+    assert.equal(failure?.oracleFinding, true, mode)
+  }
+})
+
+test("mixed expected and unexpected network errors only promote the product failure", async () => {
+  const run = await runNetworkOracleFixture("block", "mixed")
+  const failures = run.result.transitions[0]?.observations.networkFailures ?? []
+  assert.equal(run.result.findings.length, 1)
+  assert.equal(failures.length, 2)
+  assert(failures.some((failure) => failure.policyDecision === "blocked" && failure.policyReason === "external-host-blocked-by-policy" && !failure.oracleFinding))
+  assert(failures.some((failure) => failure.urlClassification === "same-origin" && failure.policyDecision === "allowed" && failure.oracleFinding))
+  assert.equal(run.result.transitions[0]?.observations.oracleFingerprints.length, 1)
+})
+
+test("page exceptions remain findings alongside policy-aware network classification", async () => {
+  const run = await runNetworkOracleFixture("block", "exception")
+  assert.equal(run.result.findings.length, 1)
+  assert(run.result.transitions[0]?.observations.pageErrors.includes("fixture page exception"))
+  assert.equal(run.result.transitions[0]?.observations.networkFailures, undefined)
+  assert.deepEqual(run.result.findings[0]?.replay.actions, run.result.findings[0]?.minimizedPath)
+})
+
 test("loops, budgets, cancellation, frames, and partial evidence remain bounded", async () => {
   const loopFixture = `<!doctype html><style>button,input,a,iframe { display:block;width:100px;height:30px }</style><button id="toggle">Toggle</button><form id="first"><input name="query"></form><form id="second"><input name="query"></form><a id="external" href="https://example.test/outside">External</a><iframe id="same" srcdoc="<style>button{width:100px;height:30px}</style><button id='framed'>Framed</button>"></iframe><script>toggle.onclick=()=>document.body.classList.toggle('on')</script>`
   const bounded = await runFixture(loopFixture, {
@@ -585,6 +648,54 @@ async function runRoutedFixture(topology: ReturnType<typeof browserPreviewTopolo
     return await exploreAdaptiveBrowserStateMachine({ page, baseUrl: effectiveOrigin, contract, observations: { consoleMessages, errors, network }, navigationScope: topology.navigationScope })
   } finally {
     await browser.close()
+  }
+}
+
+async function runNetworkOracleFixture(mode: "allow" | "block" | "record", behavior: "blocked" | "unexpected" | "mixed" | "exception", input: Record<string, unknown> = {}) {
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://preview.invalid").pathname
+    if (path === "/failed.png") {
+      request.socket.destroy()
+      return
+    }
+    response.setHeader("content-type", "text/html")
+    response.end(`<!doctype html><style>button{display:block;width:180px;height:30px}</style><button id="trigger">Trigger</button><script>
+      document.querySelector('#trigger').addEventListener('click', () => {
+        const load = (src) => { const image = document.createElement('img'); image.src = src; document.body.append(image); };
+        ${behavior === "blocked" || behavior === "mixed" ? "load('http://assets.example.invalid/tile.png');" : ""}
+        ${behavior === "unexpected" || behavior === "mixed" ? "load('/failed.png');" : ""}
+        ${behavior === "exception" ? "setTimeout(() => { throw new Error('fixture page exception'); }, 0);" : ""}
+      });
+    </script>`)
+  })
+  const startUrl = await listenLocalHttpServer(server)
+  const topology = browserPreviewTopology([`network-policy=${mode}`], undefined, startUrl)
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext()
+  await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, startUrl)
+  const page = await context.newPage()
+  const consoleMessages: Record<string, unknown>[] = []
+  const errors: Record<string, unknown>[] = []
+  const network: Record<string, unknown>[] = []
+  attachBrowserCaptureListeners({ captureConsole: true, captureErrors: true, captureNetwork: true, captureWebSocket: false, consoleMessages, errors, network, page })
+  await page.addInitScript("globalThis.__name = value => value")
+  await page.goto(startUrl, { waitUntil: "load" })
+  const contract = browserAdaptiveExplorationContract({
+    seed: `network-oracle-${mode}-${behavior}`,
+    startUrl,
+    failOnFinding: false,
+    resetPolicy: { mode: "none" },
+    actionFamilies: ["click"],
+    budgets: { maxActions: 1, maxStates: 2, maxTransitions: 1, maxDurationMs: 10_000 },
+    stabilization: { pollIntervalMs: 25, quietWindowMs: 100, maxWaitMs: 1_500, maxMutationRecords: 20 },
+    ...input,
+  })
+  try {
+    const result = await exploreAdaptiveBrowserStateMachine({ page, baseUrl: startUrl, contract, observations: { consoleMessages, errors, network }, navigationScope: topology.navigationScope, networkPolicy: topology.networkPolicy })
+    return { result, contract }
+  } finally {
+    await browser.close()
+    await closeHttpServer(server)
   }
 }
 


### PR DESCRIPTION
## Summary
- correlate adaptive console and request-failure observations with declared browser network-policy decisions
- retain expected policy blocks as structured transition/network evidence without promoting them to product oracle findings by default
- preserve unexpected request failures and page exceptions as findings, with an explicit `oraclePolicy.policyBlocks: \"finding\"` compatibility opt-in

## Root Cause
Adaptive exploration fingerprinted every new console error independently of browser request evidence. Chromium reports intentional `route.abort(\"blockedbyclient\")` decisions as `net::ERR_BLOCKED_BY_CLIENT`, so declared sandbox isolation was indistinguishable from a product failure and stopped exploration.

## Evidence Classification
- policy-blocked requests retain URL, host, same-origin/external classification, policy decision, policy reason, browser failure text, and oracle-promotion status
- expected `ERR_BLOCKED_BY_CLIENT` request/console pairs are evidence-only by default and do not consume the product error budget
- allow/record failures, unexpected same-origin failures, undeclared failures, mixed real errors, and page exceptions remain oracle findings
- minimization and replay apply the same policy-aware correlation, while opt-in policy-block findings retain deterministic console fingerprints

## Compatibility
The normalized contract defaults `oraclePolicy.policyBlocks` to `evidence`. Callers that relied on intentional policy blocks becoming findings can set `oraclePolicy.policyBlocks` to `finding`. Existing console, page-error, replay, minimization, budget, and artifact behavior remains unchanged for non-policy failures.

## Tests
- `npx tsx --test tests/browser-adaptive-exploration.test.ts` (21 passed)
- `npm run test:browser-accessibility-oracles` (47 passed)
- `npm run build` (passed)
- `git diff --check` (passed)
- `npm run check` (blocked by pre-existing Automattic/wp-codebox#1745: `wordpress.collect-workload-result outputShape should mention outputSchema id`; reproduced independently after the build and production-boundary phases passed)

Fixes #2093