### PR TITLE
Retain committed Cloudflare runtimes

### DIFF
--- a/packages/runtime-cloudflare/src/worker.ts
+++ b/packages/runtime-cloudflare/src/worker.ts
@@ -1323,8 +1323,11 @@ async function runCoordinatedWordPressRequest(request: Request, env: RuntimeEnv,
         retained.retain(responseBodyBytes)
         response = toFetchResponse(request, phpResponse)
       }
-      await trace.measure("runtime.dispose", () => discardRuntime(runtime!, site))
-      runtime = undefined
+      const retainCommittedRuntime = route !== "static-artifact-import"
+      if (!retainCommittedRuntime) {
+        await trace.measure("runtime.dispose", () => discardRuntime(runtime!, site))
+        runtime = undefined
+      }
       if (phpResponse) retained.release(responseBodyBytes)
       if (route === "static-artifact-import" && !currentPublication) currentPublication = await trace.measure("publication.current.initialize", () => initializeProvisioningPublication(env.WORDPRESS_STATE_BUCKET, activeLease, site))
       const publicationJob = await trace.measure("publication.enqueue", () => enqueuePublicationJob(env.WORDPRESS_STATE_BUCKET, activeLease, next, currentPublication, publicationChanges!, site))
@@ -1336,6 +1339,15 @@ async function runCoordinatedWordPressRequest(request: Request, env: RuntimeEnv,
         await heartbeat?.("committing", 90)
       }
       const committed = await trace.measure("coordinator.commit", () => commitLease(coordinator, request.url, activeLease, next))
+      finalized = true
+      if (retainCommittedRuntime) {
+        const stateMatched = samePointer(committed.pointer, next)
+        if (!runtime || !stateMatched) throw new Error("Committed runtime pointer does not match its persisted canonical state.")
+        const committedRuntime = { ...runtime, pointer: committed.pointer }
+        const sameRuntime = committedRuntime.php === runtime.php && committedRuntime.requestHandler === runtime.requestHandler
+        await trace.measure("runtime.cache.promote", async () => cacheRuntime(committed.pointer, committedRuntime, site), { stateMatched, sameRuntime })
+        runtime = undefined
+      }
       await onCommitted?.(committed)
       // A pre-commit R2 job is inert; only the observable coordinator receipt may wake it.
       if (publicationJob && env.WORDPRESS_STATE_DATABASE) {

--- a/scripts/cloudflare-local-gate.mjs
+++ b/scripts/cloudflare-local-gate.mjs
@@ -780,6 +780,7 @@ async function assertWordPressCronDisabled() {
 }
 
 async function assertConcurrentMutations() {
+  const outputOffset = output.length
   const responses = await Promise.all([
     fetch(`${origin}/?phase=r2-mutate`, { method: "POST" }),
     fetch(`${origin}/?phase=r2-mutate`, { method: "POST" }),
@@ -793,6 +794,11 @@ async function assertConcurrentMutations() {
   const revisions = mutations.map((mutation) => mutation.revisionValue).sort((left, right) => left - right)
   if (revisions[1] !== revisions[0] + 1 || !mutations.some((mutation) => mutation.previousPostFound)) {
     throw new Error(`Concurrent canonical mutations were not serialized: ${JSON.stringify(mutations)}`)
+  }
+  const summaries = runtimePhaseTraceSummaries(output.slice(outputOffset)).filter((summary) => summary.operation === "mutation")
+  if (summaries.length !== 2 || summaries.filter((summary) => summary.phases.some((phase) => phase.name === "runtime.cache.promote" && phase.evidence?.stateMatched === true && phase.evidence?.sameRuntime === true)).length !== 2
+    || !summaries.some((summary) => summary.runtime === "warm" && summary.phases.some((phase) => phase.name === "runtime.cache.reuse"))) {
+    throw new Error(`Concurrent canonical mutations did not carry the exact committed runtime forward: ${JSON.stringify(summaries)}.`)
   }
 }
 
@@ -960,14 +966,7 @@ async function timedWordPressPage(target, label) {
 }
 
 function assertRuntimePhaseTraceSummaries() {
-  const summaries = stripVTControlCharacters(output).split("\n").flatMap((line) => {
-    try {
-      const value = JSON.parse(line)
-      return value?.schema === "wp-codebox/cloudflare-runtime-phase-trace/v1" ? [value] : []
-    } catch {
-      return []
-    }
-  })
+  const summaries = runtimePhaseTraceSummaries(output)
   const runtimes = new Set(summaries.map((summary) => summary.runtime))
   const operations = new Set(summaries.map((summary) => summary.operation))
   for (const runtime of ["cold", "warm"]) {
@@ -975,10 +974,21 @@ function assertRuntimePhaseTraceSummaries() {
   }
   if (!operations.has("mutation")) throw new Error("Cloudflare runtime gate did not emit a machine-readable mutation operation summary.")
   const phaseNames = new Set(summaries.flatMap((summary) => summary.phases?.map((phase) => phase.name) ?? []))
-  for (const phase of ["canonical.bootstrap.seed", "persistence.markdown.write", "persistence.manifest.write"]) {
+  for (const phase of ["canonical.bootstrap.seed", "persistence.markdown.write", "persistence.manifest.write", "runtime.cache.promote"]) {
     if (!phaseNames.has(phase)) throw new Error(`Cloudflare runtime gate did not emit the required ${phase} phase.`)
   }
   if (summaries.some((summary) => !Number.isFinite(summary.totalMs) || !Array.isArray(summary.phases) || summary.phases.reduce((total, phase) => total + phase.durationMs, 0) > summary.totalMs + 1)) throw new Error("Cloudflare runtime gate received an invalid phase trace summary.")
+}
+
+function runtimePhaseTraceSummaries(rawOutput) {
+  return stripVTControlCharacters(rawOutput).split("\n").flatMap((line) => {
+    try {
+      const value = JSON.parse(line)
+      return value?.schema === "wp-codebox/cloudflare-runtime-phase-trace/v1" ? [value] : []
+    } catch {
+      return []
+    }
+  })
 }
 
 async function assertExplanatoryHomepage(html) {


### PR DESCRIPTION
## Summary

- retain normal mutation PHP-WASM runtimes only after the coordinator commits the exact persisted canonical pointer
- promote an immutable runtime wrapper with the committed pointer while preserving the same PHP and request-handler objects
- leave SSI/static-artifact runtimes on their existing isolated disposal path
- emit safe `stateMatched` and `sameRuntime` phase evidence
- prove two serialized mutations both promote exact runtimes and the second executes through warm cache reuse while observing the first commit

Closes #2133.
Advances the performance plan in #2079.

## Verification

- `npm run test:cloudflare-runtime`
- `npm run cloudflare:local-gate`
- `npm run cloudflare:local-gate:d1`
- `npm run cloudflare:dry-run`
- `npm run cloudflare:dry-run:d1`
- `npm run cloudflare:dry-run:control`
- `npm run cloudflare:dry-run:public-reader`
- independent adversarial review found no merge blockers

Both coordinator gates passed repeated mutations, SSI import, publication, cron, restart persistence, media/plugin state, and two-site isolation. Final observed homepage timing remained 940-995 ms cold and 4-6 ms warm. No remote deployment or Cloudflare resource mutation was performed.

## AI Assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode designed and implemented the exact committed-runtime carry-forward, phase evidence, behavioral gate assertions, and verification. Chris Huber reviewed and remains responsible for the change.