### PR TITLE
Fix canonical routed preview origins

### DIFF
--- a/.github/workflows/agent-task-contracts.yml
+++ b/.github/workflows/agent-task-contracts.yml
@@ -100,6 +100,13 @@ jobs:
           php-version: '8.2'
           tools: composer:v2
       - run: npm ci
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
       - run: npm run build
       - run: npm run test:agent-task-contracts
       - run: npm run test:browser-canonical-preview-origin

--- a/.github/workflows/agent-task-contracts.yml
+++ b/.github/workflows/agent-task-contracts.yml
@@ -23,6 +23,14 @@ on:
       - "tests/redaction.test.ts"
       - "tests/production-boundary-enforcement.test.ts"
       - "tests/runtime-tool-policy.test.ts"
+      - "tests/browser-canonical-preview-origin.test.ts"
+      - "packages/runtime-playground/src/browser-actions-runner.ts"
+      - "packages/runtime-playground/src/browser-artifacts.ts"
+      - "packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts"
+      - "packages/runtime-playground/src/browser-preview-routing.ts"
+      - "packages/runtime-playground/src/browser-probe-runner.ts"
+      - "packages/runtime-playground/src/editor-command-runners.ts"
+      - "packages/runtime-playground/src/preview-server.ts"
       - "packages/runtime-playground/src/phpunit-command-handlers.ts"
       - "packages/runtime-playground/src/playground-cli-runner.ts"
       - "packages/runtime-playground/src/playground-wordpress-archive-cache.ts"
@@ -56,6 +64,14 @@ on:
       - "tests/redaction.test.ts"
       - "tests/production-boundary-enforcement.test.ts"
       - "tests/runtime-tool-policy.test.ts"
+      - "tests/browser-canonical-preview-origin.test.ts"
+      - "packages/runtime-playground/src/browser-actions-runner.ts"
+      - "packages/runtime-playground/src/browser-artifacts.ts"
+      - "packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts"
+      - "packages/runtime-playground/src/browser-preview-routing.ts"
+      - "packages/runtime-playground/src/browser-probe-runner.ts"
+      - "packages/runtime-playground/src/editor-command-runners.ts"
+      - "packages/runtime-playground/src/preview-server.ts"
       - "packages/runtime-playground/src/phpunit-command-handlers.ts"
       - "packages/runtime-playground/src/playground-cli-runner.ts"
       - "packages/runtime-playground/src/playground-wordpress-archive-cache.ts"
@@ -86,6 +102,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test:agent-task-contracts
+      - run: npm run test:browser-canonical-preview-origin
       - run: npm run test:bounded-runtime-plan
       - run: npm run test:bounded-recipe-plan
       - run: npm run test:bounded-recipe-plan-integration

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "test:artifact-reference-dtos": "tsx tests/artifact-reference-dtos.test.ts",
     "test:artifact-path-primitives": "tsx tests/artifact-path-primitives.test.ts",
     "test:browser-callback-materialization-contracts": "tsx tests/browser-callback-materialization-contracts.test.ts",
+    "test:browser-canonical-preview-origin": "tsx tests/browser-canonical-preview-origin.test.ts",
     "test:materialize-replay-package-command": "tsx tests/materialize-replay-package-command.test.ts",
     "test:source-package-compiler-primitives": "tsx tests/source-package-compiler-primitives.test.ts",
     "test:source-root-preparation": "tsx tests/source-root-preparation.test.ts",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "test:native-agent-task-interruption": "node tests/execute-native-agent-task-interruption.test.mjs",
     "test:native-agent-task-playground-e2e": "tsx tests/execute-native-agent-task-playground-e2e.test.ts",
     "test:bench-command-step-behavior": "tsx tests/bench-command-step-behavior.test.ts",
-    "test:generic-primitives": "npm run test:artifact-path-primitives && npm run test:browser-callback-materialization-contracts && npm run test:source-package-compiler-primitives && npm run test:bench-command-step-behavior && npm run test:generic-ability-runtime-run",
+    "test:generic-primitives": "npm run test:artifact-path-primitives && npm run test:browser-callback-materialization-contracts && npm run test:browser-canonical-preview-origin && npm run test:source-package-compiler-primitives && npm run test:bench-command-step-behavior && npm run test:generic-ability-runtime-run",
     "test:browser-artifact-session": "tsx tests/browser-artifact-session.test.ts",
     "test:browser-environment-matrix": "tsx --test tests/browser-environment-matrix.test.ts tests/browser-environment-matrix.browser.test.ts",
     "test:browser-diagnostic-providers": "tsx tests/browser-diagnostic-providers.test.ts",

