### PR TITLE
Fix authoritative PHPUnit failure evidence

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "test:playground-phpunit-bootstrap-failure-integration": "tsx tests/playground-phpunit-bootstrap-failure.integration.test.ts",
     "test:playground-custom-archive-cache": "tsx tests/playground-custom-archive-cache.test.ts && tsx tests/playground-custom-archive-cache-process.test.ts && tsx tests/playground-custom-archive-cache.integration.test.ts",
     "test:phpunit-runtime-failure-diagnostics": "tsx tests/phpunit-runtime-failure-diagnostics.test.ts",
+    "test:phpunit-structured-evidence": "tsx tests/phpunit-structured-evidence.test.ts",
     "test:phpunit-runtime-rejection": "tsx tests/phpunit-runtime-rejection.test.ts",
     "test:playground-worker-runtime-rejection": "tsx tests/playground-worker-runtime-rejection.test.ts",
     "test:php-wasm-extension-manifests": "tsx tests/php-wasm-extension-manifests.test.ts",

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -55,11 +55,11 @@ import {
   buildWorkspacePatchArtifact,
   buildBlueprintAfter,
   buildBlueprintAfterNotes,
-  buildTestResults,
   serializeCapturedMountFiles,
   type CapturedMountFiles,
   type MountDiffsResult,
 } from "./artifacts.js"
