### PR TITLE
Fix command artifact node allocation

### DIFF
--- a/packages/runtime-core/src/bounded-execution-results.ts
+++ b/packages/runtime-core/src/bounded-execution-results.ts
@@ -42,7 +42,7 @@ export function boundedExecutionResultsForArtifacts<T extends ExecutionResult>(c
   const budget = {
     remainingBytes: COMMAND_ARTIFACT_TOTAL_STRING_MAX_BYTES,
     remainingCommandBytes: COMMAND_ARTIFACT_COMMAND_STRING_MAX_BYTES,
-    remainingNodes: COMMAND_ARTIFACT_MAX_NODES,
+    remainingNodes: 0,
     remainingTruncations: COMMAND_ARTIFACT_MAX_TRUNCATIONS,
   }
   const selectedCommands = commands.length <= COMMAND_ARTIFACT_MAX_RECORDS
@@ -51,6 +51,7 @@ export function boundedExecutionResultsForArtifacts<T extends ExecutionResult>(c
 
   return selectedCommands.map((command, selectedIndex) => {
     budget.remainingCommandBytes = COMMAND_ARTIFACT_COMMAND_STRING_MAX_BYTES
+    budget.remainingNodes = commandArtifactNodeBudget(selectedIndex, selectedCommands.length)
     const fields: CommandArtifactTruncation[] = []
     let omittedFieldCount = 0
     const capture = (value: unknown, path: string): unknown => boundedArtifactValue(value, path, budget, (field) => {
@@ -99,6 +100,11 @@ export function boundedExecutionResultsForArtifacts<T extends ExecutionResult>(c
     }
     return projected
   })
+}
+
+function commandArtifactNodeBudget(commandIndex: number, commandCount: number): number {
+  const nodesPerCommand = Math.floor(COMMAND_ARTIFACT_MAX_NODES / commandCount)
+  return nodesPerCommand + (commandIndex < COMMAND_ARTIFACT_MAX_NODES % commandCount ? 1 : 0)
 }
 
 function boundedArtifactValue(

--- a/tests/runtime-command-artifact-bounds.test.ts
+++ b/tests/runtime-command-artifact-bounds.test.ts
@@ -102,6 +102,56 @@ const nodeBudgetRecord = boundedExecutionResultsForArtifacts([{
 assert(nodeBudgetRecord?.artifactCapture?.fields.some((field) => field.reason === "node-limit"))
 assert.equal(nodeBudgetRecord?.artifactCapture?.limits.nodes, COMMAND_ARTIFACT_MAX_NODES)
 
+const fixture37Commands: ExecutionResult[] = [
+  {
+    ...command,
+    id: "fixture-37-import",
+    command: "wordpress.import",
+    stdout: "",
+    result: undefined,
+    diagnostics: Array.from({ length: COMMAND_ARTIFACT_MAX_NODES }, () => ({ import: "node" })),
+  },
+  ...Array.from({ length: 7 }, (_, index) => ({
+    ...command,
+    id: `fixture-37-editor-open-${index}`,
+    command: "wordpress.editor-open",
+    args: [`/page-${index}`],
+    stdout: "editor opened",
+    result: { status: "ok", page: index },
+    diagnostics: { session: `editor-${index}` },
+  })),
+  ...Array.from({ length: 7 }, (_, index) => ({
+    ...command,
+    id: `fixture-37-editor-validate-${index}`,
+    command: "wordpress.editor-validate-blocks",
+    args: [`/page-${index}`],
+    stdout: "validation passed",
+    result: { status: "ok", valid: true, metrics: { blockCount: index + 1 } },
+    diagnostics: { validation: "passed" },
+  })),
+  ...Array.from({ length: 7 }, (_, index) => ({
+    ...command,
+    id: `fixture-37-visual-compare-${index}`,
+    command: "wordpress.visual-compare",
+    args: [`/page-${index}`],
+    stdout: "visual comparison passed",
+    result: { status: "ok", artifactRefs: [`visual-${index}.png`], metrics: { similarity: 1 } },
+    diagnostics: { comparison: "passed" },
+  })),
+]
+const fixture37Records = boundedExecutionResultsForArtifacts(fixture37Commands)
+assert.equal(fixture37Records.length, fixture37Commands.length)
+assert(fixture37Records[0]?.artifactCapture?.fields.some((field) => field.reason === "node-limit"))
+const capturedImportNodes = (fixture37Records[0]?.diagnostics as Array<{ import?: string }>).filter(({ import: value }) => value === "node").length
+assert(capturedImportNodes <= Math.ceil(COMMAND_ARTIFACT_MAX_NODES / fixture37Commands.length))
+for (const record of fixture37Records.slice(1)) {
+  assert(record.args.length > 0)
+  assert(record.stdout.length > 0)
+  assert.equal((record.result as { status?: string } | undefined)?.status, "ok")
+  assert(Object.keys(record.diagnostics ?? {}).length > 0)
+}
+assert.deepEqual(boundedExecutionResultsForArtifacts(fixture37Commands), fixture37Records)
+
 const manyCommands = Array.from({ length: COMMAND_ARTIFACT_MAX_RECORDS + 2 }, (_, index) => ({
   ...command,
   id: `command-${index}`,


### PR DESCRIPTION
## Summary

Fixes the fixture-37 command-artifact failure where a large early Static Site Importer import exhausted the shared 25,000-node budget. The seven subsequent `wordpress.editor-open`, `wordpress.editor-validate-blocks`, and `wordpress.visual-compare` commands exited successfully but persisted empty evidence with `artifactCapture.reason = node-limit`, causing downstream normalization to produce `editor_validation = null` and `visual_parity_comparisons = []` despite browser artifacts being present.

Each retained command now receives a deterministic even share of the existing aggregate 25,000-node budget. Remainder nodes are allocated to earlier retained commands. This prevents an oversized command from erasing later records while retaining the aggregate bound; string byte budgets, record limits, UTF-8 truncation, truncation metadata, and result projection behavior remain unchanged.

## Tests

- `npm run test:runtime-command-artifact-bounds`
  - Covers an oversized fixture-37-style import followed by seven editor-open, seven editor-validation, and seven visual-comparison commands. Verifies explicit import truncation, bounded deterministic allocation, and usable later args, stdout, results, and diagnostics.
- `npm run build`

## Compatibility

Artifact capture remains on `wp-codebox/command-artifact-capture/v1` with the same aggregate limits and truncation contract. Node capture is now fairly partitioned across retained commands instead of being consumed in execution order.

## AI Assistance

GPT-5.6 Sol using OpenCode general task drafted the implementation, ran tests, and drafted this PR. Chris Huber remains responsible for every line.

Closes #2122