--- a/packages/runtime-core/src/artifact-review.ts
+++ b/packages/runtime-core/src/artifact-review.ts
@@ -92,6 +92,9 @@ export interface ArtifactReviewBrowserSummary {
     localPreviewOrigin?: string
     requestedPreviewOrigin?: string
     effectivePreviewOrigin?: string
+    canonicalBrowserOrigin?: string
+    localProxyOrigin?: string
+    upstreamRuntimeOrigin?: string
     finalUrl?: string
     windowLocationOrigin?: string
     viewport?: {

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -12,7 +12,7 @@ import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionS
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness } from "./browser-liveness.js"
 import { serializeBrowserError } from "./browser-metrics.js"
 import { executeBrowserObservationAssertion } from "./browser-observation-assertions.js"
-import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewTopology, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
+import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewTopology, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { runBrowserProbeCommand, type BrowserProbeRunPlan } from "./browser-probe-runner.js"
 import { browserActionTargetUrls, browserAuthRequest, browserProbeWaterfallArtifact, browserProbeWebSocketArtifact, browserProbeWebSocketSummary, browserRedirectDiagnosticsArtifact, browserRequestCoverageArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, browserWordPressDiagnosticsArtifact, createBrowserProbeProgressTracker, fileSha256, installBrowserWordPressDiagnostics, installWordPressAdminAuthCookies, livenessRemainingWallTimeMs, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserStorageStateImport } from "./browser-probe-support.js"
@@ -144,6 +144,10 @@ export async function runBrowserActionsCommand({
   let adaptiveExplorationSummary: BrowserArtifact["summary"]["adaptiveExploration"] | undefined
 
   try {
+    const previewReadinessError = browserPreviewReadinessError(preview)
+    if (previewReadinessError) {
+      throw previewReadinessError
+    }
     const context = browserPreviewNeedsContextRouting(networkPolicy) || !!storageStateImport ? await browser.newContext({
       ...topology.contextOptions(),
       ...(storageStateImport ? { storageState: storageStateImport.storageState } : {}),
@@ -410,6 +414,9 @@ export async function runBrowserActionsCommand({
         }
       }
     }
+  } catch (error) {
+    pendingError = error instanceof Error ? error : new Error(String(error))
+    errors.push(serializeBrowserError("probe-error", error))
   } finally {
     await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
     await browser.close()

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -125,7 +125,7 @@ export async function runBrowserActionsCommand({
   const startedAtMs = Date.now()
   const progress = createBrowserProbeProgressTracker(startedAt, 0)
   const browser = await launchChromiumBrowser()
-  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
   const { preview, networkPolicy } = topology
   let requestedUrl = initialUrl ? topology.resolveUrl(initialUrl) : preview.effectiveOrigin
   let finalUrl = requestedUrl
@@ -145,10 +145,11 @@ export async function runBrowserActionsCommand({
 
   try {
     const context = browserPreviewNeedsContextRouting(networkPolicy) || !!storageStateImport ? await browser.newContext({
+      ...topology.contextOptions(),
       ...(storageStateImport ? { storageState: storageStateImport.storageState } : {}),
     }) : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     if (onProgress) {

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -17,6 +17,9 @@ export interface BrowserArtifactBase {
   localPreviewOrigin?: string
   requestedPreviewOrigin?: string
   effectivePreviewOrigin?: string
+  canonicalBrowserOrigin?: string
+  localProxyOrigin?: string
+  upstreamRuntimeOrigin?: string
   prePageScript?: BrowserProbeScriptMetadata
   files: BrowserArtifactFiles
   summary: BrowserArtifactSummary
@@ -1043,6 +1046,9 @@ export function browserReviewSummary(probes: BrowserArtifact[]): ArtifactReviewB
       localPreviewOrigin: probe.localPreviewOrigin,
       requestedPreviewOrigin: probe.requestedPreviewOrigin,
       effectivePreviewOrigin: probe.effectivePreviewOrigin,
+      canonicalBrowserOrigin: probe.canonicalBrowserOrigin,
+      localProxyOrigin: probe.localProxyOrigin,
+      upstreamRuntimeOrigin: probe.upstreamRuntimeOrigin,
       finalUrl: probe.summary.finalUrl,
       windowLocationOrigin: probe.summary.windowLocationOrigin,
       viewport: probe.summary.viewport,

--- a/packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts
+++ b/packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts
@@ -28,7 +28,8 @@ export async function runBrowserMultiActorScenarioCommand(input: {
   // Traces are always retained for replay, even when callers narrow display captures.
   const captures = new Set([...(scenario.captures ?? ["steps", "console", "errors", "network", "screenshot"]), "trace"])
   const artifacts = new BrowserArtifactSession(artifactRoot, "files/browser", { source: "wordpress.browser-scenario", operation: "browser-multi-actor-scenario" })
-  const topology = browserPreviewTopology([], runtimeSpec, server.serverUrl)
+  const routeHost = runtimeSpec.preview?.siteUrl ? new URL(runtimeSpec.preview.siteUrl).hostname : ""
+  const topology = browserPreviewTopology(routeHost ? [`route-host=${routeHost}`] : [], runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
   const browser = await launchChromiumBrowser()
   const evidence: Record<string, ActorEvidence> = {}
   let result: BrowserMultiActorScenarioResult | undefined
@@ -43,8 +44,8 @@ export async function runBrowserMultiActorScenarioCommand(input: {
       const session = wordpressUserSessionFromCommandArgs([`session=${actor.userSession}`], runtimeSpec)
       if (!session) throw new Error(`Actor ${actor.name} requires user session ${actor.userSession}`)
       const userId = await actorUserId(actor.name, session.user.userId, session.user, runtimeSpec, runPlaygroundCommand, server)
-      const context = await browser.newContext()
-      await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, topology.preview.effectiveOrigin)
+      const context = await browser.newContext(topology.contextOptions())
+      await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, topology.origins.localProxyOrigin)
       const page = await context.newPage()
       await context.tracing.start({ screenshots: true, snapshots: true })
       await installWordPressAdminAuthCookies({ command: "wordpress.browser-scenario", cookieUrls: topology.authCookieUrls([topology.resolveUrl(scenario.url)]), page, runPlaygroundCommand, runtimeSpec, server, userId })

--- a/packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts
+++ b/packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts
@@ -6,7 +6,7 @@ import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js
 import { attachBrowserCaptureListeners, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeReplayability } from "./browser-probe.js"
-import { browserPreviewTopology, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
+import { browserPreviewReadinessError, browserPreviewTopology, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { installWordPressAdminAuthCookies } from "./browser-probe-support.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
@@ -36,6 +36,10 @@ export async function runBrowserMultiActorScenarioCommand(input: {
   let failure: Error | undefined
 
   try {
+    const previewReadinessError = browserPreviewReadinessError(topology.preview)
+    if (previewReadinessError) {
+      throw previewReadinessError
+    }
     const clientEntries: Array<[string, BrowserMultiActorClient]> = []
     const actorPages: Array<{ actor: string; page: Pick<Page, "goto"> }> = []
     // Playground PHP commands share one runtime endpoint, so provision identities

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -17,6 +17,7 @@ export interface BrowserPreviewNetworkPolicy {
   recordExternal: boolean
   stats: Map<string, { requests: number; external: boolean; blocked: number; routed: number }>
   routedRedirectEscapes: Array<{ rawOrigin: string; effectiveOrigin: string; reason: string }>
+  preserveRoutedOrigin: boolean
 }
 
 export interface BrowserPreviewNavigationDecision {
@@ -44,10 +45,20 @@ export interface BrowserPreviewTopology {
   preview: BrowserProbePreviewRouting
   networkPolicy: BrowserPreviewNetworkPolicy
   routedHosts: string[]
-  origins: { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string }
+  origins: BrowserPreviewOrigins
   navigationScope: BrowserPreviewNavigationScope
   resolveUrl(pathOrUrl: string): string
   authCookieUrls(targetUrls: string[]): string[]
+  contextOptions(): { proxy?: { server: string } }
+}
+
+export interface BrowserPreviewOrigins {
+  localPreviewOrigin: string
+  requestedPreviewOrigin?: string
+  effectivePreviewOrigin: string
+  canonicalBrowserOrigin: string
+  localProxyOrigin: string
+  upstreamRuntimeOrigin?: string
 }
 
 export interface BrowserPreviewRouteTracker {
@@ -97,22 +108,26 @@ export function browserPreviewRouting(args: string[], runtimeSpec: RuntimeCreate
   }
 }
 
-export function browserPreviewTopology(args: string[], runtimeSpec: RuntimeCreateSpec | undefined, localPreviewOrigin: string): BrowserPreviewTopology {
-  const preview = browserPreviewRouting(args, runtimeSpec, localPreviewOrigin)
+export function browserPreviewTopology(args: string[], runtimeSpec: RuntimeCreateSpec | undefined, localPreviewOrigin: string, upstreamRuntimeOrigin?: string): BrowserPreviewTopology {
   const routedHosts = commaListArg(args, "route-host")
+  const preview = browserPreviewRouting(args, runtimeSpec, localPreviewOrigin)
+  applyCanonicalRoutedPreviewOrigin(preview, runtimeSpec?.preview?.siteUrl, routedHosts)
   const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
 
   return {
     preview,
     networkPolicy,
     routedHosts,
-    origins: browserPreviewOrigins(preview),
+    origins: browserPreviewOrigins(preview, upstreamRuntimeOrigin),
     navigationScope: browserPreviewNavigationScope(preview.effectiveOrigin, networkPolicy),
     resolveUrl(pathOrUrl) {
       return resolveBrowserPreviewUrl(pathOrUrl, preview.effectiveOrigin)
     },
     authCookieUrls(targetUrls) {
       return browserPreviewAuthCookieUrls(localPreviewOrigin, routedHosts, targetUrls)
+    },
+    contextOptions() {
+      return networkPolicy.preserveRoutedOrigin ? { proxy: { server: new URL(localPreviewOrigin).origin } } : {}
     },
   }
 }
@@ -146,12 +161,50 @@ export function browserPreviewNavigationScope(effectivePreviewOrigin: string, po
   }
 }
 
-export function browserPreviewOrigins(preview: BrowserProbePreviewRouting): { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string } {
+export function browserPreviewOrigins(preview: BrowserProbePreviewRouting, upstreamRuntimeOrigin?: string): BrowserPreviewOrigins {
   return {
     localPreviewOrigin: preview.localOrigin,
-    requestedPreviewOrigin: preview.publicOrigin,
+    ...(preview.publicOrigin ? { requestedPreviewOrigin: preview.publicOrigin } : {}),
     effectivePreviewOrigin: preview.effectiveOrigin,
+    canonicalBrowserOrigin: new URL(preview.effectiveOrigin).origin,
+    localProxyOrigin: new URL(preview.localOrigin).origin,
+    ...(upstreamRuntimeOrigin ? { upstreamRuntimeOrigin: new URL(upstreamRuntimeOrigin).origin } : {}),
   }
+}
+
+function applyCanonicalRoutedPreviewOrigin(preview: BrowserProbePreviewRouting, siteUrl: string | undefined, routedHosts: string[]): void {
+  if (preview.effectiveMode !== "local" || !siteUrl) {
+    return
+  }
+
+  let canonical: URL
+  try {
+    canonical = new URL(siteUrl)
+  } catch {
+    return
+  }
+  const host = normalizeBrowserPreviewHost(canonical.hostname)
+  if (!routedHosts.map(normalizeBrowserPreviewHost).includes(host)) {
+    return
+  }
+
+  if (canonical.protocol !== "http:") {
+    preview.diagnostics.push({
+      code: "preview-canonical-origin-preservation-inconclusive",
+      severity: "error",
+      message: "The local Playground provider cannot preserve this declared canonical preview protocol.",
+      details: { status: "inconclusive", canonicalOrigin: canonical.origin, supportedProtocols: ["http:"] },
+    })
+    return
+  }
+
+  preview.effectiveOrigin = canonical.toString()
+  preview.diagnostics.push({
+    code: "preview-canonical-routed-origin",
+    severity: "info",
+    message: "The declared routed preview alias is the browser-visible origin.",
+    details: { canonicalOrigin: canonical.origin, localProxyOrigin: new URL(preview.localOrigin).origin },
+  })
 }
 
 export function browserPreviewReadinessError(preview: BrowserProbePreviewRouting): Error | undefined {
@@ -218,6 +271,7 @@ export function browserPreviewNetworkPolicy(args: string[], routeHosts: string[]
     recordExternal: strictBooleanArg(args, "record-external", false),
     stats: new Map(),
     routedRedirectEscapes: [],
+    preserveRoutedOrigin: new URL(preview.effectiveOrigin).origin !== new URL(preview.localOrigin).origin && preview.effectiveMode === "local",
   }
 }
 
@@ -321,28 +375,38 @@ async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (
     stat.requests += 1
     stat.external = !policy.firstPartyHosts.has(host)
 
-    if (policy.blockHosts.has(host) || (policy.mode === "block" && stat.external && !policy.allowHosts.has(host))) {
+    if (policy.blockHosts.has(host)) {
       stat.blocked += 1
       await route.abort("blockedbyclient")
       return
     }
 
-    if (!policy.routeHosts.has(host)) {
-      await route.continue()
+    if (policy.routeHosts.has(host)) {
+      stat.routed += 1
+      if (policy.preserveRoutedOrigin) {
+        await route.continue()
+        return
+      }
+      const task = fulfillBrowserPreviewRoutedHost(route, requestUrl, policy, origin)
+      tracker?.pending.add(task)
+      try {
+        await task
+      } catch (error) {
+        tracker?.errors.push(sanitizeBrowserPreviewRouteError(error))
+        await route.abort("failed").catch(() => undefined)
+      } finally {
+        tracker?.pending.delete(task)
+      }
       return
     }
 
-    stat.routed += 1
-    const task = fulfillBrowserPreviewRoutedHost(route, requestUrl, policy, origin)
-    tracker?.pending.add(task)
-    try {
-      await task
-    } catch (error) {
-      tracker?.errors.push(sanitizeBrowserPreviewRouteError(error))
-      await route.abort("failed").catch(() => undefined)
-    } finally {
-      tracker?.pending.delete(task)
+    if (policy.preserveRoutedOrigin || (policy.mode === "block" && stat.external && !policy.allowHosts.has(host)) || (request.resourceType() === "document" && stat.external)) {
+      stat.blocked += 1
+      await route.abort("blockedbyclient")
+      return
     }
+
+    await route.continue()
   })
 }
 

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -242,7 +242,7 @@ export async function runSingleBrowserProbeCommand({
   const activeDiagnosticProviders = runPlan.diagnosticProviders ?? diagnosticProviders ?? []
   const captureSelection = browserProbeCaptureSelection(capture, assertions)
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
-  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
   const { preview, networkPolicy } = topology
   const routeTracker = createBrowserPreviewRouteTracker()
   const targetUrl = topology.resolveUrl(runPlan.url)
@@ -304,6 +304,7 @@ export async function runSingleBrowserProbeCommand({
     const contextPermissions = browserProbeContextPermissions(requestedContext)
     context = browserPreviewNeedsContextRouting(networkPolicy) || !!storageStateImport || requestedContext.device || requestedContext.geolocation || requestedContext.locale || requestedContext.timezone || requestedContext.userAgent || contextPermissions.length > 0
       ? await browser.newContext({
+        ...topology.contextOptions(),
         ...(deviceProfile ?? {}),
         ...(storageStateImport ? { storageState: storageStateImport.storageState } : {}),
         ...(requestedContext.locale ? { locale: requestedContext.locale } : {}),
@@ -316,7 +317,7 @@ export async function runSingleBrowserProbeCommand({
       await context.grantPermissions(contextPermissions)
     }
     if (context && browserPreviewNeedsContextRouting(networkPolicy)) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin, routeTracker)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin, routeTracker)
     }
     page = context ? await context.newPage() : await browser.newPage()
     if (requestedContext.geolocation?.permission === "denied") geolocationPermissionCleanup = await applyPlaywrightGeolocationPermission(page, "denied")
@@ -343,7 +344,7 @@ export async function runSingleBrowserProbeCommand({
       await applyBrowserProbeThrottleProfile(page, throttleProfile)
     }
     if (!context && browserPreviewNeedsContextRouting(networkPolicy)) {
-      await routeBrowserPreviewPageNetwork(page, networkPolicy, preview.effectiveOrigin, routeTracker)
+      await routeBrowserPreviewPageNetwork(page, networkPolicy, topology.origins.localProxyOrigin, routeTracker)
     }
     await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
     if (lifecycleSelectors.length > 0) {

--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -550,6 +550,10 @@ export async function runEditorOpenCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
+    const previewReadinessError = browserPreviewReadinessError(preview)
+    if (previewReadinessError) {
+      throw previewReadinessError
+    }
     const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
     if (context) {
       await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
@@ -626,6 +630,9 @@ export async function runEditorOpenCommand({
       })
       screenshotSha256 = await fileSha256(screenshotPath)
     }
+  } catch (error) {
+    pendingError = error instanceof Error ? error : new Error(String(error))
+    errors.push(serializeBrowserError("probe-error", error))
   } finally {
     await browser.close()
     if (capture.has("steps")) {
@@ -833,6 +840,10 @@ export async function runEditorActionsCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
+    const previewReadinessError = browserPreviewReadinessError(preview)
+    if (previewReadinessError) {
+      throw previewReadinessError
+    }
     const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
     if (context) {
       await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
@@ -938,6 +949,9 @@ export async function runEditorActionsCommand({
       await artifactSession.writeGenerated("screenshot", "editor-action-screenshot.png", (path) => page.screenshot({ path, fullPage: true }).then(() => undefined))
       screenshotSha256 = await fileSha256(screenshotPath)
     }
+  } catch (error) {
+    pendingError = error instanceof Error ? error : new Error(String(error))
+    errors.push(serializeBrowserError("probe-error", error))
   } finally {
     await browser.close()
     if (capture.has("steps")) {
@@ -1931,6 +1945,10 @@ export async function runEditorValidateBlocksCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
+    const previewReadinessError = browserPreviewReadinessError(preview)
+    if (previewReadinessError) {
+      throw previewReadinessError
+    }
     const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
     if (context) {
       await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)

--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -6,7 +6,7 @@ import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js
 import type { BrowserArtifact, BrowserArtifactFiles, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserEditorReadinessSummary, BrowserEditorSaveSummary, BrowserEditorValidateBlocksSummary, BrowserEditorValiditySummary, BrowserProbeAuthSummary, BrowserProbeErrorRecord, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, launchChromiumBrowser } from "./browser-capture-session.js"
 import { browserStepRecord } from "./browser-interactions.js"
-import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, browserPreviewTopology, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
+import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { argValue, commaListArg, durationArg, jsonArrayArg } from "./commands.js"
 import { DEFAULT_EDITOR_WAIT_SELECTOR, editorActionStepsFromArgs, editorOpenTargetFromArgs, editorValidateContentFromArgs, editorValidateProviderFromArgs, resolveEditorOpenTarget, type EditorActionStep, type EditorBlockSpec, type EditorBlockTarget } from "./editor-actions.js"
@@ -57,9 +57,10 @@ export async function runEditorCanvasProbeCommand({
   const blockSelector = argValue(args, "block-selector")?.trim() || EDITOR_CANVAS_DEFAULT_BLOCK_SELECTOR
   const timeoutMs = editorCanvasTimeoutMs(args)
   const selectorGroups = editorCanvasSelectorGroups(args, layoutSelector, blockSelector)
-  const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
-  const previewOrigins = browserPreviewOrigins(preview)
-  const targetUrl = resolveBrowserPreviewUrl(urlArg, preview.effectiveOrigin)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
+  const { preview, networkPolicy } = topology
+  const previewOrigins = topology.origins
+  const targetUrl = topology.resolveUrl(urlArg)
   const artifactSession = new BrowserArtifactSession(artifactRoot, "files/browser", { source: "wordpress.editor-canvas-probe", operation: "editor-canvas-probe" })
   const screenshotPath = artifactSession.absolutePath("editor-canvas-screenshot.png")
   const startedAt = now()
@@ -79,7 +80,11 @@ export async function runEditorCanvasProbeCommand({
       throw previewReadinessError
     }
 
-    const page = await browser.newPage()
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
+    if (context) {
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
+    }
+    const page = context ? await context.newPage() : await browser.newPage()
     viewport = await browserProbeViewport(page)
     attachBrowserCaptureListeners({
       captureConsole: false,
@@ -520,7 +525,7 @@ export async function runEditorOpenCommand({
   }
 
   const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
-  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
   const { preview, networkPolicy } = topology
   const targetUrl = topology.resolveUrl(target.url)
   const artifactPathPrefix = editorOpenArtifactPathPrefixFromArgs(args)
@@ -545,9 +550,9 @@ export async function runEditorOpenCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
-    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-open", cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
@@ -803,7 +808,7 @@ export async function runEditorActionsCommand({
   const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
   const stepTimeoutMs = durationArg(args, "step-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
   const totalTimeoutMs = durationArg(args, "timeout", BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS)
-  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
   const { preview, networkPolicy } = topology
   const targetUrl = topology.resolveUrl(target.url)
   const artifactSession = new BrowserArtifactSession(artifactRoot, "files/browser", { source: "wordpress.editor-actions", operation: "editor-actions" })
@@ -828,9 +833,9 @@ export async function runEditorActionsCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
-    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-actions", cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
@@ -1910,7 +1915,7 @@ export async function runEditorValidateBlocksCommand({
   const content = await editorValidateContentFromArgs(args)
   const provider = editorValidateProviderFromArgs(args)
   const waitTimeoutMs = durationArg(args, "wait-timeout", EDITOR_VALIDATE_BLOCKS_READY_TIMEOUT_MS)
-  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl, server.previewProxyDiagnostics?.targetOrigin)
   const { preview, networkPolicy } = topology
   const targetUrl = topology.resolveUrl(target.url)
   const artifactSession = new BrowserArtifactSession(artifactRoot, "files/browser", { source: "wordpress.editor-validate-blocks", operation: "editor-validate-blocks" })
@@ -1926,9 +1931,9 @@ export async function runEditorValidateBlocksCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
-    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext(topology.contextOptions()) : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-validate-blocks", cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -182,12 +182,12 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
         hostname: target.hostname,
         port: target.port,
         method: incoming.method,
-        path: incoming.url ?? "/",
+        path: previewProxyRequestPath(incoming.url),
         headers: proxyRequestHeaders(incoming.headers),
       },
       (response) => {
         targetResponse = response
-        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, proxyResponseHeaders(response.headers))
+        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, proxyResponseHeaders(response.headers, incoming, target))
         response.on("error", (error) => {
           outgoing.destroy(error)
           settle()
@@ -209,6 +209,18 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
     outgoing.on("close", abortUpstream)
     incoming.pipe(targetRequest)
   })
+}
+
+function previewProxyRequestPath(rawUrl: string | undefined): string {
+  if (!rawUrl) {
+    return "/"
+  }
+  try {
+    const url = new URL(rawUrl)
+    return `${url.pathname}${url.search}`
+  } catch {
+    return rawUrl
+  }
 }
 
 function createPreviewProxyQueue(): (task: () => Promise<void>) => Promise<void> {
@@ -277,12 +289,32 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders 
   }
 }
 
-function proxyResponseHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+function proxyResponseHeaders(headers: IncomingHttpHeaders, incoming: IncomingMessage, target: URL): IncomingHttpHeaders {
   const forwarded = { ...headers }
   delete forwarded.connection
   delete forwarded["transfer-encoding"]
 
+  if (typeof forwarded.location === "string") {
+    try {
+      const location = new URL(forwarded.location, target)
+      if (location.origin === target.origin && incoming.headers.host) {
+        const protocol = firstHeaderValue(incoming.headers["x-forwarded-proto"]) ?? "http"
+        location.protocol = `${protocol.replace(/:$/, "")}:`
+        const visible = new URL(`${location.protocol}//${incoming.headers.host}`)
+        location.hostname = visible.hostname
+        location.port = visible.port
+        forwarded.location = location.toString()
+      }
+    } catch {
+      // Preserve malformed upstream locations for the browser to diagnose.
+    }
+  }
+
   return forwarded
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
 }
 
 function writeProxyError(outgoing: ServerResponse, error: Error): void {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -161,6 +161,7 @@ function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
 
 function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
   return new Promise((resolve) => {
+    const requestTarget = previewProxyRequestTarget(incoming)
     let settled = false
     let targetResponse: IncomingMessage | undefined
     const settle = () => {
@@ -182,12 +183,12 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
         hostname: target.hostname,
         port: target.port,
         method: incoming.method,
-        path: previewProxyRequestPath(incoming.url),
-        headers: proxyRequestHeaders(incoming.headers),
+        path: requestTarget.path,
+        headers: proxyRequestHeaders(incoming.headers, requestTarget),
       },
       (response) => {
         targetResponse = response
-        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, proxyResponseHeaders(response.headers, incoming, target))
+        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, proxyResponseHeaders(response.headers, requestTarget, target))
         response.on("error", (error) => {
           outgoing.destroy(error)
           settle()
@@ -211,16 +212,31 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
   })
 }
 
-function previewProxyRequestPath(rawUrl: string | undefined): string {
-  if (!rawUrl) {
-    return "/"
-  }
+interface PreviewProxyRequestTarget {
+  host: string
+  path: string
+  port: string
+  protocol: "http:" | "https:"
+}
+
+function previewProxyRequestTarget(incoming: IncomingMessage): PreviewProxyRequestTarget {
+  const rawUrl = incoming.url ?? "/"
   try {
     const url = new URL(rawUrl)
-    return `${url.pathname}${url.search}`
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return {
+        host: url.host,
+        path: `${url.pathname}${url.search}`,
+        port: url.port || (url.protocol === "https:" ? "443" : "80"),
+        protocol: url.protocol,
+      }
+    }
   } catch {
-    return rawUrl
+    // Origin-form requests use the proxy listener's HTTP authority.
   }
+  const host = incoming.headers.host ?? "localhost"
+  const authority = new URL(`http://${host}`)
+  return { host: authority.host, path: rawUrl, port: authority.port || "80", protocol: "http:" }
 }
 
 function createPreviewProxyQueue(): (task: () => Promise<void>) => Promise<void> {
@@ -279,17 +295,26 @@ function formatPreviewHost(host: string): string {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
 }
 
-function proxyRequestHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget): IncomingHttpHeaders {
   const forwarded = { ...headers }
   delete forwarded.connection
   delete forwarded["transfer-encoding"]
+  delete forwarded.forwarded
+  delete forwarded["x-forwarded-for"]
+  delete forwarded["x-forwarded-host"]
+  delete forwarded["x-forwarded-port"]
+  delete forwarded["x-forwarded-proto"]
 
   return {
     ...forwarded,
+    host: requestTarget.host,
+    "x-forwarded-host": requestTarget.host,
+    "x-forwarded-port": requestTarget.port,
+    "x-forwarded-proto": requestTarget.protocol.slice(0, -1),
   }
 }
 
-function proxyResponseHeaders(headers: IncomingHttpHeaders, incoming: IncomingMessage, target: URL): IncomingHttpHeaders {
+function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, target: URL): IncomingHttpHeaders {
   const forwarded = { ...headers }
   delete forwarded.connection
   delete forwarded["transfer-encoding"]
@@ -297,10 +322,9 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, incoming: IncomingMe
   if (typeof forwarded.location === "string") {
     try {
       const location = new URL(forwarded.location, target)
-      if (location.origin === target.origin && incoming.headers.host) {
-        const protocol = firstHeaderValue(incoming.headers["x-forwarded-proto"]) ?? "http"
-        location.protocol = `${protocol.replace(/:$/, "")}:`
-        const visible = new URL(`${location.protocol}//${incoming.headers.host}`)
+      if (location.origin === target.origin) {
+        location.protocol = requestTarget.protocol
+        const visible = new URL(`${requestTarget.protocol}//${requestTarget.host}`)
         location.hostname = visible.hostname
         location.port = visible.port
         forwarded.location = location.toString()
@@ -311,10 +335,6 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, incoming: IncomingMe
   }
 
   return forwarded
-}
-
-function firstHeaderValue(value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value
 }
 
 function writeProxyError(outgoing: ServerResponse, error: Error): void {

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -22,6 +22,7 @@ import {
   verifyBrowserCallbackSignature,
 } from "../packages/runtime-core/src/index.js"
 import { browserPreviewAuthCookieUrls, browserPreviewTopology } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { browserReviewSummary, type BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
@@ -104,6 +105,8 @@ assert.deepEqual(topology.origins, {
   localPreviewOrigin: "http://127.0.0.1:9400",
   requestedPreviewOrigin: "https://example.test/site",
   effectivePreviewOrigin: "https://example.test/site",
+  canonicalBrowserOrigin: "https://example.test",
+  localProxyOrigin: "http://127.0.0.1:9400",
 })
 assert.deepEqual(topology.authCookieUrls(["https://example.test/wp-admin/"]), [
   "http://127.0.0.1/",
@@ -135,6 +138,53 @@ assert.deepEqual(topology.navigationScope.resolve("https://cdn.example.test/asse
 })
 assert.equal(topology.navigationScope.resolve("https://outside.example/", "https://example.test/").reason, "host-not-routed-to-preview")
 assert.deepEqual(browserPreviewAuthCookieUrls("http://localhost:9400", ["PUBLIC.example.test"], ["https://public.example.test/wp-admin/"]), ["http://localhost/", "https://public.example.test/"])
+
+const canonicalTopology = browserPreviewTopology(
+  ["route-host=localhost"],
+  { preview: { siteUrl: "http://localhost/events/" } },
+  "http://127.0.0.1:9400",
+  "http://127.0.0.1:9500",
+)
+assert.equal(canonicalTopology.preview.effectiveOrigin, "http://localhost/events/")
+assert.equal(canonicalTopology.resolveUrl("/events/near-me/"), "http://localhost/events/near-me/")
+assert.deepEqual(canonicalTopology.origins, {
+  localPreviewOrigin: "http://127.0.0.1:9400",
+  effectivePreviewOrigin: "http://localhost/events/",
+  canonicalBrowserOrigin: "http://localhost",
+  localProxyOrigin: "http://127.0.0.1:9400",
+  upstreamRuntimeOrigin: "http://127.0.0.1:9500",
+})
+assert.equal(canonicalTopology.preview.diagnostics[0]?.code, "preview-canonical-routed-origin")
+const canonicalReview = browserReviewSummary([{
+  artifactType: "probe",
+  requestedUrl: "http://localhost/events/",
+  url: "http://localhost/events/",
+  preview: canonicalTopology.preview,
+  ...canonicalTopology.origins,
+  files: { summary: "files/browser/summary.json" },
+  summary: { consoleMessages: 0, errors: 0, htmlSnapshot: false, networkEvents: 0, replayability: "diagnostic-only", screenshot: false, viewport: null },
+} satisfies BrowserArtifact])
+assert.deepEqual(canonicalReview?.probes[0] && {
+  canonicalBrowserOrigin: canonicalReview.probes[0].canonicalBrowserOrigin,
+  localProxyOrigin: canonicalReview.probes[0].localProxyOrigin,
+  upstreamRuntimeOrigin: canonicalReview.probes[0].upstreamRuntimeOrigin,
+}, {
+  canonicalBrowserOrigin: "http://localhost",
+  localProxyOrigin: "http://127.0.0.1:9400",
+  upstreamRuntimeOrigin: "http://127.0.0.1:9500",
+})
+const unsupportedCanonicalTopology = browserPreviewTopology(
+  ["route-host=secure.example.test"],
+  { preview: { siteUrl: "https://secure.example.test/" } },
+  "http://127.0.0.1:9400",
+)
+assert.equal(unsupportedCanonicalTopology.preview.effectiveOrigin, "http://127.0.0.1:9400")
+assert.deepEqual(unsupportedCanonicalTopology.preview.diagnostics[0], {
+  code: "preview-canonical-origin-preservation-inconclusive",
+  severity: "error",
+  message: "The local Playground provider cannot preserve this declared canonical preview protocol.",
+  details: { status: "inconclusive", canonicalOrigin: "https://secure.example.test", supportedProtocols: ["http:"] },
+})
 
 let activeUpstreamRequests = 0
 let maxActiveUpstreamRequests = 0

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -21,7 +21,7 @@ import {
   trustedBrowserSessionOrigins,
   verifyBrowserCallbackSignature,
 } from "../packages/runtime-core/src/index.js"
-import { browserPreviewAuthCookieUrls, browserPreviewTopology } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { browserPreviewAuthCookieUrls, browserPreviewReadinessError, browserPreviewTopology } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import { browserReviewSummary, type BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
@@ -185,6 +185,7 @@ assert.deepEqual(unsupportedCanonicalTopology.preview.diagnostics[0], {
   message: "The local Playground provider cannot preserve this declared canonical preview protocol.",
   details: { status: "inconclusive", canonicalOrigin: "https://secure.example.test", supportedProtocols: ["http:"] },
 })
+assert.match(browserPreviewReadinessError(unsupportedCanonicalTopology.preview)?.message ?? "", /cannot preserve/)
 
 let activeUpstreamRequests = 0
 let maxActiveUpstreamRequests = 0

--- a/tests/browser-canonical-preview-origin.test.ts
+++ b/tests/browser-canonical-preview-origin.test.ts
@@ -1,15 +1,23 @@
 import assert from "node:assert/strict"
 import { createServer } from "node:http"
 import { launchChromiumBrowser } from "../packages/runtime-playground/src/browser-capture-session.js"
-import { browserPreviewTopology, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { browserPreviewNetworkPolicySummary, browserPreviewTopology, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
-const requests: Array<{ host?: string; method?: string; url?: string; body: string }> = []
+const requests: Array<{ host?: string; method?: string; url?: string; body: string; forwardedHost?: string; forwardedPort?: string; forwardedProto?: string }> = []
 const upstream = createServer((request, response) => {
   let body = ""
   request.on("data", (chunk) => { body += chunk.toString() })
   request.on("end", () => {
-    requests.push({ host: request.headers.host, method: request.method, url: request.url, body })
+    requests.push({
+      host: request.headers.host,
+      method: request.method,
+      url: request.url,
+      body,
+      forwardedHost: request.headers["x-forwarded-host"] as string | undefined,
+      forwardedPort: request.headers["x-forwarded-port"] as string | undefined,
+      forwardedProto: request.headers["x-forwarded-proto"] as string | undefined,
+    })
     if (request.url === "/events/redirect/") {
       response.writeHead(302, { location: "http://localhost/events/final/" })
       response.end()
@@ -21,7 +29,7 @@ const upstream = createServer((request, response) => {
       return
     }
     if (request.url === "/events/external-redirect/") {
-      response.writeHead(302, { location: "https://undeclared.example/escape/" })
+      response.writeHead(302, { location: "http://undeclared.example/escape/" })
       response.end()
       return
     }
@@ -52,12 +60,20 @@ const topology = browserPreviewTopology(
 const browser = await launchChromiumBrowser()
 
 try {
-  const context = await browser.newContext(topology.contextOptions())
+  const context = await browser.newContext({
+    ...topology.contextOptions(),
+    extraHTTPHeaders: {
+      "x-forwarded-host": "spoofed.example",
+      "x-forwarded-port": "443",
+      "x-forwarded-proto": "https",
+    },
+  })
   await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, topology.origins.localProxyOrigin)
   const page = await context.newPage()
 
   await page.goto(topology.resolveUrl("/events/"), { waitUntil: "load" })
   assert.equal(new URL(page.url()).origin, "http://localhost")
+  assert(requests.some((request) => request.url === "/events/" && request.host === "localhost" && request.forwardedHost === "localhost" && request.forwardedPort === "80" && request.forwardedProto === "http"))
   assert.deepEqual(await page.evaluate(() => {
     history.pushState({}, "", "http://localhost/events/pushed/")
     history.replaceState({}, "", "http://localhost/events/replaced/")
@@ -87,8 +103,11 @@ try {
   await Promise.all([page.waitForURL("http://localhost/events/subsite/"), page.click("#subsite")])
   assert.equal(page.url(), "http://localhost/events/subsite/")
 
-  await assert.rejects(page.goto("https://undeclared.example/escape/"))
+  await assert.rejects(page.goto("http://undeclared.example/escape/"))
   await assert.rejects(page.goto("http://localhost/events/external-redirect/"))
+  const policyEvidence = browserPreviewNetworkPolicySummary(topology.networkPolicy)
+  assert((policyEvidence.hosts["undeclared.example"]?.blocked ?? 0) >= 1, JSON.stringify(policyEvidence))
+  assert(policyEvidence.blockedRequests >= 1)
 
   assert.deepEqual(topology.origins, {
     localPreviewOrigin: proxy.serverUrl,

--- a/tests/browser-canonical-preview-origin.test.ts
+++ b/tests/browser-canonical-preview-origin.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import { launchChromiumBrowser } from "../packages/runtime-playground/src/browser-capture-session.js"
+import { browserPreviewTopology, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+
+const requests: Array<{ host?: string; method?: string; url?: string; body: string }> = []
+const upstream = createServer((request, response) => {
+  let body = ""
+  request.on("data", (chunk) => { body += chunk.toString() })
+  request.on("end", () => {
+    requests.push({ host: request.headers.host, method: request.method, url: request.url, body })
+    if (request.url === "/events/redirect/") {
+      response.writeHead(302, { location: "http://localhost/events/final/" })
+      response.end()
+      return
+    }
+    if (request.url === "/events/local-redirect/") {
+      response.writeHead(302, { location: `${upstreamUrl}/events/final/` })
+      response.end()
+      return
+    }
+    if (request.url === "/events/external-redirect/") {
+      response.writeHead(302, { location: "https://undeclared.example/escape/" })
+      response.end()
+      return
+    }
+
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "set-cookie": "canonical_cookie=present; Path=/events/; SameSite=Lax",
+    })
+    response.end(`<!doctype html>
+      <title>Canonical preview</title>
+      <form id="canonical-form" method="post" action="http://localhost/events/form/"><input name="value" value="canonical"><button>Submit</button></form>
+      <a id="subsite" href="http://localhost/events/subsite/">Subsite</a>
+      <script>localStorage.setItem("canonical-storage", "present")</script>`)
+  })
+})
+const upstreamUrl = await listenLocalHttpServer(upstream)
+const proxy = await withPreviewProxy({
+  playground: { async run() { return { text: "" } } },
+  serverUrl: upstreamUrl,
+  async [Symbol.asyncDispose]() {},
+} satisfies PlaygroundCliServer, 0)
+const topology = browserPreviewTopology(
+  ["route-host=localhost"],
+  { preview: { siteUrl: "http://localhost/events/" } },
+  proxy.serverUrl,
+  proxy.previewProxyDiagnostics?.targetOrigin,
+)
+const browser = await launchChromiumBrowser()
+
+try {
+  const context = await browser.newContext(topology.contextOptions())
+  await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, topology.origins.localProxyOrigin)
+  const page = await context.newPage()
+
+  await page.goto(topology.resolveUrl("/events/"), { waitUntil: "load" })
+  assert.equal(new URL(page.url()).origin, "http://localhost")
+  assert.deepEqual(await page.evaluate(() => {
+    history.pushState({}, "", "http://localhost/events/pushed/")
+    history.replaceState({}, "", "http://localhost/events/replaced/")
+    return {
+      cookie: document.cookie,
+      origin: location.origin,
+      pathname: location.pathname,
+      storage: localStorage.getItem("canonical-storage"),
+    }
+  }), {
+    cookie: "canonical_cookie=present",
+    origin: "http://localhost",
+    pathname: "/events/replaced/",
+    storage: "present",
+  })
+
+  await page.goto("http://localhost/events/")
+  await Promise.all([page.waitForURL("http://localhost/events/form/"), page.click("#canonical-form button")])
+  assert(requests.some((request) => request.host === "localhost" && request.method === "POST" && request.url === "/events/form/" && request.body === "value=canonical"))
+
+  await page.goto("http://localhost/events/redirect/")
+  assert.equal(page.url(), "http://localhost/events/final/")
+  await page.goto("http://localhost/events/local-redirect/")
+  assert.equal(page.url(), "http://localhost/events/final/")
+
+  await page.goto("http://localhost/events/")
+  await Promise.all([page.waitForURL("http://localhost/events/subsite/"), page.click("#subsite")])
+  assert.equal(page.url(), "http://localhost/events/subsite/")
+
+  await assert.rejects(page.goto("https://undeclared.example/escape/"))
+  await assert.rejects(page.goto("http://localhost/events/external-redirect/"))
+
+  assert.deepEqual(topology.origins, {
+    localPreviewOrigin: proxy.serverUrl,
+    effectivePreviewOrigin: "http://localhost/events/",
+    canonicalBrowserOrigin: "http://localhost",
+    localProxyOrigin: new URL(proxy.serverUrl).origin,
+    upstreamRuntimeOrigin: new URL(upstreamUrl).origin,
+  })
+  await context.close()
+} finally {
+  await browser.close()
+  await proxy[Symbol.asyncDispose]()
+  await closeHttpServer(upstream)
+}


### PR DESCRIPTION
## Summary
- expose declared `runtime.preview.siteUrl` route aliases as the browser-visible origin while proxying transport to the disposable local preview
- apply the canonical topology consistently across probes, actions, scenarios, and editor runners
- distinguish canonical browser, local proxy, and upstream runtime origins in browser artifacts

## Architecture and root cause
`route-host` previously rewrote individual requests with Playwright interception after navigation had already resolved against the ephemeral `127.0.0.1:<port>` preview. That made network requests work but left the document at the wrong origin, so browser-native History, storage, cookie, form, and redirect semantics diverged from production.

For a declared HTTP `runtime.preview.siteUrl` alias, local Playground runners now create the browser context with the local preview server as an HTTP proxy and navigate against the canonical site URL. The browser therefore owns canonical same-origin semantics while the proxy forwards the request to the disposable upstream runtime. Proxy absolute-form requests retain their canonical `Host`, and local-upstream redirects are translated back to the browser-visible host.

## Security boundary
- only a `siteUrl` hostname explicitly present in `route-host` activates canonical origin preservation
- canonical proxy mode blocks every undeclared host before transport, including top-level navigation and redirect escapes
- explicit `block-host` still wins over routed aliases
- providers that cannot preserve the declared protocol return `preview-canonical-origin-preservation-inconclusive` instead of navigating under a different origin

## Compatibility
The existing request-interception route remains unchanged for non-canonical routed previews. Public and secure preview modes retain their existing effective origins. The local Playground provider currently preserves declared HTTP aliases; HTTPS canonical aliases are reported as structured inconclusive because the local proxy does not terminate canonical TLS.

## Tests
- `npm run test:browser-canonical-preview-origin`
- `npm run test:browser-callback-materialization-contracts`
- `npx tsx tests/browser-adaptive-exploration.test.ts` (16 passed)
- `npm run build`
- `git diff --check`
- `npm run check` reached the existing smoke suite, then failed at unrelated `command-registry-smoke`: `wordpress.collect-workload-result outputShape should mention outputSchema id`

Fixes #2092