### PR TITLE
Fix adaptive policy-block console correlation

### DIFF
--- a/packages/runtime-playground/src/browser-adaptive-explorer.ts
+++ b/packages/runtime-playground/src/browser-adaptive-explorer.ts
@@ -19,6 +19,7 @@ import { stableJson } from "@automattic/wp-codebox-core/internals"
 import type { Frame, Page } from "playwright"
 
 import { discoverBrowserActionCorpusDescriptors } from "./browser-action-discovery.js"
+import { redactBrowserNetworkUrl } from "./browser-metrics.js"
 import { browserPreviewNetworkDecision, type BrowserPreviewNavigationScope, type BrowserPreviewNetworkPolicy } from "./browser-preview-routing.js"
 
 interface AdaptiveObservationSources {
@@ -595,7 +596,7 @@ function adaptiveOracleEvidence(consoleRecords: Record<string, unknown>[], netwo
     const message = recordMessage(record)
     const locationUrl = objectRecord(record.location).url
     const match = classifiedFailures.findIndex((failure, index) => unmatchedFailures.has(index)
-      && (typeof locationUrl === "string" && locationUrl ? failure.url === locationUrl && failureTokenMatches(message, failure.failure) : failureTokenMatches(message, failure.failure)))
+      && (typeof locationUrl === "string" && locationUrl ? networkUrlsMatch(failure.url, locationUrl) && failureTokenMatches(message, failure.failure) : failureTokenMatches(message, failure.failure)))
     if (match < 0) return [message]
     unmatchedFailures.delete(match)
     const failure = classifiedFailures[match]!
@@ -641,6 +642,10 @@ function boundedNetworkFailureEvidence(failures: Array<BrowserAdaptiveNetworkFai
 function failureTokenMatches(message: string, failure: string | undefined): boolean {
   const token = failure?.match(/ERR_[A-Z0-9_]+/i)?.[0]
   return Boolean(token && message.toUpperCase().includes(token.toUpperCase()))
+}
+
+function networkUrlsMatch(networkUrl: string, consoleUrl: string): boolean {
+  return redactBrowserNetworkUrl(networkUrl) === redactBrowserNetworkUrl(consoleUrl)
 }
 
 function networkFailureOracleMessage(failure: BrowserAdaptiveNetworkFailure): string {

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -608,7 +608,7 @@ export function serializeBrowserRequestFailure(request: Request, timestamp = now
   }
 }
 
-function redactBrowserNetworkUrl(url: string): string {
+export function redactBrowserNetworkUrl(url: string): string {
   return redactString(url, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
 }
 

--- a/tests/browser-adaptive-exploration.test.ts
+++ b/tests/browser-adaptive-exploration.test.ts
@@ -500,7 +500,7 @@ test("declared network-policy blocks remain structured evidence without becoming
   assert.equal(run.result.summary.errors, 0)
   assert(transition?.observations.consoleErrors.some((message) => message.includes("ERR_BLOCKED_BY_CLIENT")), "raw browser console evidence remains available")
   assert.deepEqual(transition?.observations.networkFailures, [{
-    url: "http://assets.example.invalid/tile.png",
+    url: "http://assets.example.invalid/tile.png?cache=[redacted]",
     host: "assets.example.invalid",
     urlClassification: "external",
     policyDecision: "blocked",
@@ -561,6 +561,21 @@ test("same-URL product errors require a matching failure token before policy cor
   assert(fingerprints.includes(productFingerprint))
   assert(fingerprints.includes(environmentBoundOracleFingerprint(blockMessage)))
   assert.equal(finding.result.transitions[0]?.observations.networkFailureSummary?.policyBlocks, 1)
+})
+
+test("redacted policy-block URLs correlate without hiding independent console errors across browser contexts", async () => {
+  for (const environment of ["desktop", "mobile"] as const) {
+    const evidence = await runNetworkOracleFixture("block", "blocked", {}, false, false, environment)
+    assert.equal(evidence.result.findings.length, 0, environment)
+    assert.deepEqual(evidence.result.transitions[0]?.observations.oracleFingerprints, [], environment)
+    assert.equal(evidence.result.transitions[0]?.observations.networkFailureSummary?.policyBlocks, 1, environment)
+
+    const independent = await runNetworkOracleFixture("block", "blocked", {}, false, true, environment)
+    const productFingerprint = browserAdaptiveDigest("oracle", { environmentDigest: independent.contract.environmentDigest, value: "same-URL product defect" })
+    assert.deepEqual(independent.result.transitions[0]?.observations.oracleFingerprints, [productFingerprint], environment)
+    assert.equal(independent.result.findings[0]?.fingerprint, productFingerprint, environment)
+    assert.equal(independent.result.transitions[0]?.observations.networkFailureSummary?.oracleFindings, 0, environment)
+  }
 })
 
 test("allow and record policies do not explain unexpected same-origin request failures", async () => {
@@ -737,7 +752,7 @@ async function runRoutedFixture(topology: ReturnType<typeof browserPreviewTopolo
   }
 }
 
-async function runNetworkOracleFixture(mode: "allow" | "block" | "record", behavior: "blocked" | "unexpected" | "mixed" | "exception", input: Record<string, unknown> = {}, urlLessConsole = false, sameUrlProductError = false) {
+async function runNetworkOracleFixture(mode: "allow" | "block" | "record", behavior: "blocked" | "unexpected" | "mixed" | "exception", input: Record<string, unknown> = {}, urlLessConsole = false, sameUrlProductError = false, environment: "desktop" | "mobile" = "desktop") {
   const server = createServer((request, response) => {
     const path = new URL(request.url ?? "/", "http://preview.invalid").pathname
     if (path === "/failed.png") {
@@ -748,7 +763,7 @@ async function runNetworkOracleFixture(mode: "allow" | "block" | "record", behav
     response.end(`<!doctype html><style>button{display:block;width:180px;height:30px}</style><button id="trigger">Trigger</button><script>
       document.querySelector('#trigger').addEventListener('click', () => {
         const load = (src) => { const image = document.createElement('img'); image.src = src; document.body.append(image); };
-        ${behavior === "blocked" || behavior === "mixed" ? "load('http://assets.example.invalid/tile.png');" : ""}
+        ${behavior === "blocked" || behavior === "mixed" ? "load('http://assets.example.invalid/tile.png?cache=fixture-secret');" : ""}
         ${behavior === "unexpected" || behavior === "mixed" ? "load('/failed.png');" : ""}
         ${behavior === "exception" ? "setTimeout(() => { throw new Error('fixture page exception'); }, 0);" : ""}
       });
@@ -757,7 +772,8 @@ async function runNetworkOracleFixture(mode: "allow" | "block" | "record", behav
   const startUrl = await listenLocalHttpServer(server)
   const topology = browserPreviewTopology([`network-policy=${mode}`], undefined, startUrl)
   const browser = await chromium.launch({ headless: true })
-  const context = await browser.newContext()
+  const browserEnvironment = environment === "mobile" ? { hasTouch: true, isMobile: true, viewport: { height: 844, width: 390 } } : undefined
+  const context = await browser.newContext(browserEnvironment)
   await routeBrowserPreviewContextNetwork(context, topology.networkPolicy, startUrl)
   const page = await context.newPage()
   const consoleMessages: Record<string, unknown>[] = []
@@ -779,6 +795,7 @@ async function runNetworkOracleFixture(mode: "allow" | "block" | "record", behav
     actionFamilies: ["click"],
     budgets: { maxActions: 1, maxStates: 2, maxTransitions: 1, maxDurationMs: 10_000 },
     stabilization: { pollIntervalMs: 25, quietWindowMs: 100, maxWaitMs: 1_500, maxMutationRecords: 20 },
+    ...(browserEnvironment ? { environment: browserEnvironment } : {}),
     ...input,
   })
   try {


### PR DESCRIPTION
## Summary
- correlate console resource-load errors against the same redacted URL representation stored in network evidence
- keep evidence-only policy blocks visible in transition diagnostics without promoting their correlated console messages into oracle findings
- cover query-bearing blocked resources and independent console errors in desktop and mobile/touch browser contexts

## Root cause
Browser network capture redacts URL query values immediately, while console `location.url` remains raw until artifact serialization. Adaptive oracle aggregation compared those two representations exactly, so a query-bearing blocked request could be correctly classified as evidence-only network data while its correlated console error remained unmatched and became a finding.

## Correlation semantics
Correlation still requires both the generic resource URL and the browser failure token to match. The URL comparison now normalizes both sides through the existing browser network URL-redaction contract. This suppresses only console messages attributable to an evidence-only policy block; independent same-URL console errors without the matching failure token remain findings.

## Tests
- `npx tsx --test tests/browser-adaptive-exploration.test.ts`: new regression passes; 24/25 overall, with the unrelated timing-sensitive cancellation test failing because no error transition was emitted before cancellation
- isolated cancellation rerun: same unrelated failure
- `npm run build`: passes
- `npm run check`: relevant build and browser routing/security gates pass, then the existing command-registry smoke fails with `wordpress.collect-workload-result outputShape should mention outputSchema id`
- `git diff --check`: passes

## Residual risks
The supplied evidence bundle reports `missing_runtime_snapshot` and partial replay status, so the original WordPress runtime could not be replayed deterministically. The regression instead reproduces the captured redacted-network/raw-console mismatch in real Chromium across desktop and mobile/touch contexts.

Fixes #2114