### PR TITLE
Execute mapped-domain multisite site seeds

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -539,10 +539,21 @@ Recipes may also attach reusable bootstrap declarations to a site seed:
 }
 ```
 
-These are generic declarations for orchestrators and future runtime setup
-support. The current built-in fixture importer treats multisite/domain bootstrap
-as declared metadata and blocks executable fixture imports that require runtime
-setup not yet provided by WP Codebox.
+The Playground backend executes these declarations before fixture import. It
+creates the declared WordPress sites in deterministic order, uses the declared
+primary domain for the network main site, and automatically routes those
+first-party hosts through the local preview without adding them to the external
+network allowlist. Runtime site-seed evidence records the requested and effective
+network/site identities under `topology`.
+
+Mapped-domain browser evidence is exact for anonymous requests: page navigation,
+redirects, subresources, and root-relative REST requests retain the browser's
+original `Host` identity. Fixture-user browser authentication is materialized per
+declared host. Evidence reports that behavior as `per-host-materialized` and does
+not claim production cross-domain cookie parity. Backends without executable
+topology support fail recipe validation with an unsupported-capability diagnostic.
+Existing recipes without an enabled site-seed multisite declaration keep their
+current path-based behavior.
 
 ## Fixture Users And User Sessions
 

--- a/package.json
+++ b/package.json
@@ -241,6 +241,8 @@
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
+    "test:site-seed-multisite": "tsx tests/site-seed-multisite.test.ts",
+    "test:playground-mapped-domain-multisite-integration": "tsx tests/playground-mapped-domain-multisite.integration.test.ts",
     "test:runtime-workers": "tsx tests/runtime-workers.test.ts",
     "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
     "test:recipe-runtime-setup-staged-materialization": "tsx tests/recipe-runtime-setup-staged-materialization.test.ts",

--- a/packages/cli/src/commands/recipe-site-seeds.ts
+++ b/packages/cli/src/commands/recipe-site-seeds.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises"
 import { basename, resolve } from "node:path"
 import { assertFixtureImportDeterministicIdsSupported, fixtureImportDeterministicIdPlan, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
-import { siteSeedScopesAreBounded } from "../recipe-dry-run.js"
+import { siteSeedScopesAreBounded, type RecipeSiteSeedTopologyEvidence } from "../recipe-dry-run.js"
 import type { RecipeExecutionResult, RecipeRunSiteSeed } from "./recipe-run-types.js"
 
 export async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string, runtime: Runtime, executions: RecipeExecutionResult[]): Promise<RecipeRunSiteSeed[]> {
@@ -10,9 +10,11 @@ export async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirec
 
   for (const [index, siteSeed] of (recipe.inputs?.siteSeeds ?? []).entries()) {
     const base = recipeSiteSeedRunBase(siteSeed, recipeDirectory, index)
+    const topology = siteSeed.bootstrap?.multisite?.enabled ? await siteSeedTopologyEvidence(siteSeed, runtime, executions, index) : undefined
     if (siteSeed.type !== "fixture") {
       results.push({
         ...base,
+        ...(topology ? { topology } : {}),
         action: "skipped",
         reason: "parent-site export is not implemented in this first executable site seed slice",
       })
@@ -33,6 +35,7 @@ export async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirec
       const imported = parseSiteSeedImportResult(execution.stdout)
       results.push({
         ...base,
+        ...(topology ? { topology } : {}),
         action: "imported",
         counts: {
           ...bounded.counts,
@@ -59,6 +62,7 @@ export async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirec
     const imported = parseSiteSeedImportResult(execution.stdout)
     results.push({
       ...base,
+      ...(topology ? { topology } : {}),
       action: "imported",
       counts: imported.counts,
       ...(imported.warnings.length > 0 ? { warnings: imported.warnings } : {}),
@@ -71,6 +75,59 @@ export async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirec
   }
 
   return results
+}
+
+async function siteSeedTopologyEvidence(siteSeed: WorkspaceRecipeSiteSeed, runtime: Runtime, executions: RecipeExecutionResult[], index: number): Promise<RecipeSiteSeedTopologyEvidence> {
+  const runtimeInfo = await runtime.info()
+  if (runtimeInfo.backend !== "wordpress-playground") {
+    throw new Error(`Runtime backend ${runtimeInfo.backend} cannot execute siteSeed mapped-domain multisite bootstrap; select wordpress or wordpress-playground.`)
+  }
+  const requested = siteSeed.bootstrap!
+  const execution = await runtime.execute({ command: "wordpress.run-php", args: [`code=${siteSeedTopologyEvidenceCode()}`] })
+  executions.push(withRecipeExecutionPhase(execution, "setup", index))
+  if (execution.exitCode !== 0) throw new Error(`Site seed mapped-domain multisite evidence failed: ${execution.stderr || execution.stdout}`)
+  const parsed = JSON.parse(execution.stdout.trim() || "{}") as { multisite?: unknown; install?: unknown; dynamicHost?: unknown; network?: unknown; sites?: unknown }
+  if (parsed.multisite !== true || parsed.dynamicHost !== true || (parsed.install !== "subdomain" && parsed.install !== "subdirectory") || !parsed.network || typeof parsed.network !== "object" || !Array.isArray(parsed.sites)) {
+    throw new Error("Site seed mapped-domain multisite bootstrap did not return valid effective topology evidence.")
+  }
+  const sites = parsed.sites.filter((site): site is { id: number; domain: string; path: string; primary: boolean } => Boolean(site) && typeof site === "object" && typeof (site as { id?: unknown }).id === "number" && typeof (site as { domain?: unknown }).domain === "string" && typeof (site as { path?: unknown }).path === "string")
+  const expected = (requested.multisite?.sites ?? []).map((site) => `${site.domain.toLowerCase()}${site.path ?? "/"}`).sort()
+  const effective = sites.map((site) => `${site.domain.toLowerCase()}${site.path}`).sort()
+  for (const identity of expected) {
+    if (!effective.includes(identity)) throw new Error(`Site seed mapped-domain multisite bootstrap did not materialize declared site: ${identity}`)
+  }
+  const routeHosts = [...new Set((requested.multisite?.sites ?? []).map((site) => site.domain.toLowerCase()))].sort()
+  return {
+    schema: "wp-codebox/site-seed-topology/v1",
+    backend: runtimeInfo.backend,
+    requested,
+    effective: {
+      multisite: true,
+      install: parsed.install,
+      network: parsed.network as { id: number; domain: string; path: string },
+      sites,
+    },
+    browser: { routeHosts, hostIdentity: "preserved", externalNetworkAccess: "unchanged" },
+    auth: { anonymous: "exact", authenticated: "per-host-materialized", crossDomainCookieParity: "not-claimed" },
+  }
+}
+
+function siteSeedTopologyEvidenceCode(): string {
+  return `
+$network = get_network();
+$main_site_id = get_main_site_id($network ? (int) $network->id : null);
+$config = file_get_contents(ABSPATH . 'wp-config.php');
+$sites = array();
+foreach (get_sites(array('network_id' => $network ? (int) $network->id : null, 'number' => 0, 'orderby' => 'id', 'order' => 'ASC')) as $site) {
+    $sites[] = array('id' => (int) $site->blog_id, 'domain' => (string) $site->domain, 'path' => (string) $site->path, 'primary' => (int) $site->blog_id === (int) $main_site_id);
+}
+echo wp_json_encode(array(
+    'multisite' => is_multisite(),
+    'dynamicHost' => is_string($config) && str_contains($config, 'WP_CODEBOX_DYNAMIC_MULTISITE_HOST'),
+    'install' => is_subdomain_install() ? 'subdomain' : 'subdirectory',
+    'network' => array('id' => $network ? (int) $network->id : 0, 'domain' => $network ? (string) $network->domain : '', 'path' => $network ? (string) $network->path : ''),
+    'sites' => $sites,
+));`
 }
 
 function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: "setup", recipeStepIndex: number): RecipeExecutionResult {

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -216,6 +216,7 @@ export interface RecipeDryRunSiteSeed {
   importer?: string
   deterministicIds?: FixtureImportDeterministicIdPlan
   bootstrap?: WorkspaceRecipeSiteSeedBootstrap
+  topology?: RecipeSiteSeedTopologyEvidence
   scopes: WorkspaceRecipeSiteSeed["scopes"]
   bounded: boolean
   dryRunOnly: boolean
@@ -224,6 +225,28 @@ export interface RecipeDryRunSiteSeed {
     importsIntoSandbox: boolean
     includesRecordData: boolean
     secrets: "excluded-by-default"
+  }
+}
+
+export interface RecipeSiteSeedTopologyEvidence {
+  schema: "wp-codebox/site-seed-topology/v1"
+  backend: string
+  requested: WorkspaceRecipeSiteSeedBootstrap
+  effective: {
+    multisite: boolean
+    install: "subdomain" | "subdirectory"
+    network: { id: number; domain: string; path: string }
+    sites: Array<{ id: number; domain: string; path: string; primary: boolean }>
+  }
+  browser: {
+    routeHosts: string[]
+    hostIdentity: "preserved"
+    externalNetworkAccess: "unchanged"
+  }
+  auth: {
+    anonymous: "exact"
+    authenticated: "per-host-materialized"
+    crossDomainCookieParity: "not-claimed"
   }
 }
 

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -734,7 +734,7 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
   }
 
   for (const [index, siteSeed] of (recipe.inputs?.siteSeeds ?? []).entries()) {
-    await validateRecipeSiteSeed(siteSeed, recipeDirectory, `$.inputs.siteSeeds[${index}]`, addIssue)
+    await validateRecipeSiteSeed(siteSeed, recipeDirectory, `$.inputs.siteSeeds[${index}]`, normalizeRuntimeBackendKind(recipe.runtime?.backend), addIssue)
   }
 
   for (const [index, stagedFile] of (recipe.inputs?.stagedFiles ?? []).entries()) {
@@ -1397,7 +1397,7 @@ async function validateRecipePluginRuntime(pluginRuntime: WorkspaceRecipePluginR
   }
 }
 
-async function validateRecipeSiteSeed(siteSeed: WorkspaceRecipeSiteSeed, recipeDirectory: string, path: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+async function validateRecipeSiteSeed(siteSeed: WorkspaceRecipeSiteSeed, recipeDirectory: string, path: string, backend: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
   if (!/^[a-z0-9][a-z0-9_.-]*$/i.test(siteSeed.name)) {
     addIssue("invalid-site-seed-name", `${path}.name`, `Site seed names must be stable identifiers: ${siteSeed.name}`)
   }
@@ -1427,7 +1427,7 @@ async function validateRecipeSiteSeed(siteSeed: WorkspaceRecipeSiteSeed, recipeD
     }
   }
 
-  validateSiteSeedBootstrap(siteSeed, path, addIssue)
+  validateSiteSeedBootstrap(siteSeed, path, backend, addIssue)
 
   if (siteSeed.type === "parent_site" && siteSeed.source) {
     addIssue("invalid-site-seed-source", `${path}.source`, "Parent-site seed declarations must not name a source file until explicit parent export support lands.")
@@ -1452,27 +1452,46 @@ async function validateRecipeSiteSeed(siteSeed: WorkspaceRecipeSiteSeed, recipeD
   }
 }
 
-function validateSiteSeedBootstrap(siteSeed: WorkspaceRecipeSiteSeed, path: string, addIssue: (code: string, path: string, message: string) => void): void {
+function validateSiteSeedBootstrap(siteSeed: WorkspaceRecipeSiteSeed, path: string, backend: string, addIssue: (code: string, path: string, message: string) => void): void {
   const bootstrap = siteSeed.bootstrap
   if (!bootstrap) {
     return
   }
 
-  if (bootstrap.multisite?.enabled && siteSeed.type === "fixture") {
-    addIssue("unsupported-site-seed-multisite-bootstrap", `${path}.bootstrap.multisite`, "Multisite bootstrap is a reusable declaration only until the runtime exposes a platform setup primitive.")
+  if (bootstrap.multisite?.enabled && backend !== "wordpress-playground") {
+    addIssue("unsupported-site-seed-multisite-bootstrap", `${path}.bootstrap.multisite`, `Runtime backend ${backend} does not provide executable siteSeed mapped-domain multisite bootstrap. Select wordpress or wordpress-playground.`)
   }
 
+  const identities = new Set<string>()
   for (const [index, site] of (bootstrap.multisite?.sites ?? []).entries()) {
-    if (!site.domain || typeof site.domain !== "string") {
-      addIssue("invalid-site-seed-bootstrap-domain", `${path}.bootstrap.multisite.sites[${index}].domain`, "Bootstrap sites require a domain.")
-    }
+    validateSiteSeedBootstrapIdentity(site, `${path}.bootstrap.multisite.sites[${index}]`, addIssue)
+    const identity = `${String(site.domain).toLowerCase()}${normalizedBootstrapPath(site.path)}`
+    if (identities.has(identity)) addIssue("duplicate-site-seed-bootstrap-site", `${path}.bootstrap.multisite.sites[${index}]`, `Bootstrap site identities must be unique: ${identity}`)
+    identities.add(identity)
   }
 
+  let primaryDomains = 0
   for (const [index, domain] of (bootstrap.domains ?? []).entries()) {
-    if (!domain.domain || typeof domain.domain !== "string") {
-      addIssue("invalid-site-seed-bootstrap-domain", `${path}.bootstrap.domains[${index}].domain`, "Bootstrap domains require a domain.")
-    }
+    validateSiteSeedBootstrapIdentity(domain, `${path}.bootstrap.domains[${index}]`, addIssue)
+    if (domain.primary) primaryDomains += 1
+    const identity = `${String(domain.domain).toLowerCase()}${normalizedBootstrapPath(domain.path)}`
+    if (bootstrap.multisite?.enabled && !identities.has(identity)) addIssue("unmatched-site-seed-bootstrap-domain", `${path}.bootstrap.domains[${index}]`, `Bootstrap domains must match a declared multisite site identity: ${identity}`)
   }
+  if (bootstrap.multisite?.enabled && (bootstrap.multisite.sites?.length ?? 0) === 0) addIssue("missing-site-seed-bootstrap-sites", `${path}.bootstrap.multisite.sites`, "Executable multisite bootstrap requires at least one declared site.")
+  if (primaryDomains > 1) addIssue("ambiguous-site-seed-bootstrap-primary", `${path}.bootstrap.domains`, "Executable multisite bootstrap supports at most one primary domain.")
+}
+
+function validateSiteSeedBootstrapIdentity(identity: { domain: string; path?: string }, path: string, addIssue: (code: string, path: string, message: string) => void): void {
+  if (!identity.domain || typeof identity.domain !== "string" || !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(identity.domain)) {
+    addIssue("invalid-site-seed-bootstrap-domain", `${path}.domain`, "Bootstrap domains must be hostnames without a scheme, path, wildcard, or port.")
+  }
+  if (identity.path !== undefined && (!identity.path.startsWith("/") || !identity.path.endsWith("/") || identity.path.includes("//") || identity.path.includes("?") || identity.path.includes("#"))) {
+    addIssue("invalid-site-seed-bootstrap-path", `${path}.path`, "Bootstrap paths must be canonical absolute directory paths ending in /.")
+  }
+}
+
+function normalizedBootstrapPath(path: string | undefined): string {
+  return path?.endsWith("/") ? path : `${path ?? ""}/`
 }
 
 function validateSiteSeedScopeBounds(scope: NonNullable<WorkspaceRecipeSiteSeed["scopes"]["posts"]>, path: string, scopeName: string, seedType: WorkspaceRecipeSiteSeed["type"], addIssue: (code: string, path: string, message: string) => void): void {

--- a/packages/runtime-playground/src/blueprint.ts
+++ b/packages/runtime-playground/src/blueprint.ts
@@ -1,4 +1,5 @@
 import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { playgroundSiteSeedMultisiteBlueprintSteps, playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 export function normalizeBlueprint(blueprint: unknown): { extraLibraries?: unknown; landingPage?: unknown; preferredVersions?: unknown; steps: unknown[] } {
   if (!blueprint || typeof blueprint !== "object" || Array.isArray(blueprint)) {
@@ -45,6 +46,22 @@ export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpe
       }] : []),
       ...steps,
     ],
+  }
+}
+
+export function playgroundRuntimeBlueprint(spec: RuntimeCreateSpec): unknown {
+  const siteUrl = playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl
+  const base = playgroundBlueprint(spec.environment.blueprint, spec.policy, siteUrl)
+  const multisiteSteps = playgroundSiteSeedMultisiteBlueprintSteps(spec)
+  if (multisiteSteps.length === 0) return base
+
+  const normalized = !base || typeof base !== "object" || Array.isArray(base) ? {} : base as Record<string, unknown>
+  const steps = Array.isArray(normalized.steps) ? normalized.steps : []
+  const defineSiteUrlIndex = steps.findIndex((step) => Boolean(step) && typeof step === "object" && !Array.isArray(step) && (step as { step?: unknown }).step === "defineSiteUrl")
+  const insertAt = defineSiteUrlIndex < 0 ? 0 : defineSiteUrlIndex + 1
+  return {
+    ...normalized,
+    steps: [...steps.slice(0, insertAt), ...multisiteSteps, ...steps.slice(insertAt)],
   }
 }
 

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -2,6 +2,7 @@ import { redactError, redactString, type RuntimeCreateSpec } from "@automattic/w
 import type { BrowserProbeNetworkPolicySummary, BrowserProbePreviewMode, BrowserProbePreviewRouting } from "./browser-artifacts.js"
 import { argValue, commaListArg, strictBooleanArg } from "./commands.js"
 import type { Page, Route } from "playwright"
+import { playgroundSiteSeedMultisiteTopology, playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 const BROWSER_PREVIEW_ROUTE_DRAIN_TIMEOUT_MS = 5_000
 const BROWSER_PREVIEW_ROUTE_DOCUMENT_FETCH_ATTEMPTS = 3
@@ -110,9 +111,10 @@ export function browserPreviewRouting(args: string[], runtimeSpec: RuntimeCreate
 }
 
 export function browserPreviewTopology(args: string[], runtimeSpec: RuntimeCreateSpec | undefined, localPreviewOrigin: string, upstreamRuntimeOrigin?: string): BrowserPreviewTopology {
-  const routedHosts = commaListArg(args, "route-host")
+  const declaredTopology = playgroundSiteSeedMultisiteTopology(runtimeSpec)
+  const routedHosts = [...new Set([...commaListArg(args, "route-host"), ...(declaredTopology?.routeHosts ?? [])])]
   const preview = browserPreviewRouting(args, runtimeSpec, localPreviewOrigin)
-  applyCanonicalRoutedPreviewOrigin(preview, runtimeSpec?.preview?.siteUrl, routedHosts)
+  applyCanonicalRoutedPreviewOrigin(preview, playgroundSiteSeedPrimaryUrl(runtimeSpec) ?? runtimeSpec?.preview?.siteUrl, routedHosts)
   const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
 
   return {

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -1,4 +1,4 @@
-import { playgroundBlueprint } from "./blueprint.js"
+import { playgroundRuntimeBlueprint } from "./blueprint.js"
 import { PlaygroundCliExitError, type PlaygroundCliBufferedOutput } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
 import { startProgrammaticPlaygroundServer } from "./programmatic-playground-runner.js"
@@ -14,6 +14,7 @@ import { resolveWordPressRelease } from "@wp-playground/wordpress"
 import { phpEnvAssignments, phpLiteral, phpWpConfigDefineAssignments } from "./php-snippets.js"
 import { stageReadonlyPlaygroundMounts, type ReadonlyMountStaging } from "./mount-materialization.js"
 import { acquirePlaygroundArchiveReference, isCustomPlaygroundWordPressArchive, maintainPlaygroundCustomArchiveCache, playgroundWordPressArchiveCacheDirectory, withPlaygroundArchiveCacheLock, type PlaygroundArchiveReference, type PlaygroundCustomArchiveCacheDiagnostic, type PlaygroundCustomArchiveCacheMaintenance } from "./playground-wordpress-archive-cache.js"
+import { playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 const DEFAULT_RUNTIME_PHP_INI_ENTRIES = { memory_limit: "512M" }
 
@@ -171,7 +172,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           ...(spec.environment.extensions?.length ? { phpExtension: spec.environment.extensions.map((extension) => extension.manifest) } : {}),
           phpIniEntries: pluginRuntimePhpIniEntries(spec),
           phpEnv: connectorSecretEnvironment(spec),
-          "site-url": spec.preview?.siteUrl,
+          "site-url": playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl,
           blueprint: playgroundCliBlueprint(spec),
         })
       } finally {
@@ -523,7 +524,7 @@ function distributionEnv(values: Record<string, unknown> | undefined): Record<st
 }
 
 function playgroundCliBlueprint(spec: RuntimeCreateSpec): unknown {
-  const blueprint = playgroundBlueprint(spec.environment.blueprint, spec.policy, spec.preview?.siteUrl)
+  const blueprint = playgroundRuntimeBlueprint(spec)
   if (blueprint !== spec.environment.blueprint) {
     return blueprint
   }

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -4,10 +4,11 @@ import { bootWordPressAndRequestHandler } from "@wp-playground/wordpress"
 import type { MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { createServer as createHttpServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http"
 import { dirname } from "node:path"
-import { playgroundBlueprint } from "./blueprint.js"
+import { playgroundRuntimeBlueprint } from "./blueprint.js"
 import { assertPhpWasmExternalExtensionsSupported } from "./php-wasm-preflight.js"
 import { phpEnvAssignments } from "./php-snippets.js"
 import type { PlaygroundCliServer, PlaygroundServerRunResponse } from "./preview-server.js"
+import { playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 const { createNodeFsMountHandler, loadNodeRuntime } = PHPWasmNode as unknown as {
   createNodeFsMountHandler(localPath: string): unknown
@@ -53,7 +54,7 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
     createPhpRuntime: () => loadNodeRuntime(phpVersion, programmaticNodeRuntimeOptions(spec, nextProcessId++)),
     maxPhpInstances: 1,
     phpVersion,
-    siteUrl: spec.preview?.siteUrl ?? "http://127.0.0.1",
+    siteUrl: playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl ?? "http://127.0.0.1",
     documentRoot: "/wordpress",
     sapiName: "cli",
     wordpressInstallMode: options.wordpressInstallMode ?? "install-from-existing-files",
@@ -179,7 +180,7 @@ function ensureVfsParentDirectory(php: ProgrammaticPHP, vfsPath: string): void {
 }
 
 async function applyBlueprint(php: ProgrammaticPHP, spec: RuntimeCreateSpec): Promise<void> {
-  const blueprint = playgroundBlueprint(spec.environment.blueprint, spec.policy, spec.preview?.siteUrl)
+  const blueprint = playgroundRuntimeBlueprint(spec)
   if (!blueprint || typeof blueprint !== "object" || !("steps" in blueprint) || !Array.isArray(blueprint.steps) || blueprint.steps.length === 0) {
     return
   }

--- a/packages/runtime-playground/src/site-seed-multisite.ts
+++ b/packages/runtime-playground/src/site-seed-multisite.ts
@@ -1,0 +1,167 @@
+import type { RuntimeCreateSpec, WorkspaceRecipeSiteSeedBootstrap } from "@automattic/wp-codebox-core"
+
+export interface PlaygroundSiteSeedMultisiteTopology {
+  install: "subdomain" | "subdirectory"
+  primary: { domain: string; path: string; title: string }
+  sites: Array<{ domain: string; path: string; title: string; primary: boolean }>
+  routeHosts: string[]
+}
+
+export function playgroundSiteSeedMultisiteTopology(spec: RuntimeCreateSpec | undefined): PlaygroundSiteSeedMultisiteTopology | undefined {
+  const bootstraps = recipeSiteSeedBootstraps(spec)
+  if (bootstraps.length === 0) return undefined
+
+  const fingerprints = new Set(bootstraps.map((bootstrap) => JSON.stringify(bootstrap)))
+  if (fingerprints.size !== 1) {
+    throw new Error("Playground mapped-domain multisite bootstrap requires all site seeds to declare the same topology.")
+  }
+
+  const bootstrap = bootstraps[0]!
+  const sites = (bootstrap.multisite?.sites ?? []).map((site) => ({
+    domain: normalizeHost(site.domain),
+    path: normalizePath(site.path),
+    title: site.title?.trim() || site.domain,
+  }))
+  if (sites.length === 0) {
+    throw new Error("Playground mapped-domain multisite bootstrap requires at least one declared site.")
+  }
+
+  const primaryDeclarations = (bootstrap.domains ?? []).filter((domain) => domain.primary)
+  if (primaryDeclarations.length > 1) {
+    throw new Error("Playground mapped-domain multisite bootstrap supports exactly one primary domain.")
+  }
+  const requestedPrimary = primaryDeclarations[0]
+    ? { domain: normalizeHost(primaryDeclarations[0].domain), path: normalizePath(primaryDeclarations[0].path) }
+    : { domain: sites[0]!.domain, path: sites[0]!.path }
+  const primaryIndex = sites.findIndex((site) => site.domain === requestedPrimary.domain && site.path === requestedPrimary.path)
+  if (primaryIndex < 0) {
+    throw new Error("Playground mapped-domain multisite primary domain must match a declared multisite site domain and path.")
+  }
+
+  const normalizedSites = sites.map((site, index) => ({ ...site, primary: index === primaryIndex }))
+  return {
+    install: bootstrap.multisite?.install ?? "subdirectory",
+    primary: normalizedSites[primaryIndex]!,
+    sites: normalizedSites,
+    routeHosts: [...new Set(normalizedSites.map((site) => site.domain))].sort(),
+  }
+}
+
+export function playgroundSiteSeedPrimaryUrl(spec: RuntimeCreateSpec | undefined): string | undefined {
+  const primary = playgroundSiteSeedMultisiteTopology(spec)?.primary
+  return primary ? `http://${primary.domain}${primary.path}` : undefined
+}
+
+export function playgroundSiteSeedMultisiteBlueprintSteps(spec: RuntimeCreateSpec): unknown[] {
+  const topology = playgroundSiteSeedMultisiteTopology(spec)
+  if (!topology) return []
+  return [
+    { step: "enableMultisite" },
+    { step: "runPHP", code: playgroundSiteSeedMultisiteSetupPhp(topology) },
+  ]
+}
+
+function recipeSiteSeedBootstraps(spec: RuntimeCreateSpec | undefined): WorkspaceRecipeSiteSeedBootstrap[] {
+  const recipe = spec?.metadata?.recipe
+  if (!isRecord(recipe)) return []
+  const inputs = isRecord(recipe.inputs) ? recipe.inputs : undefined
+  if (!inputs || !Array.isArray(inputs.siteSeeds)) return []
+  return inputs.siteSeeds.flatMap((seed) => {
+    if (!isRecord(seed) || !isRecord(seed.bootstrap) || !isRecord(seed.bootstrap.multisite) || seed.bootstrap.multisite.enabled !== true) return []
+    return [seed.bootstrap as unknown as WorkspaceRecipeSiteSeedBootstrap]
+  })
+}
+
+function normalizeHost(host: string): string {
+  const normalized = host.trim().toLowerCase().replace(/\.$/, "")
+  if (!/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(normalized)) {
+    throw new Error(`Playground mapped-domain multisite bootstrap domain must be a hostname without a scheme, path, wildcard, or port: ${host}`)
+  }
+  return normalized
+}
+
+function normalizePath(path: string | undefined): string {
+  const value = path?.trim() || "/"
+  if (!value.startsWith("/") || value.includes("//") || value.includes("?") || value.includes("#")) {
+    throw new Error(`Playground mapped-domain multisite bootstrap path must be an absolute directory path: ${value}`)
+  }
+  return value.endsWith("/") ? value : `${value}/`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function playgroundSiteSeedMultisiteSetupPhp(topology: PlaygroundSiteSeedMultisiteTopology): string {
+  const encoded = JSON.stringify(JSON.stringify(topology))
+  return `<?php
+require_once '/wordpress/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+$topology = json_decode(${encoded}, true);
+if (!is_array($topology) || !is_multisite()) {
+    throw new RuntimeException('Playground mapped-domain multisite bootstrap did not enable WordPress multisite.');
+}
+
+$config_path = ABSPATH . 'wp-config.php';
+$config = file_get_contents($config_path);
+if (!is_string($config)) {
+    throw new RuntimeException('Playground mapped-domain multisite bootstrap could not read wp-config.php.');
+}
+$subdomain = 'subdomain' === $topology['install'] ? 'true' : 'false';
+$config = preg_replace("/define\\(\\s*[\\x27\\x22]SUBDOMAIN_INSTALL[\\x27\\x22]\\s*,\\s*(?:true|false)\\s*\\);/i", "define( 'SUBDOMAIN_INSTALL', " . $subdomain . " );", $config);
+$config_lines = preg_split('/\\R/', $config);
+if (is_array($config_lines)) {
+    $config = implode("\n", array_filter($config_lines, static fn(string $line): bool => !(str_contains($line, '$' . '_SERVER') && str_contains($line, 'HTTP_HOST'))));
+}
+$host_bootstrap = <<<'WP_CODEBOX_PHP'
+/* WP_CODEBOX_DYNAMIC_MULTISITE_HOST */
+$wp_codebox_mapped_hosts = __WP_CODEBOX_MAPPED_HOSTS__;
+$wp_codebox_request_host = strtolower(preg_replace('/:[0-9]+$/', '', (string) ($_SERVER['HTTP_HOST'] ?? '')));
+if (!in_array($wp_codebox_request_host, $wp_codebox_mapped_hosts, true)) {
+    $_SERVER['HTTP_HOST'] = '__WP_CODEBOX_PRIMARY_DOMAIN__';
+}
+unset($wp_codebox_mapped_hosts, $wp_codebox_request_host);
+WP_CODEBOX_PHP;
+$host_bootstrap = str_replace('__WP_CODEBOX_PRIMARY_DOMAIN__', $topology['primary']['domain'], $host_bootstrap);
+$host_bootstrap = str_replace('__WP_CODEBOX_MAPPED_HOSTS__', var_export(array_values(array_unique(array_column($topology['sites'], 'domain'))), true), $host_bootstrap);
+$config = preg_replace('/^<\\?php\\s*/i', "<?php\n" . $host_bootstrap . "\n", $config, 1);
+if (!is_string($config) || false === file_put_contents($config_path, $config)) {
+    throw new RuntimeException('Playground mapped-domain multisite bootstrap could not persist dynamic host configuration.');
+}
+
+global $wpdb;
+$network_id = get_current_network_id();
+$main_site_id = get_main_site_id($network_id);
+$primary = $topology['primary'];
+$wpdb->update($wpdb->site, array('domain' => $primary['domain'], 'path' => $primary['path']), array('id' => $network_id), array('%s', '%s'), array('%d'));
+$wpdb->update($wpdb->blogs, array('domain' => $primary['domain'], 'path' => $primary['path']), array('blog_id' => $main_site_id), array('%s', '%s'), array('%d'));
+update_blog_option($main_site_id, 'home', 'http://' . $primary['domain'] . $primary['path']);
+update_blog_option($main_site_id, 'siteurl', 'http://' . $primary['domain'] . $primary['path']);
+update_blog_option($main_site_id, 'blogname', $primary['title']);
+
+foreach ($topology['sites'] as $site) {
+    if (!empty($site['primary'])) {
+        continue;
+    }
+    $existing = get_sites(array('network_id' => $network_id, 'domain' => $site['domain'], 'path' => $site['path'], 'number' => 1));
+    $site_id = $existing ? (int) $existing[0]->blog_id : wp_insert_site(array(
+        'domain' => $site['domain'],
+        'path' => $site['path'],
+        'network_id' => $network_id,
+        'title' => $site['title'],
+    ));
+    if (is_wp_error($site_id)) {
+        throw new RuntimeException('Playground mapped-domain multisite site creation failed: ' . $site_id->get_error_message());
+    }
+    update_blog_option((int) $site_id, 'home', 'http://' . $site['domain'] . $site['path']);
+    update_blog_option((int) $site_id, 'siteurl', 'http://' . $site['domain'] . $site['path']);
+    update_blog_option((int) $site_id, 'blogname', $site['title']);
+}
+
+clean_network_cache($network_id);
+foreach (get_sites(array('network_id' => $network_id, 'number' => 0)) as $site) {
+    clean_blog_cache($site);
+}
+`
+}

--- a/tests/playground-mapped-domain-multisite.integration.test.ts
+++ b/tests/playground-mapped-domain-multisite.integration.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-mapped-domain-multisite-"))
+const recipePath = join(root, "recipe.json")
+const seedPath = join(root, "seed.json")
+const pluginPath = join(root, "mapped-topology-fixture.php")
+const artifactsPath = join(root, "artifacts")
+
+try {
+  await writeFile(seedPath, JSON.stringify({ options: { blogdescription: "mapped topology fixture" } }))
+  await writeFile(pluginPath, mappedTopologyFixturePlugin())
+  await writeFile(recipePath, `${JSON.stringify(mappedTopologyRecipe())}\n`)
+
+  const output = await runRecipe()
+  if (output) {
+    assert.equal(output.success, true, JSON.stringify(output))
+    const topology = output.siteSeeds?.[0]?.topology
+    assert.equal(topology?.effective?.multisite, true)
+    assert.equal(topology?.effective?.install, "subdomain")
+    assert.deepEqual(topology?.browser?.routeHosts, ["alpha.example.test", "beta.example.test"])
+    assert.equal(topology?.auth?.anonymous, "exact")
+    assert.equal(topology?.auth?.crossDomainCookieParity, "not-claimed")
+    assert.deepEqual(topology?.effective?.sites?.map((site) => `${site.domain}${site.path}`), ["alpha.example.test/", "beta.example.test/"])
+
+    const probes = output.executions?.filter((execution) => execution.command === "wordpress.browser-probe") ?? []
+    assert.equal(probes.length, 3)
+    const alpha = JSON.parse(probes[0]!.stdout).summary.scriptResult
+    const beta = JSON.parse(probes[1]!.stdout).summary.scriptResult
+    const redirect = JSON.parse(probes[2]!.stdout)
+    assert.deepEqual(alpha, { page: "alpha.example.test", subresource: "alpha.example.test", rest: "alpha.example.test", blogId: 1 })
+    assert.deepEqual(beta, { page: "beta.example.test", subresource: "beta.example.test", rest: "beta.example.test", blogId: 2 })
+    assert.equal(new URL(redirect.finalUrl).hostname, "beta.example.test")
+    assert.deepEqual(redirect.summary.scriptResult, { page: "beta.example.test", subresource: "beta.example.test", rest: "beta.example.test", blogId: 2 })
+  }
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+function mappedTopologyRecipe(): Record<string, unknown> {
+  const probeScript = `
+const rest = await fetch('/wp-json/wp-codebox/v1/mapped-site').then((response) => response.json());
+const subresource = await fetch('/mapped-subresource.txt').then((response) => response.text());
+return { page: document.body.dataset.domain, subresource, rest: rest.domain, blogId: rest.blogId };`
+  return {
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { backend: "wordpress-playground", wp: "6.5" },
+    inputs: {
+      stagedFiles: [{ source: pluginPath, target: "/wordpress/wp-content/mu-plugins/mapped-topology-fixture.php" }],
+      siteSeeds: [{
+        type: "fixture",
+        name: "mapped-network",
+        source: seedPath,
+        scopes: { options: { names: ["blogdescription"] } },
+        bootstrap: {
+          multisite: {
+            enabled: true,
+            install: "subdomain",
+            sites: [
+              { domain: "alpha.example.test", path: "/", title: "Alpha" },
+              { domain: "beta.example.test", path: "/", title: "Beta" },
+            ],
+          },
+          domains: [
+            { domain: "alpha.example.test", path: "/", primary: true },
+            { domain: "beta.example.test", path: "/" },
+          ],
+        },
+      }],
+    },
+    workflow: {
+      steps: [
+        { command: "wordpress.browser-probe", args: ["url=http://alpha.example.test/mapped-page", "wait-for=load", `script=${probeScript}`, "capture=html,network"] },
+        { command: "wordpress.browser-probe", args: ["url=http://beta.example.test/mapped-page", "wait-for=load", `script=${probeScript}`, "capture=html,network"] },
+        { command: "wordpress.browser-probe", args: ["url=http://alpha.example.test/mapped-redirect", "wait-for=load", `script=${probeScript}`, "capture=html,network"] },
+      ],
+    },
+  }
+}
+
+function mappedTopologyFixturePlugin(): string {
+  return `<?php
+add_action('rest_api_init', static function (): void {
+    register_rest_route('wp-codebox/v1', '/mapped-site', array('methods' => 'GET', 'permission_callback' => '__return_true', 'callback' => static function (): array {
+        return array('blogId' => get_current_blog_id(), 'domain' => wp_parse_url(home_url('/'), PHP_URL_HOST));
+    }));
+});
+add_action('template_redirect', static function (): void {
+    $path = wp_parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+    $domain = wp_parse_url(home_url('/'), PHP_URL_HOST);
+    if ('/mapped-redirect' === $path) {
+        wp_redirect('http://beta.example.test/mapped-page');
+        exit;
+    }
+    if ('/mapped-subresource.txt' === $path) {
+        header('Content-Type: text/plain');
+        echo $domain;
+        exit;
+    }
+    if ('/mapped-page' === $path) {
+        header('Content-Type: text/html; charset=utf-8');
+        echo '<!doctype html><body data-domain="' . esc_attr($domain) . '"><link rel="preload" href="/mapped-subresource.txt" as="fetch" crossorigin></body>';
+        exit;
+    }
+});
+`
+}
+
+async function runRecipe(): Promise<RecipeRunOutput | undefined> {
+  try {
+    const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--artifacts", artifactsPath, "--json"], { cwd: process.cwd(), timeout: 300_000, maxBuffer: 4 * 1024 * 1024 })
+    return JSON.parse(result.stdout) as RecipeRunOutput
+  } catch (error) {
+    const output = recipeRunOutput(error && typeof error === "object" && "stdout" in error ? error.stdout : undefined)
+    const message = output?.phaseEvidence?.find((phase) => phase.name === "runtime_startup")?.error?.message ?? ""
+    if (/Unable to resolve Playground startup asset.*fetch failed|Could not resolve host|network is unreachable/i.test(message)) {
+      console.log("playground mapped-domain multisite integration skipped: WordPress runtime source unavailable")
+      return undefined
+    }
+    throw error
+  }
+}
+
+function recipeRunOutput(value: unknown): RecipeRunOutput | undefined {
+  if (typeof value !== "string") return undefined
+  try { return JSON.parse(value) as RecipeRunOutput } catch { return undefined }
+}
+
+interface RecipeRunOutput {
+  success?: boolean
+  siteSeeds?: Array<{ topology?: { effective?: { multisite?: boolean; install?: string; sites?: Array<{ domain: string; path: string }> }; browser?: { routeHosts?: string[] }; auth?: { anonymous?: string; crossDomainCookieParity?: string } } }>
+  executions?: Array<{ command?: string; stdout: string }>
+  phaseEvidence?: Array<{ name?: string; error?: { message?: string } }>
+}

--- a/tests/site-seed-multisite.test.ts
+++ b/tests/site-seed-multisite.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+import type { RuntimeCreateSpec, WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { playgroundRuntimeBlueprint } from "../packages/runtime-playground/src/blueprint.js"
+import { browserPreviewTopology } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { playgroundSiteSeedMultisiteTopology, playgroundSiteSeedPrimaryUrl } from "../packages/runtime-playground/src/site-seed-multisite.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: { backend: "wordpress-playground" },
+  inputs: {
+    siteSeeds: [{
+      type: "fixture",
+      name: "mapped-network",
+      source: "seed.json",
+      scopes: { options: { names: ["blogdescription"] } },
+      bootstrap: {
+        multisite: {
+          enabled: true,
+          install: "subdomain",
+          sites: [
+            { domain: "alpha.example.test", path: "/", title: "Alpha" },
+            { domain: "beta.example.test", path: "/", title: "Beta" },
+          ],
+        },
+        domains: [
+          { domain: "alpha.example.test", path: "/", primary: true },
+          { domain: "beta.example.test", path: "/" },
+        ],
+      },
+    }],
+  },
+  workflow: { steps: [] },
+}
+
+const spec = {
+  backend: "wordpress-playground",
+  environment: { version: "latest", blueprint: { steps: [{ step: "login" }] } },
+  policy: { network: "deny", filesystem: "readwrite-mounts", commands: ["wordpress.run-php"], secrets: "none", approvals: "never" },
+  metadata: { recipe },
+} as RuntimeCreateSpec
+
+assert.deepEqual(playgroundSiteSeedMultisiteTopology(spec), {
+  install: "subdomain",
+  primary: { domain: "alpha.example.test", path: "/", title: "Alpha", primary: true },
+  sites: [
+    { domain: "alpha.example.test", path: "/", title: "Alpha", primary: true },
+    { domain: "beta.example.test", path: "/", title: "Beta", primary: false },
+  ],
+  routeHosts: ["alpha.example.test", "beta.example.test"],
+})
+assert.equal(playgroundSiteSeedPrimaryUrl(spec), "http://alpha.example.test/")
+
+const blueprint = playgroundRuntimeBlueprint(spec) as { steps: Array<{ step: string; siteUrl?: string; code?: string }> }
+assert.deepEqual(blueprint.steps.map((step) => step.step), ["defineSiteUrl", "enableMultisite", "runPHP", "login"])
+assert.equal(blueprint.steps[0]?.siteUrl, "http://alpha.example.test/")
+assert.match(blueprint.steps[2]?.code ?? "", /wp_insert_site/)
+assert.match(blueprint.steps[2]?.code ?? "", /HTTP_HOST/)
+
+const browser = browserPreviewTopology([], spec, "http://127.0.0.1:9400")
+assert.deepEqual(browser.routedHosts, ["alpha.example.test", "beta.example.test"])
+assert.equal(browser.preview.effectiveOrigin, "http://alpha.example.test/")
+assert.deepEqual(browser.contextOptions(), { proxy: { server: "http://127.0.0.1:9400" } })
+assert.equal(browser.networkPolicy.allowHosts.size, 0, "first-party route derivation must not broaden external host access")
+
+const pathBasedSpec = { ...spec, metadata: { recipe: { ...recipe, inputs: {} } } } as RuntimeCreateSpec
+assert.equal(playgroundSiteSeedMultisiteTopology(pathBasedSpec), undefined)
+assert.deepEqual(playgroundRuntimeBlueprint(pathBasedSpec), { steps: [{ step: "login" }] })
+
+const unsafeRuntimeSpec = structuredClone(spec)
+const unsafeRecipe = unsafeRuntimeSpec.metadata!.recipe as WorkspaceRecipe
+unsafeRecipe.inputs!.siteSeeds![0]!.bootstrap!.multisite!.sites![0]!.domain = "alpha.example.test'; phpinfo();"
+assert.throws(() => playgroundSiteSeedMultisiteTopology(unsafeRuntimeSpec), /must be a hostname/)
+
+await withTempDir("wp-codebox-site-seed-multisite-validation-", async (directory) => {
+  await writeFile(join(directory, "seed.json"), JSON.stringify({ options: { blogdescription: "fixture" } }))
+  const unsupported = structuredClone(recipe)
+  unsupported.runtime = { backend: "custom-runtime" }
+  const issues = await validateWorkspaceRecipeSemantics(unsupported, join(directory, "recipe.json"))
+  assert.match(issues.find((issue) => issue.code === "unsupported-site-seed-multisite-bootstrap")?.message ?? "", /does not provide executable.*Select wordpress/i)
+
+  const invalid = structuredClone(recipe)
+  invalid.inputs!.siteSeeds![0]!.bootstrap!.domains![0]!.domain = "https://alpha.example.test:8443"
+  const invalidIssues = await validateWorkspaceRecipeSemantics(invalid, join(directory, "recipe.json"))
+  assert.ok(invalidIssues.some((issue) => issue.code === "invalid-site-seed-bootstrap-domain"))
+  assert.ok(invalidIssues.some((issue) => issue.code === "unmatched-site-seed-bootstrap-domain"))
+})
+
+console.log("site seed mapped-domain multisite contract ok")


### PR DESCRIPTION
## Summary
- execute the existing `siteSeed.bootstrap.multisite` and `domains` contract in the Playground backend before fixture import
- create deterministic WordPress network/site identities, derive declared first-party browser route hosts, and preserve each request's original Host through page, subresource, redirect, and REST traffic
- emit requested/effective topology and explicit anonymous/auth cookie-fidelity evidence while failing unsupported backends and invalid topology declarations closed

Closes #2136

## Architecture and layer ownership
- `runtime-core` remains unchanged and backend-agnostic; the existing generic recipe contract is used directly
- `runtime-playground` owns Playground blueprint compilation, dynamic `wp-config.php` host selection, WordPress site creation, and mapped-host browser routing
- the CLI owns backend capability validation and recipe-run topology evidence
- WordPress core APIs (`wp_insert_site`, `get_sites`, network/blog options) provide site storage and request resolution; no consumer router or parallel topology abstraction was added

## Requested/effective topology evidence
Each executable site seed reports `wp-codebox/site-seed-topology/v1` with:
- the original requested bootstrap declaration
- effective network id/domain/path and ordered site id/domain/path mappings
- effective subdomain/subdirectory install mode
- derived first-party route hosts and preserved Host identity
- unchanged external network access policy

The runtime verifies the persisted dynamic-host marker and every declared site identity before fixture import continues.

## Browser and network policy
Declared site hosts are routed through the existing local preview proxy and forwarded-host plumbing. They are not added to `allow-host` and do not broaden external network access. Runtime validation independently rejects schemes, ports, wildcards, paths in domains, and unsafe topology paths before values can reach generated PHP.

## Cookie fidelity
- anonymous mapped-domain behavior is tested as exact
- fixture-user auth remains materialized separately for each routed host using the existing storage-state path
- evidence explicitly reports `per-host-materialized` and `crossDomainCookieParity: not-claimed`; this PR does not claim production shared-cookie/domain-cookie parity

## Backward compatibility
Recipes without enabled site-seed multisite bootstrap retain their existing blueprint and path-based behavior. Existing site-seed tests pass unchanged. Unsupported custom backends receive an actionable validation/runtime diagnostic instead of metadata-only execution.

## Tests
- `npm run build`
- `npm run test:site-seed-multisite`
- `npm exec -- tsx tests/recipe-site-seeds.test.ts`
- `npm run test:playground-mapped-domain-multisite-integration`
- `npm run test:browser-preview-routing`
- `npm run test:browser-routed-command-security`
- `npm exec -- tsx tests/playground-cli-runner-bootstrap-ini.test.ts`
- `npm exec -- tsx tests/programmatic-playground-runner.test.ts`
- `npm run test:schema-parity`
- `npm run test:recipe-validation-descriptors`
- `npm run test:recipe-run-provenance`
- `npm run test:fixture-auth-storage-state`
- `npm run test:recipe-user-session`
- `npm run wp-codebox -- schema recipe --json`
- `git diff --check`

The real Playground integration creates two mapped sites and proves page identity, a root-relative subresource, cross-host redirect, and root-relative REST resolution on both blogs. `npm run check` reaches the pre-existing unrelated command-registry failure tracked in #1745. The pre-existing docs boundary failure is tracked in #2061.

## Residual limitations
- local mapped origins use HTTP because the existing local Playground routed-origin provider does not claim HTTPS fidelity
- mapped-domain auth is per-host materialization, not shared cross-domain cookie fidelity
- declarations remain bounded by the existing 25-site schema limit

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode investigated the existing recipe, Playground, browser routing, auth, and evidence contracts; implemented the change; diagnosed Playground's generated fixed-host multisite configuration; and authored and ran the tests. Chris Huber owns review and product decisions.