### PR TITLE
fix: diagnose unavailable MySQL runtime providers

### DIFF
--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -1414,6 +1414,7 @@ async function waitForMysqlDatabase(container: string, engine: keyof typeof MYSQ
       return
     } catch (error) {
       if (signal?.aborted) throw error
+      if (providerUnavailableDiagnostic(error, "docker")) throw error
       await abortableDelay(100, signal)
     }
   }
@@ -1559,9 +1560,10 @@ export function executeRuntimeServiceProcess(command: string, args: string[], op
     const child = spawn(command, args, {
       env: options.env,
       signal: options.signal,
-      timeout: options.timeout,
       stdio: ["pipe", "pipe", "pipe"],
     })
+    const timeout = setTimeout(() => child.kill(), options.timeout)
+    timeout.unref()
     const stdout: Buffer[] = []
     const stderr: Buffer[] = []
     let stdoutBytes = 0
@@ -1582,11 +1584,13 @@ export function executeRuntimeServiceProcess(command: string, args: string[], op
     child.once("error", (error) => {
       if (settled) return
       settled = true
+      clearTimeout(timeout)
       reject(error)
     })
     child.once("close", (code) => {
       if (settled) return
       settled = true
+      clearTimeout(timeout)
       const boundedStdout = Buffer.concat(stdout).toString("utf8")
       const boundedStderr = Buffer.concat(stderr).toString("utf8")
       if (overflow) {

--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -1450,7 +1450,7 @@ async function releaseService(container: string, evidence: RuntimeServiceEvidenc
     }
     evidence.lifecycle = "failed"
     evidence.teardown = "failed"
-    evidence.diagnostic = { code: "teardown-failed" }
+    if (evidence.diagnostic?.code !== "provider-unavailable") evidence.diagnostic = { code: "teardown-failed" }
     throw new Error(`Managed runtime service teardown failed: ${evidence.id}`)
   }
 }

--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -30,7 +30,11 @@ export interface RuntimeServiceEvidence {
   readiness: "pending" | "ready" | "failed"
   lifecycle: "provisioning" | "provisioned" | "released" | "failed"
   teardown?: "completed" | "failed"
-  diagnostic?: { code: "readiness-failed" | "provision-failed" | "teardown-failed" | "interrupted" }
+  diagnostic?: {
+    code: "readiness-failed" | "provision-failed" | "provider-unavailable" | "teardown-failed" | "interrupted"
+    command?: string
+    cause?: { code: string; message: string }
+  }
   controls?: RuntimeServiceControlResult[]
   memory?: { budgetMiB: number; observedRssMiB?: number }
 }
@@ -300,10 +304,17 @@ async function provisionMysqlDockerService(service: WorkspaceRecipeRuntimeServic
   } catch (error) {
     evidence.readiness = "failed"
     evidence.lifecycle = "failed"
-    evidence.diagnostic = { code: signal?.aborted ? "interrupted" : started ? "readiness-failed" : "provision-failed" }
+    evidence.diagnostic = signal?.aborted
+      ? { code: "interrupted" }
+      : providerUnavailableDiagnostic(error, "docker") ?? { code: started ? "readiness-failed" : "provision-failed" }
     if (started) await releaseService(container, evidence, dependencies, undefined).catch(() => undefined)
     throw new RuntimeServiceProvisionError(`Managed runtime service failed: ${service.id}`, evidenceList)
   }
+}
+
+function providerUnavailableDiagnostic(error: unknown, command: string): RuntimeServiceEvidence["diagnostic"] | undefined {
+  if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") return undefined
+  return { code: "provider-unavailable", command, cause: { code: "ENOENT", message: "Provider command executable was not found" } }
 }
 
 const NATIVE_MARIADB_ROOT_PREFIX = "wp-codebox-mariadb-"

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
@@ -152,6 +153,12 @@ await assert.rejects(provisionRuntimeServices([service], { dependencies: missing
   })
   return true
 })
+const missingProviderChild = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
+  import { executeRuntimeServiceProcess } from "./packages/cli/src/runtime-services.ts";
+  await executeRuntimeServiceProcess("wp-codebox-provider-command-that-does-not-exist", [], { timeout: 300_000 }).catch(() => undefined);
+`], { cwd: process.cwd(), encoding: "utf8", timeout: 5_000 })
+assert.equal(missingProviderChild.error, undefined, `spawn ENOENT child exits without retaining its process timeout: ${missingProviderChild.error?.message ?? ""}`)
+assert.equal(missingProviderChild.status, 0, missingProviderChild.stderr)
 
 const failedStartDependencies: RuntimeServiceDependencies = {
   ...dependencies,
@@ -167,6 +174,27 @@ const failedReadinessDependencies: RuntimeServiceDependencies = {
   async waitForReady() { throw new Error("provider readiness failed") },
 }
 await assert.rejects(provisionRuntimeServices([service], { dependencies: failedReadinessDependencies }), (error: unknown) => error instanceof RuntimeServiceProvisionError && error.evidence[0]?.diagnostic?.code === "readiness-failed")
+
+const unavailableDuringReadinessDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  async execute(command, args, options) {
+    if (args[0] === "exec") return await executeRuntimeServiceProcess("wp-codebox-provider-command-that-does-not-exist", args, options)
+    return dependencies.execute(command, args, options)
+  },
+}
+await assert.rejects(provisionRuntimeServices([service], { dependencies: unavailableDuringReadinessDependencies }), (error: unknown) => error instanceof RuntimeServiceProvisionError && error.evidence[0]?.diagnostic?.code === "provider-unavailable")
+
+let ordinaryReadinessAttempts = 0
+const retryingReadinessDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  async execute(command, args, options) {
+    if (args[0] === "exec" && ordinaryReadinessAttempts++ === 0) throw new Error("provider readiness command failed")
+    return dependencies.execute(command, args, options)
+  },
+}
+const retriedReadiness = await provisionRuntimeServices([service], { dependencies: retryingReadinessDependencies })
+assert.equal(ordinaryReadinessAttempts, 2, "ordinary Docker readiness failures remain retryable")
+await retriedReadiness.release()
 
 const emptyRootCalls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = []
 const emptyRootDependencies: RuntimeServiceDependencies = {

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -178,11 +178,16 @@ await assert.rejects(provisionRuntimeServices([service], { dependencies: failedR
 const unavailableDuringReadinessDependencies: RuntimeServiceDependencies = {
   ...dependencies,
   async execute(command, args, options) {
-    if (args[0] === "exec") return await executeRuntimeServiceProcess("wp-codebox-provider-command-that-does-not-exist", args, options)
+    if (args[0] === "exec" || args[0] === "rm") return await executeRuntimeServiceProcess("wp-codebox-provider-command-that-does-not-exist", args, options)
     return dependencies.execute(command, args, options)
   },
 }
-await assert.rejects(provisionRuntimeServices([service], { dependencies: unavailableDuringReadinessDependencies }), (error: unknown) => error instanceof RuntimeServiceProvisionError && error.evidence[0]?.diagnostic?.code === "provider-unavailable")
+await assert.rejects(provisionRuntimeServices([service], { dependencies: unavailableDuringReadinessDependencies }), (error: unknown) => {
+  assert.ok(error instanceof RuntimeServiceProvisionError)
+  assert.equal(error.evidence[0]?.diagnostic?.code, "provider-unavailable", "cleanup failure does not replace the primary provider failure")
+  assert.equal(error.evidence[0]?.teardown, "failed", "failed cleanup remains visible in service evidence")
+  return true
+})
 
 let ordinaryReadinessAttempts = 0
 const retryingReadinessDependencies: RuntimeServiceDependencies = {

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -4,7 +4,7 @@ import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { runRecipeBuildCommand } from "../packages/cli/src/commands/recipe-build.ts"
-import { parseLoopbackPort, provisionRuntimeServices, provisionRuntimeServicesForRecipe, RuntimeServiceProvisionError, runtimeServiceEvidenceFromError, runtimeServicePlan, waitForMysqlProtocol, type RuntimeServiceDependencies } from "../packages/cli/src/runtime-services.ts"
+import { executeRuntimeServiceProcess, parseLoopbackPort, provisionRuntimeServices, provisionRuntimeServicesForRecipe, RuntimeServiceProvisionError, runtimeServiceEvidenceFromError, runtimeServicePlan, waitForMysqlProtocol, type RuntimeServiceDependencies } from "../packages/cli/src/runtime-services.ts"
 import { planWorkspaceRecipe } from "../packages/cli/src/recipe-dry-run.ts"
 import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.ts"
 import { buildWordPressPhpunitRecipe } from "../packages/runtime-core/src/recipe-builders.ts"
@@ -138,6 +138,35 @@ assert.equal(calls[0]?.args[0], "image", "the provider checks the image before s
 await provisioned.release()
 await provisioned.release()
 assert.equal(calls.filter((call) => call.args[0] === "rm").length, 1, "release is idempotent")
+
+const missingProviderDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  execute: async (_command, args, options) => await executeRuntimeServiceProcess("wp-codebox-provider-command-that-does-not-exist", args, options),
+}
+await assert.rejects(provisionRuntimeServices([service], { dependencies: missingProviderDependencies }), (error: unknown) => {
+  assert.ok(error instanceof RuntimeServiceProvisionError)
+  assert.deepEqual(error.evidence[0]?.diagnostic, {
+    code: "provider-unavailable",
+    command: "docker",
+    cause: { code: "ENOENT", message: "Provider command executable was not found" },
+  })
+  return true
+})
+
+const failedStartDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  async execute(command, args, options) {
+    if (args[0] === "run") throw new Error("provider start failed")
+    return dependencies.execute(command, args, options)
+  },
+}
+await assert.rejects(provisionRuntimeServices([service], { dependencies: failedStartDependencies }), (error: unknown) => error instanceof RuntimeServiceProvisionError && error.evidence[0]?.diagnostic?.code === "provision-failed")
+
+const failedReadinessDependencies: RuntimeServiceDependencies = {
+  ...dependencies,
+  async waitForReady() { throw new Error("provider readiness failed") },
+}
+await assert.rejects(provisionRuntimeServices([service], { dependencies: failedReadinessDependencies }), (error: unknown) => error instanceof RuntimeServiceProvisionError && error.evidence[0]?.diagnostic?.code === "readiness-failed")
 
 const emptyRootCalls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = []
 const emptyRootDependencies: RuntimeServiceDependencies = {


### PR DESCRIPTION
## Summary

- classify runtime-service process spawn `ENOENT` as a generic `provider-unavailable` diagnostic
- identify the missing provider command while emitting only synthesized, bounded cause evidence
- clean up the generic process executor's timeout immediately on spawn errors so unavailable commands cannot retain the CLI process
- preserve provider unavailability when the command disappears during MySQL readiness while retaining ordinary Docker retry and failure classifications

## Root cause

`provisionMysqlDockerService` caught the process spawn error from the Docker image/start path but discarded it, reducing every pre-start failure to `{ code: \"provision-failed\" }`. When the `docker` executable was absent, the actionable `ENOENT` cause therefore never reached managed runtime-service evidence.

Two related lifecycle paths also needed correction:

- Node's built-in child-process timeout remained referenced after spawn `ENOENT`, keeping the CLI alive until the Docker pull timeout elapsed.
- `waitForMysqlDatabase` treated all Docker execution failures as retryable, so readiness-time `ENOENT` was eventually collapsed to `readiness-failed`.

The resulting structured diagnostic is:

```json
{
  "code": "provider-unavailable",
  "command": "docker",
  "cause": {
    "code": "ENOENT",
    "message": "Provider command executable was not found"
  }
}
```

The evidence is provider-neutral and bounded: it does not forward raw stderr, process environment values, or an unbounded host error message. The generic process executor now owns an unref'd timeout and clears it on both spawn errors and process close. Readiness retries ordinary command failures but immediately preserves provider-command `ENOENT`.

## Tests

- `timeout 20s npx tsx tests/runtime-services.test.ts`
  - includes a child-process regression proving a missing command with a nominal 300-second timeout exits within 5 seconds
  - covers provider loss during `docker exec`
  - confirms ordinary Docker readiness command failures remain retryable
  - confirms ordinary start/readiness failures retain their existing classifications
- `npx tsx tests/external-mysql-runtime-service.test.ts`
- `npx tsx tests/native-mariadb-runtime-service.test.ts`
- `npm run build`
- `git diff --check`

The repository does not define a lint script; the workspace TypeScript build provides package typechecking.

MySQL remains fail-closed: an unavailable Docker provider still throws `RuntimeServiceProvisionError`, and no SQLite substitution or fallback was added.

Fixes #2006