+import { buildPhpunitTestResults, readCapturedPhpunitCompletedResults } from "./phpunit-test-results.js"
 import { buildRuntimeReferenceIndex } from "./runtime-reference-index.js"
 import { buildReplayableWordPressSiteBlueprint, buildReplayableWordPressSiteLimitations } from "./replayable-wordpress-site-bundle.js"
 import { runtimeSnapshotPayload, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
@@ -179,7 +179,8 @@ export class ArtifactBundleBuilder {
     diagnostics.summary.notice = diagnostics.diagnostics.filter((diagnostic) => diagnostic.severity === "notice").length
     diagnostics.summary.info = diagnostics.diagnostics.filter((diagnostic) => diagnostic.severity === "info").length
     diagnostics.status = diagnostics.summary.total > 0 ? "reported" : "clean"
-    const testResults = buildTestResults()
+    const phpunitCompletedResults = await readCapturedPhpunitCompletedResults(source.artifactRoot)
+    const testResults = buildPhpunitTestResults(source.commands, phpunitCompletedResults)
     const workspacePatch = buildWorkspacePatchArtifact({
       createdAt,
       provenance,
@@ -263,6 +264,7 @@ export class ArtifactBundleBuilder {
       ...source.browserManifestFiles(),
       ...source.observationManifestFiles(),
       ...commandArtifactManifestFiles(source.artifactRoot, source.commands),
+      ...phpunitCompletedResults.map(({ path }) => artifactManifestFile(join(source.artifactRoot, path), "test-results", "text/plain")),
       ...source.pluginCheckManifestFiles(),
       ...source.themeCheckManifestFiles(),
       ...runtimeSnapshotFiles,
@@ -392,7 +394,7 @@ export class ArtifactBundleBuilder {
     await writeFile(changedFilesPath, changedFilesJson)
     await writeFile(patchPath, redactedPatch)
     await writeRedactedArtifact(redactor, diagnosticsPath, source.artifactRoot, artifactJson(diagnostics))
-    await writeRedactedArtifact(redactor, testResultsPath, source.artifactRoot, artifactJson(testResults))
+    await writeFile(testResultsPath, artifactJson(testResults))
     await writeRedactedArtifact(redactor, previewEvidencePath, source.artifactRoot, artifactJson(previewEvidence))
     await writeFile(previewSessionEvidencePath, previewSessionEvidenceJson)
     const redaction = redactor.summary()

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -18,7 +18,6 @@ import type {
   ArtifactRedactionSummary,
   ArtifactReview,
   ArtifactReviewBrowserSummary,
-  ArtifactTestResults,
   MountSpec,
   ObservationResult,
   RuntimeCreateSpec,
@@ -519,31 +518,6 @@ export function buildWorkspacePatchArtifact({
 function stringMetadata(metadata: Record<string, unknown>, key: string): string | undefined {
   const value = metadata[key]
   return typeof value === "string" && value.length > 0 ? value : undefined
-}
-
-export function buildTestResults(): ArtifactTestResults {
-  return {
-    schema: "wp-codebox/test-results/v1",
-    status: "unknown",
-    summary: {
-      total: 0,
-      passed: 0,
-      failed: 0,
-      skipped: 0,
-      unknown: 0,
-    },
-    suites: [],
-    rawLogReferences: [
-      {
-        path: "commands.jsonl",
-        kind: "commands-jsonl",
-      },
-      {
-        path: "logs/commands.log",
-        kind: "commands-log",
-      },
-    ],
-  }
 }
 
 export function buildArtifactProvenance({

--- a/packages/runtime-playground/src/phpunit-test-results.ts
+++ b/packages/runtime-playground/src/phpunit-test-results.ts
@@ -1,0 +1,180 @@
+import { readdir, readFile } from "node:fs/promises"
+import { join, relative } from "node:path"
+import type { ArtifactTestResults, ExecutionResult } from "@automattic/wp-codebox-core"
+
+export const PHPUNIT_COMPLETED_RESULT_PREFIX = "WP_CODEBOX_PHPUNIT_RESULT:"
+
+export interface PhpunitCompletedResult {
+  schema: "wp-codebox/phpunit-result/v1"
+  status: "passed" | "failed"
+  total: number
+  passed: number
+  failed: number
+  skipped: number
+  assertions: number
+  failures: number
+  errors: number
+}
+
+export interface CapturedPhpunitCompletedResult {
+  path: string
+  result: PhpunitCompletedResult
+}
+
+export function parsePhpunitCompletedResult(log: string): PhpunitCompletedResult | undefined {
+  for (const line of log.split("\n").reverse()) {
+    if (!line.startsWith(PHPUNIT_COMPLETED_RESULT_PREFIX)) continue
+
+    try {
+      const value = JSON.parse(line.slice(PHPUNIT_COMPLETED_RESULT_PREFIX.length)) as Record<string, unknown>
+      if (
+        value.schema !== "wp-codebox/phpunit-result/v1"
+        || (value.status !== "passed" && value.status !== "failed")
+        || !validCount(value.total)
+        || !validCount(value.skipped)
+        || !validCount(value.assertions)
+        || !validCount(value.failures)
+        || !validCount(value.errors)
+        || value.failures + value.errors + value.skipped > value.total
+        || (value.status === "passed") !== (value.failures + value.errors === 0)
+      ) {
+        return undefined
+      }
+      const failed = value.failures + value.errors
+      return {
+        schema: value.schema,
+        status: value.status,
+        total: value.total,
+        passed: value.total - failed - value.skipped,
+        failed,
+        skipped: value.skipped,
+        assertions: value.assertions,
+        failures: value.failures,
+        errors: value.errors,
+      }
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+export function parsePhpunitOutput(output: string): PhpunitCompletedResult | undefined {
+  const summaries = [...output.matchAll(/Tests:\s*(\d+)([^\r\n]*)/g)]
+  const summary = summaries.at(-1)
+  if (summary) {
+    const count = (label: string): number => Number(summary[2].match(new RegExp(`(?:^|,\\s*)${label}:\\s*(\\d+)`))?.[1] ?? 0)
+    const total = Number(summary[1])
+    const failures = count("Failures")
+    const errors = count("Errors")
+    const skipped = count("Skipped")
+    const assertions = count("Assertions")
+    return completedResult(total, assertions, failures, errors, skipped)
+  }
+
+  const successful = [...output.matchAll(/OK \((\d+) tests?,\s*(\d+) assertions?\)/g)].at(-1)
+  return successful ? completedResult(Number(successful[1]), Number(successful[2]), 0, 0, 0) : undefined
+}
+
+export async function readCapturedPhpunitCompletedResults(artifactRoot: string): Promise<CapturedPhpunitCompletedResult[]> {
+  const paths = await phpunitResultPaths(join(artifactRoot, "files", "phpunit"))
+  const results: CapturedPhpunitCompletedResult[] = []
+
+  for (const path of paths) {
+    const result = parsePhpunitCompletedResult(await readFile(path, "utf8"))
+    if (result) results.push({ path: relative(artifactRoot, path), result })
+  }
+  return results
+}
+
+export function buildPhpunitTestResults(commands: ExecutionResult[], completed: CapturedPhpunitCompletedResult[]): ArtifactTestResults {
+  const phpunitCommands = commands.filter((command) => command.command === "wordpress.phpunit")
+  const rawLogReferences = [
+    { path: "commands.jsonl", kind: "commands-jsonl" },
+    { path: "logs/commands.log", kind: "commands-log" },
+    ...completed.flatMap(({ path }) => [
+      { path, kind: "phpunit-result" },
+      { path: phpunitDiagnosticPath(path), kind: "phpunit-output" },
+    ]),
+  ]
+  const suites: ArtifactTestResults["suites"] = completed.map(({ path, result }, index) => ({
+    name: completed.length === 1 ? "wordpress.phpunit" : `wordpress.phpunit:${index + 1}`,
+    status: result.status,
+    tests: result.total,
+    passed: result.passed,
+    failed: result.failed,
+    skipped: result.skipped,
+    unknown: 0,
+    rawLogReferences: [{ path, kind: "phpunit-result" }, { path: phpunitDiagnosticPath(path), kind: "phpunit-output" }, { path: "logs/commands.log", kind: "commands-log" }],
+  }))
+  for (let index = completed.length; index < phpunitCommands.length; index += 1) {
+    suites.push({
+      name: phpunitCommands.length === 1 ? "wordpress.phpunit" : `wordpress.phpunit:${index + 1}`,
+      status: "unknown",
+      tests: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      unknown: 0,
+      rawLogReferences: [{ path: "logs/commands.log", kind: "commands-log" }],
+    })
+  }
+
+  const summary = completed.reduce((aggregate, { result }) => ({
+    total: aggregate.total + result.total,
+    passed: aggregate.passed + result.passed,
+    failed: aggregate.failed + result.failed,
+    skipped: aggregate.skipped + result.skipped,
+    unknown: aggregate.unknown,
+  }), { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 })
+  const hasUnknownSuite = suites.some((suite) => suite.status === "unknown")
+  const status = suites.some((suite) => suite.status === "failed")
+    ? "failed"
+    : hasUnknownSuite || suites.length === 0
+      ? "unknown"
+      : summary.total > 0 && summary.skipped === summary.total
+        ? "skipped"
+        : "passed"
+
+  return { schema: "wp-codebox/test-results/v1", status, summary, suites, rawLogReferences }
+}
+
+function validCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+async function phpunitResultPaths(directory: string): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const paths: string[] = []
+  for (const entry of entries) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) paths.push(...await phpunitResultPaths(path))
+    else if (entry.isFile() && entry.name === ".wp-codebox-result.txt") paths.push(path)
+  }
+  return paths.sort()
+}
+
+function completedResult(total: number, assertions: number, failures: number, errors: number, skipped: number): PhpunitCompletedResult {
+  const failed = failures + errors
+  return {
+    schema: "wp-codebox/phpunit-result/v1",
+    status: failed === 0 ? "passed" : "failed",
+    total,
+    passed: Math.max(0, total - failed - skipped),
+    failed,
+    skipped,
+    assertions,
+    failures,
+    errors,
+  }
+}
+
+export function phpunitDiagnosticPath(completedResultPath: string): string {
+  return completedResultPath.replace(/\.wp-codebox-result\.txt$/, ".pg-test-result.txt")
+}

--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -115,6 +115,21 @@ export function assertPlaygroundResponseOk(command: string, response: Playground
   }
 }
 
+export function completedPlaygroundCommandError(command: string, cause: unknown): PlaygroundCommandError {
+  const commandCause = cause instanceof PlaygroundCommandCrashError ? cause.cause : cause
+  const diagnostics = playgroundCrashDiagnostics(commandCause)
+  return new PlaygroundCommandError(command, {
+    cause: commandCause,
+    exitCode: playgroundNonzeroExitCode(commandCause) ?? playgroundNonzeroExitCode(cause) ?? 1,
+    errors: diagnostics.length > 0 ? diagnostics.join("\n") : errorMessage(commandCause),
+    text: "",
+  })
+}
+
+export function playgroundCommandDiagnosticText(cause: unknown): string {
+  return [errorMessage(cause), ...playgroundCrashDiagnostics(cause)].join("\n")
+}
+
 /**
  * Extract a human-readable failure message from the structured PHPUnit
  * diagnostics log (.pg-test-result.txt). The PHP runner emits STAGE_FAIL / STAGE_DIE /
@@ -308,6 +323,16 @@ function playgroundCrashDiagnostics(cause: unknown): string[] {
   }
 
   return [...metadata, ...sections]
+}
+
+function playgroundNonzeroExitCode(cause: unknown): number | undefined {
+  for (const record of diagnosticRecords(cause)) {
+    if (typeof record.exitCode === "number" && Number.isInteger(record.exitCode) && record.exitCode !== 0) {
+      return record.exitCode
+    }
+  }
+  const match = errorMessage(cause).match(/\bexit code (\d+)\b/i)
+  return match && Number(match[1]) !== 0 ? Number(match[1]) : undefined
 }
 
 function diagnosticRecords(value: unknown, seen = new Set<unknown>()): Record<string, unknown>[] {

--- a/packages/runtime-playground/src/runtime-diagnostics.ts
+++ b/packages/runtime-playground/src/runtime-diagnostics.ts
@@ -2,9 +2,25 @@ import { basename, dirname, join } from "node:path"
 import { captureArtifactFile, type MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { extractPhpunitFailureMessage } from "./playground-command-errors.js"
+import { PHPUNIT_COMPLETED_RESULT_PREFIX, parsePhpunitCompletedResult, type PhpunitCompletedResult } from "./phpunit-test-results.js"
 
 export async function persistPluginPhpunitResult(server: PlaygroundCliServer, vfsPath: string, artifactRoot: string, namespace?: string): Promise<void> {
   await persistPhpunitResult(server, vfsPath, join(artifactRoot, "files", "phpunit", ...(namespace ? [namespace] : []), ".pg-test-result.txt"))
+}
+
+export async function persistPluginPhpunitCompletedResult(artifactRoot: string, result: PhpunitCompletedResult, namespace?: string): Promise<void> {
+  const hostPath = join(artifactRoot, "files", "phpunit", ...(namespace ? [namespace] : []), ".wp-codebox-result.txt")
+  const { passed: _passed, failed: _failed, ...aggregate } = result
+  await captureArtifactFile({
+    root: dirname(hostPath),
+    path: basename(hostPath),
+    kind: "test-results",
+    contentType: "text/plain; charset=utf-8",
+    contents: `${PHPUNIT_COMPLETED_RESULT_PREFIX}${JSON.stringify(aggregate)}\n`,
+    redact: (_path, contents) => contents,
+    redaction: { policy: "applied", sensitive: false },
+    provenance: { source: "wordpress-playground", operation: "persist-phpunit-completed-result" },
+  })
 }
 
 export async function persistCorePhpunitResult(server: PlaygroundCliServer, vfsPath: string, artifactRoot: string): Promise<void> {
@@ -36,11 +52,21 @@ export async function readPluginPhpunitDiagnostic(server: PlaygroundCliServer, v
   return readPhpunitDiagnostic(server, vfsPath)
 }
 
+export async function readPluginPhpunitCompletedResult(server: PlaygroundCliServer, vfsPath: string): Promise<PhpunitCompletedResult | undefined> {
+  const contents = await readPhpunitResult(server, vfsPath)
+  return contents ? parsePhpunitCompletedResult(contents) : undefined
+}
+
 export async function readCorePhpunitDiagnostic(server: PlaygroundCliServer, vfsPath: string): Promise<string | undefined> {
   return readPhpunitDiagnostic(server, vfsPath)
 }
 
 async function readPhpunitDiagnostic(server: PlaygroundCliServer, vfsPath: string): Promise<string | undefined> {
+  const contents = await readPhpunitResult(server, vfsPath)
+  return contents ? extractPhpunitFailureMessage(contents) : undefined
+}
+
+async function readPhpunitResult(server: PlaygroundCliServer, vfsPath: string): Promise<string | undefined> {
   if (!server.playground.readFileAsText) {
     return undefined
   }
@@ -52,7 +78,7 @@ async function readPhpunitDiagnostic(server: PlaygroundCliServer, vfsPath: strin
     return undefined
   }
 
-  return extractPhpunitFailureMessage(contents)
+  return contents
 }
 
 export async function persistVfsDiagnosticFile(server: PlaygroundCliServer, vfsPath: string, mounts: MountSpec[]): Promise<void> {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -51,10 +51,11 @@ import {
   themeSetupInputFromArgs,
 } from "./commands.js"
 import { bootstrapAbilityPhpCode, bootstrapPhpCode, phpCodeFromArgs, splitLeadingStrictTypesDeclare } from "./php-bootstrap.js"
-import { assertPlaygroundResponseOk, attachPlaygroundDiagnostics, type PlaygroundRunResponse } from "./playground-command-errors.js"
+import { assertPlaygroundResponseOk, attachPlaygroundDiagnostics, completedPlaygroundCommandError, playgroundCommandDiagnosticText, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
-import { persistCorePhpunitResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitDiagnostic } from "./runtime-diagnostics.js"
+import { persistCorePhpunitResult, persistPluginPhpunitCompletedResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitCompletedResult, readPluginPhpunitDiagnostic } from "./runtime-diagnostics.js"
 import { phpunitExecutionSemantics, requiresManagedMysqlMultisitePreinstall } from "./phpunit-command-semantics.js"
+import { parsePhpunitOutput } from "./phpunit-test-results.js"
 import type { RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
 import { COMMAND_DIAGNOSTICS_ARTIFACT_SCHEMA, PERFORMANCE_OBSERVATION_SCHEMA, commandDiagnosticsCaptureArgs, commandDiagnosticsCaptureSpecFromArgs, createRuntimeCommandResultEnvelope, redactJsonValue, type ExecutionSpec, type MountSpec, type PerformanceObservation, type RuntimeCommandResultEnvelope, type RuntimeCreateSpec, type RuntimeEpisodeTraceRef } from "@automattic/wp-codebox-core"
 import { wordpressUserSessionFromCommandArgs } from "./wordpress-user-sessions.js"
@@ -981,6 +982,11 @@ export async function runPhpunitCommand({
   } catch (error) {
     await persistPluginPhpunitResult(server, resultFile, artifactRoot, processIdentity)
     await persistVfsDiagnosticFileToHost(server, resultFile, diagnosticHostFile, mounts)
+    const completed = await readPluginPhpunitCompletedResult(server, resultFile) ?? parsePhpunitOutput(playgroundCommandDiagnosticText(error))
+    if (completed) {
+      await persistPluginPhpunitCompletedResult(artifactRoot, completed, processIdentity)
+      throw attachPlaygroundDiagnostics(completedPlaygroundCommandError("wordpress.phpunit", error), "wordpress.phpunit completed result", `completed ${completed.status}; total ${completed.total}; failed ${completed.failed}; skipped ${completed.skipped}; failures ${completed.failures}; errors ${completed.errors}`)
+    }
     const structured = await readPluginPhpunitDiagnostic(server, resultFile)
     if (structured) {
       throw attachPlaygroundDiagnostics(error, "wordpress.phpunit structured diagnostics", structured)
@@ -991,6 +997,10 @@ export async function runPhpunitCommand({
   await persistPluginPhpunitResult(server, resultFile, artifactRoot, processIdentity)
   await persistVfsDiagnosticFileToHost(server, resultFile, diagnosticHostFile, mounts)
   const structured = await readPluginPhpunitDiagnostic(server, resultFile)
+  const completed = await readPluginPhpunitCompletedResult(server, resultFile) ?? parsePhpunitOutput(response.text)
+  if (completed) {
+    await persistPluginPhpunitCompletedResult(artifactRoot, completed, processIdentity)
+  }
   try {
     assertPlaygroundResponseOk("wordpress.phpunit", response)
   } catch (error) {

--- a/tests/phpunit-structured-evidence.test.ts
+++ b/tests/phpunit-structured-evidence.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ExecutionResult } from "../packages/runtime-core/src/runtime-contracts.js"
+import { PlaygroundCommandCrashError } from "../packages/runtime-playground/src/playground-command-errors.js"
+import { PLUGIN_PHPUNIT_RESULT_FILE } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
+import { buildPhpunitTestResults, parsePhpunitCompletedResult } from "../packages/runtime-playground/src/phpunit-test-results.js"
+import { runPhpunitCommand } from "../packages/runtime-playground/src/wordpress-command-runners.js"
+
+const passedLog = completedLog({ status: "passed", total: 3, passed: 3, failed: 0, skipped: 0, assertions: 3, failures: 0, errors: 0 })
+const failedLog = completedLog({ status: "failed", total: 4, passed: 1, failed: 2, skipped: 1, assertions: 2, failures: 1, errors: 1 })
+assert.equal(parsePhpunitCompletedResult(passedLog)?.status, "passed")
+assert.equal(parsePhpunitCompletedResult(failedLog)?.failed, 2)
+assert.equal(parsePhpunitCompletedResult("STAGE_FAIL:run_tests:RuntimeException: crashed"), undefined)
+
+const passedEvidence = buildPhpunitTestResults([execution(0)], [{ path: "files/phpunit/.wp-codebox-result.txt", result: parsePhpunitCompletedResult(passedLog)! }])
+assert.equal(passedEvidence.status, "passed")
+assert.deepEqual(passedEvidence.summary, { total: 3, passed: 3, failed: 0, skipped: 0, unknown: 0 })
+
+const failedEvidence = buildPhpunitTestResults([execution(1)], [{ path: "files/phpunit/.wp-codebox-result.txt", result: parsePhpunitCompletedResult(failedLog)! }])
+assert.equal(failedEvidence.status, "failed")
+assert.deepEqual(failedEvidence.summary, { total: 4, passed: 1, failed: 2, skipped: 1, unknown: 0 })
+assert(failedEvidence.rawLogReferences.some((reference) => reference.path === "files/phpunit/.pg-test-result.txt"))
+
+const crashEvidence = buildPhpunitTestResults([execution(1)], [])
+assert.equal(crashEvidence.status, "unknown")
+assert.deepEqual(crashEvidence.summary, { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 })
+
+const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-phpunit-structured-evidence-"))
+try {
+  const completedCrash = new PlaygroundCommandCrashError("wordpress.phpunit", Object.assign(new Error("PHP.run() failed with exit code 2"), { exitCode: 2 }))
+  await assert.rejects(
+    runPhpunitWith(completedCrash, failedLog, artifactRoot),
+    (error: Error) => {
+      assert.match(error.message, /failed with exit code 2/)
+      assert.match(error.message, /failureClassification=runtime-command-failure/)
+      assert.match(error.message, /total 4; failed 2; skipped 1/)
+      assert.doesNotMatch(error.message, /crashed before producing a structured response/)
+      return true
+    },
+  )
+
+  const workloadCrash = new PlaygroundCommandCrashError("wordpress.phpunit", new Error("worker terminated"))
+  await assert.rejects(
+    runPhpunitWith(workloadCrash, "STAGE_BEGIN:run_tests\nSTAGE_FAIL:run_tests:RuntimeException: worker terminated", artifactRoot),
+    (error: Error) => {
+      assert.match(error.message, /crashed before producing a structured response/)
+      assert.match(error.message, /failureClassification=runtime-worker-failure/)
+      return true
+    },
+  )
+} finally {
+  await rm(artifactRoot, { recursive: true, force: true })
+}
+
+function runPhpunitWith(error: Error, log: string, artifactRoot: string): Promise<string> {
+  return runPhpunitCommand({
+    artifactRoot,
+    mounts: [],
+    runPlaygroundCommand: async () => { throw error },
+    runtimeSpec: { environment: { kind: "wordpress", name: "test", version: "latest" }, policy: { commands: ["wordpress.phpunit"] } } as never,
+    server: { playground: { readFileAsText: async (path: string) => {
+      assert.equal(path, PLUGIN_PHPUNIT_RESULT_FILE)
+      return log
+    } } } as never,
+    spec: { command: "wordpress.phpunit", args: ["plugin-slug=demo-plugin"] },
+  })
+}
+
+function completedLog(result: Omit<ReturnType<typeof parsePhpunitCompletedResult> & {}, "schema">): string {
+  const { passed: _passed, failed: _failed, ...aggregate } = result
+  return `STAGE_BEGIN:run_tests\nWP_CODEBOX_PHPUNIT_RESULT:${JSON.stringify({ schema: "wp-codebox/phpunit-result/v1", ...aggregate })}\nSTAGE_OK:run_tests\n`
+}
+
+function execution(exitCode: number): ExecutionResult {
+  return { id: "command-1", command: "wordpress.phpunit", args: [], exitCode, stdout: "", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z" }
+}
+
+console.log("phpunit structured evidence ok")

--- a/tests/playground-phpunit-readonly-cache.integration.test.ts
+++ b/tests/playground-phpunit-readonly-cache.integration.test.ts
@@ -15,6 +15,7 @@ const dependency = join(root, "dependency")
 const harness = join(root, "harness")
 const recipePath = join(root, "recipe.json")
 const artifactsPath = join(root, "artifacts")
+const failingArtifactsPath = join(root, "failing-artifacts")
 const sentinel = Buffer.from([0, 255, 1, 2, 3, 127, 128])
 
 try {
@@ -59,8 +60,41 @@ try {
   const diagnostic = await readFile(join(artifactsPath, runtime.paths?.runtimeDirectory ?? "", "files/phpunit/.pg-test-result.txt"), "utf8")
   assert.match(diagnostic, /^DISCOVERY: .* found=1$/m, "actual PHPUnit runner must discover the fixture test file")
   assert.match(diagnostic, /^STAGE_BEGIN:run_tests/m, "actual PHPUnit runner must reach its test stage")
+  const passingEvidence = await readTestResults(artifactsPath, runtime.paths?.runtimeDirectory)
+  const completedResult = await readFile(join(artifactsPath, runtime.paths?.runtimeDirectory ?? "", "files/phpunit/.wp-codebox-result.txt"), "utf8").catch((error) => String(error))
+  assert.match(completedResult, /"status":"passed","total":6/)
+  assert.equal(passingEvidence.status, "passed")
+  assert.deepEqual(passingEvidence.summary, { total: 6, passed: 6, failed: 0, skipped: 0, unknown: 0 })
+
+  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_passes(): void { $this->assertTrue(true); } public function test_fails(): void { $this->assertTrue(false); } public function test_errors(): void { throw new RuntimeException('fixture error'); } public function test_skips(): void { $this->markTestSkipped('fixture skipped'); } }\n")
+  const failedOutput = await runFailedRecipe()
+  assert.equal(failedOutput.success, false)
+  assert.match(failedOutput.error?.message ?? "", /failureClassification=runtime-command-failure/)
+  assert.doesNotMatch(failedOutput.error?.message ?? "", /crashed before producing a structured response/)
+  const failedRuntime = JSON.parse(await readFile(join(failingArtifactsPath, "latest-runtime.json"), "utf8")) as { paths?: { runtimeDirectory?: string } }
+  const failingEvidence = await readTestResults(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory)
+  assert.equal(failingEvidence.status, "failed")
+  assert.deepEqual(failingEvidence.summary, { total: 4, passed: 1, failed: 2, skipped: 1, unknown: 0 })
+  assert(failingEvidence.rawLogReferences.some((reference) => reference.path === "files/phpunit/.pg-test-result.txt"))
 } finally {
   await rm(root, { recursive: true, force: true })
+}
+
+async function runFailedRecipe(): Promise<{ success?: boolean, error?: { message?: string } }> {
+  try {
+    const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--artifacts", failingArtifactsPath, "--json"], {
+      cwd: process.cwd(), timeout: 300_000, maxBuffer: 2 * 1024 * 1024,
+    })
+    return JSON.parse(result.stdout)
+  } catch (error) {
+    assert(error && typeof error === "object" && "stdout" in error && typeof error.stdout === "string")
+    return JSON.parse(error.stdout)
+  }
+}
+
+async function readTestResults(artifactPath: string, runtimeDirectory?: string): Promise<{ status: string, summary: { total: number, passed: number, failed: number, skipped: number, unknown: number }, rawLogReferences: Array<{ path: string }> }> {
+  assert.ok(runtimeDirectory, "recipe must retain a runtime artifact directory")
+  return JSON.parse(await readFile(join(artifactPath, runtimeDirectory, "files/test-results.json"), "utf8"))
 }
 
 async function writeFixture(): Promise<void> {


### PR DESCRIPTION
## Summary

- parse PHPUnit's own completed terminal aggregate at the `wordpress.phpunit` Playground command boundary and persist a validated completion record
- reclassify only completed nonzero PHPUnit runs as `runtime-command-failure`, preserving the original nonzero exit and worker diagnostics
- build `wp-codebox/test-results/v1` from authoritative completion records with real totals and links to the raw PHPUnit/command logs; marker-free crashes remain `unknown`

Closes #2129.

## Root cause

`server.playground.run()` rejects when PHP exits nonzero. The generic Playground wrapper converted every rejection into `PlaygroundCommandCrashError` before `runPhpunitCommand()` could distinguish PHPUnit's ordinary failure exit. Artifact generation was also hard-coded to emit `status: unknown` with zero counts.

The fix belongs in `runtime-playground`: this layer owns the `PHP.run` boundary, PHPUnit command semantics, diagnostic persistence, and artifact bundle assembly. Consumers should not infer or invent counts downstream.

## Before / after

Before, a completed `206/206` suite ending with `Errors: 65, Failures: 16, Skipped: 2` became `runtime-worker-failure` and zero-test unknown evidence.

After, the real Playground regression fixture proves:

- passing suite: `status: passed`, `total: 6`, `passed: 6`, `failed: 0`, `skipped: 0`
- completed failing suite: `status: failed`, `total: 4`, `passed: 1`, `failed: 2`, `skipped: 1`
- the failing recipe remains unsuccessful and the command remains nonzero with `failureClassification=runtime-command-failure`
- a rejected workload with no completed aggregate remains `runtime-worker-failure` and emits unknown zero-count evidence

## Verification

Passed:

- `npm run build`
- `npm run test:phpunit-structured-evidence`
- `npm run test:playground-phpunit-readonly-cache-integration`
- `npm run test:phpunit-runtime-rejection`
- `npx tsx scripts/artifact-bundle-verifier-smoke.ts`
- `git diff --check`

Repository-wide `npm run check` reached the smoke suite but is blocked by unchanged current-main issue #1745 (`wordpress.collect-workload-result outputShape should mention outputSchema id`). Additional unchanged focused-gate failures discovered while verifying are tracked in #2137, #2138, and #2139.