### PR TITLE
Add content-addressed Cloudflare canonical restore packs

### DIFF
--- a/packages/runtime-cloudflare/src/canonical-restore-pack.ts
+++ b/packages/runtime-cloudflare/src/canonical-restore-pack.ts
@@ -1,0 +1,160 @@
+import { decodeZip, encodeZip } from "@php-wasm/stream-compression"
+
+export const CANONICAL_RESTORE_PACK_SCHEMA = "wp-codebox/cloudflare-canonical-restore-pack/v1"
+export const CANONICAL_RESTORE_PACK_TOMBSTONES = "metadata/wp-content-deleted.json"
+export const MAX_RESTORE_PACK_BYTES = 256 * 1024 * 1024
+export const MAX_RESTORE_PACK_DECODED_BYTES = 192 * 1024 * 1024
+
+export interface CanonicalRestorePackFile {
+  path: string
+  objectKey: string
+  sha256: string
+  size: number
+}
+
+export interface CanonicalRestorePackMetadata {
+  schema: typeof CANONICAL_RESTORE_PACK_SCHEMA
+  objectKey: string
+  sha256: string
+  size: number
+  fileCount: number
+  decodedBytes: number
+}
+
+export interface RestorePackContents {
+  markdown: Array<{ path: string; bytes: Uint8Array }>
+  uploads: Array<{ path: string; bytes: Uint8Array }>
+  wpContent: Array<{ path: string; bytes: Uint8Array }>
+  wpContentDeleted: string[]
+}
+
+export interface RestorePackBucket {
+  get(key: string): Promise<{ size: number; arrayBuffer(): Promise<ArrayBuffer> } | null>
+}
+
+type Domain = "markdown" | "uploads" | "wp-content"
+
+interface RestorePackSource {
+  domain: Domain
+  file: { path: string; size: number }
+  bytes: Uint8Array
+}
+
+export async function createCanonicalRestorePack(
+  root: string,
+  contents: RestorePackContents,
+): Promise<{ metadata: CanonicalRestorePackMetadata; bytes: Uint8Array }> {
+  const sources: RestorePackSource[] = [
+    ...contents.markdown.map((file) => ({ domain: "markdown" as const, file: metadata(file), bytes: file.bytes })),
+    ...contents.uploads.map((file) => ({ domain: "uploads" as const, file: metadata(file), bytes: file.bytes })),
+    ...contents.wpContent.map((file) => ({ domain: "wp-content" as const, file: metadata(file), bytes: file.bytes })),
+  ].sort((left, right) => entryName(left.domain, left.file.path).localeCompare(entryName(right.domain, right.file.path)))
+  const tombstones = JSON.stringify({ wpContentDeleted: contents.wpContentDeleted })
+  const files = [
+    ...sources.map(({ domain, file, bytes }) => new File([bytes as Uint8Array<ArrayBuffer>], entryName(domain, file.path), { lastModified: 0 })),
+    new File([tombstones], CANONICAL_RESTORE_PACK_TOMBSTONES, { lastModified: 0, type: "application/json" }),
+  ]
+  const bytes = new Uint8Array(await new Response(encodeZip(files)).arrayBuffer())
+  if (bytes.byteLength > MAX_RESTORE_PACK_BYTES) throw new Error("Canonical restore pack exceeds its compressed byte budget.")
+  const sha256 = await sha256Hex(bytes)
+  return {
+    metadata: {
+      schema: CANONICAL_RESTORE_PACK_SCHEMA,
+      objectKey: `${root}/restore-packs/${sha256}.zip`,
+      sha256,
+      size: bytes.byteLength,
+      fileCount: sources.length,
+      decodedBytes: sources.reduce((total, source) => total + source.bytes.byteLength, 0),
+    },
+    bytes,
+  }
+}
+
+export async function decodeCanonicalRestorePack(
+  metadata: unknown,
+  root: string,
+  files: { markdown: CanonicalRestorePackFile[]; uploads: CanonicalRestorePackFile[]; wpContent: CanonicalRestorePackFile[]; wpContentDeleted: string[] },
+  bytes: Uint8Array,
+): Promise<RestorePackContents> {
+  validateCanonicalRestorePackMetadata(metadata, root, files)
+  const pack = metadata as CanonicalRestorePackMetadata
+  if (bytes.byteLength !== pack.size || await sha256Hex(bytes) !== pack.sha256) throw new Error("Canonical restore pack failed compressed integrity validation.")
+  const expected = new Map<string, { domain: Domain; file: CanonicalRestorePackFile }>()
+  for (const [domain, domainFiles] of [["markdown", files.markdown], ["uploads", files.uploads], ["wp-content", files.wpContent]] as const) {
+    for (const file of domainFiles) expected.set(entryName(domain, file.path), { domain, file })
+  }
+  const restored: RestorePackContents = { markdown: [], uploads: [], wpContent: [], wpContentDeleted: [] }
+  const seen = new Set<string>()
+  let decodedBytes = 0
+  let tombstones = false
+  try {
+    for await (const entry of decodeZip(new Blob([bytes as Uint8Array<ArrayBuffer>]).stream())) {
+      if (entry.name.endsWith("/") || seen.has(entry.name)) throw new Error("Canonical restore pack contains an invalid ZIP entry.")
+      seen.add(entry.name)
+      if (entry.name === CANONICAL_RESTORE_PACK_TOMBSTONES) {
+        const expectedTombstones = JSON.stringify({ wpContentDeleted: files.wpContentDeleted })
+        if (entry.size !== new TextEncoder().encode(expectedTombstones).byteLength) throw new Error("Canonical restore pack tombstones do not match its manifest.")
+        const raw = await entry.text()
+        if (raw !== expectedTombstones) throw new Error("Canonical restore pack tombstones do not match its manifest.")
+        tombstones = true
+        continue
+      }
+      const source = expected.get(entry.name)
+      if (!source) throw new Error("Canonical restore pack contains an unexpected ZIP entry.")
+      if (entry.size !== source.file.size || decodedBytes + entry.size > pack.decodedBytes) throw new Error("Canonical restore pack file failed size validation.")
+      const entryBytes = new Uint8Array(await entry.arrayBuffer())
+      decodedBytes += entryBytes.byteLength
+      if (entryBytes.byteLength !== source.file.size || await sha256Hex(entryBytes) !== source.file.sha256) {
+        throw new Error("Canonical restore pack file failed integrity validation.")
+      }
+      if (source.domain === "markdown") restored.markdown.push({ path: source.file.path, bytes: entryBytes })
+      else if (source.domain === "uploads") restored.uploads.push({ path: source.file.path, bytes: entryBytes })
+      else restored.wpContent.push({ path: source.file.path, bytes: entryBytes })
+    }
+  } catch (error) {
+    throw new Error(`Canonical restore pack could not be decoded: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  if (!tombstones || seen.size !== expected.size + 1 || decodedBytes !== pack.decodedBytes) throw new Error("Canonical restore pack is incomplete.")
+  restored.wpContentDeleted = [...files.wpContentDeleted]
+  return restored
+}
+
+export async function readCanonicalRestorePack(
+  bucket: RestorePackBucket,
+  metadata: CanonicalRestorePackMetadata,
+  root: string,
+  files: { markdown: CanonicalRestorePackFile[]; uploads: CanonicalRestorePackFile[]; wpContent: CanonicalRestorePackFile[]; wpContentDeleted: string[] },
+): Promise<RestorePackContents> {
+  validateCanonicalRestorePackMetadata(metadata, root, files)
+  const object = await bucket.get(metadata.objectKey)
+  if (!object) throw new Error("Canonical restore pack is missing.")
+  if (object.size !== metadata.size) throw new Error("Canonical restore pack compressed size does not match its manifest.")
+  return decodeCanonicalRestorePack(metadata, root, files, new Uint8Array(await object.arrayBuffer()))
+}
+
+export function validateCanonicalRestorePackMetadata(
+  value: unknown,
+  root: string,
+  files: { markdown: CanonicalRestorePackFile[]; uploads: CanonicalRestorePackFile[]; wpContent: CanonicalRestorePackFile[] },
+): asserts value is CanonicalRestorePackMetadata {
+  if (!value || typeof value !== "object") throw new Error("Canonical restore pack metadata is invalid.")
+  const pack = value as Partial<CanonicalRestorePackMetadata>
+  const fileCount = files.markdown.length + files.uploads.length + files.wpContent.length
+  const decodedBytes = [...files.markdown, ...files.uploads, ...files.wpContent].reduce((total, file) => total + file.size, 0)
+  if (pack.schema !== CANONICAL_RESTORE_PACK_SCHEMA || typeof pack.sha256 !== "string" || !/^[a-f0-9]{64}$/.test(pack.sha256)
+    || pack.objectKey !== `${root}/restore-packs/${pack.sha256}.zip` || typeof pack.size !== "number" || !Number.isSafeInteger(pack.size) || pack.size < 1 || pack.size > MAX_RESTORE_PACK_BYTES
+    || pack.fileCount !== fileCount || pack.decodedBytes !== decodedBytes || decodedBytes > MAX_RESTORE_PACK_DECODED_BYTES) throw new Error("Canonical restore pack metadata is invalid.")
+}
+
+function metadata(file: { path: string; bytes: Uint8Array }): { path: string; size: number } {
+  return { path: file.path, size: file.bytes.byteLength }
+}
+
+function entryName(domain: Domain, path: string): string {
+  return `${domain}/${path}`
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as Uint8Array<ArrayBuffer>)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")
+}

--- a/packages/runtime-cloudflare/src/worker.ts
+++ b/packages/runtime-cloudflare/src/worker.ts
@@ -37,6 +37,7 @@ import wordpressRuntimeArtifactManifest from "../assets/wordpress-runtime-artifa
 import wordpressStaticArtifactManifest from "../assets/wordpress-static-artifact.json" with { type: "json" }
 import sqliteIntegrationArtifactManifest from "../assets/sqlite-database-integration-artifact.json" with { type: "json" }
 import staticSiteImporterArtifactManifest from "../assets/static-site-importer-artifact.json" with { type: "json" }
+import { createCanonicalRestorePack, decodeCanonicalRestorePack, validateCanonicalRestorePackMetadata, type CanonicalRestorePackMetadata } from "./canonical-restore-pack.js"
 
 const PHP_VERSION = "8.5.8"
 const wordpressStaticArtifact = wordpressStaticArtifactManifest as WordPressStaticArtifactManifest
@@ -400,6 +401,7 @@ interface MarkdownManifest extends MarkdownPointer {
   uploads?: MarkdownManifestFile[]
   wpContent?: MarkdownManifestFile[]
   wpContentDeleted?: string[]
+  restorePack?: CanonicalRestorePackMetadata
 }
 
 interface RuntimeFile {
@@ -493,6 +495,9 @@ interface PublicationInvocationEvidence {
 
 const cachedRuntimes = new Map<string, { baseRevision: string; promise: Promise<Runtime>; state: "pending" | "ready" }>()
 const LEASE_ACQUISITION_TIMEOUT_MS = 100_000
+const MAX_MARKDOWN_FILES = 5_000
+const MAX_MARKDOWN_FILE_BYTES = 16 * 1024 * 1024
+const MAX_MARKDOWN_TOTAL_BYTES = 64 * 1024 * 1024
 
 async function resetCanonicalWordPress(request: Request, env: RuntimeEnv, coordinator: RevisionCoordinator, site: SiteContext): Promise<Response> {
   if (request.method !== "POST") return new Response("Canonical reset requires POST.", { status: 405 })
@@ -1447,6 +1452,15 @@ async function putImmutableJson(bucket: R2Bucket, key: string, serialized: strin
   if (!existing || await existing.text() !== serialized) throw new Error(`Immutable R2 object conflicts with existing content: ${key}.`)
 }
 
+async function putImmutableBytes(bucket: R2Bucket, key: string, bytes: Uint8Array, contentType: string): Promise<void> {
+  const created = await bucket.put(key, bytes, { onlyIf: { etagDoesNotMatch: "*" }, httpMetadata: { contentType } })
+  if (created) return
+  const existing = await bucket.get(key)
+  if (!existing || existing.size !== bytes.byteLength || await sha256Hex(new Uint8Array(await existing.arrayBuffer())) !== await sha256Hex(bytes)) {
+    throw new Error(`Immutable R2 object conflicts with existing content: ${key}.`)
+  }
+}
+
 function wordPressPageCacheKey(request: Request, pointer: MarkdownPointer, site: SiteContext): Request {
   const url = new URL(request.url)
   url.searchParams.set("__wp_codebox_revision", pointer.revision)
@@ -1822,13 +1836,26 @@ async function readCanonicalRevision(bucket: R2Bucket, pointer: MarkdownPointer,
     return manifest
   }
   const manifest = trace ? await trace.measure("canonical.manifest.read", readManifest) : await readManifest()
+  const objectEvidence = { markdownFiles: manifest.files.length, markdownBytes: sumManifestFileBytes(manifest.files), uploadFiles: manifest.uploads?.length ?? 0, uploadBytes: sumManifestFileBytes(manifest.uploads ?? []), wpContentFiles: manifest.wpContent?.length ?? 0, wpContentBytes: sumManifestFileBytes(manifest.wpContent ?? []), wpContentDeleted: manifest.wpContentDeleted?.length ?? 0 }
+  if (manifest.restorePack !== undefined) {
+    const restorePack = manifest.restorePack
+    validateCanonicalRestorePackMetadata(restorePack, siteStorageKeys(site).root, { markdown: manifest.files, uploads: manifest.uploads ?? [], wpContent: manifest.wpContent ?? [] })
+    const fetchPack = async () => {
+      const object = await bucket.get(restorePack.objectKey)
+      if (!object) throw new Error("Canonical restore pack is missing.")
+      if (object.size !== restorePack.size) throw new Error("Canonical restore pack compressed size does not match its manifest.")
+      return new Uint8Array(await object.arrayBuffer())
+    }
+    const pack = trace ? await trace.measure("canonical.restore-pack.fetch", fetchPack, { requests: 1, bytes: restorePack.size }) : await fetchPack()
+    const restore = () => decodeCanonicalRestorePack(restorePack, siteStorageKeys(site).root, { markdown: manifest.files, uploads: manifest.uploads ?? [], wpContent: manifest.wpContent ?? [], wpContentDeleted: manifest.wpContentDeleted ?? [] }, pack)
+    return trace ? trace.measure("canonical.restore-pack.verify-decode", restore, { requests: 0, bytes: restorePack.decodedBytes, files: restorePack.fileCount }) : restore()
+  }
   const hydrate = () => Promise.all([
     readManifestFiles(bucket, manifest.files, "Markdown"),
     readManifestFiles(bucket, manifest.uploads ?? [], "upload"),
     readManifestFiles(bucket, manifest.wpContent ?? [], "wp-content"),
   ])
-  const objectEvidence = { markdownFiles: manifest.files.length, markdownBytes: sumManifestFileBytes(manifest.files), uploadFiles: manifest.uploads?.length ?? 0, uploadBytes: sumManifestFileBytes(manifest.uploads ?? []), wpContentFiles: manifest.wpContent?.length ?? 0, wpContentBytes: sumManifestFileBytes(manifest.wpContent ?? []), wpContentDeleted: manifest.wpContentDeleted?.length ?? 0 }
-  const [markdown, uploads, wpContent] = trace ? await trace.measure("canonical.objects.hydrate", hydrate, objectEvidence) : await hydrate()
+  const [markdown, uploads, wpContent] = trace ? await trace.measure("canonical.objects.hydrate", hydrate, { ...objectEvidence, requests: manifest.files.length + (manifest.uploads?.length ?? 0) + (manifest.wpContent?.length ?? 0) }) : await hydrate()
   return { markdown, uploads, wpContent, wpContentDeleted: manifest.wpContentDeleted ?? [] }
 }
 
@@ -1838,6 +1865,7 @@ async function readManifestFiles(bucket: R2Bucket, files: MarkdownManifestFile[]
   return Promise.all(files.map(async (file): Promise<RuntimeFile> => {
     const object = await bucket.get(file.objectKey)
     if (!object) throw new Error(`R2 ${label} object is missing: ${file.objectKey}`)
+    if (object.size !== file.size) throw new Error(`R2 ${label} object failed size validation: ${file.objectKey}`)
     const bytes = new Uint8Array(await object.arrayBuffer())
     if (bytes.byteLength !== file.size || await sha256Hex(bytes) !== file.sha256) throw new Error(`R2 ${label} object failed integrity validation: ${file.objectKey}`)
     return { path: file.path, bytes }
@@ -1933,7 +1961,19 @@ async function persistMarkdownManifest(bucket: R2Bucket, files: MarkdownManifest
   const manifestKey = `${siteStorageKeys(site).markdownRevisionPrefix}/${revision}.json`
   const persistedAt = new Date().toISOString()
   const pointer: MarkdownPointer = { revision, manifestKey, persistedAt }
-  const manifest: MarkdownManifest = { ...pointer, files, uploads, wpContent, wpContentDeleted }
+  validateMarkdownManifestFiles(files, site)
+  validateUploadManifestFiles(uploads, site)
+  validateWpContentManifestFiles(wpContent, site)
+  validateWpContentDeletedPaths(wpContentDeleted)
+  // Canonical objects remain authoritative; independently re-read them before deriving the pack.
+  const [markdown, restoredUploads, restoredWpContent] = await Promise.all([
+    readManifestFiles(bucket, files, "Markdown"),
+    readManifestFiles(bucket, uploads, "upload"),
+    readManifestFiles(bucket, wpContent, "wp-content"),
+  ])
+  const pack = await createCanonicalRestorePack(siteStorageKeys(site).root, { markdown, uploads: restoredUploads, wpContent: restoredWpContent, wpContentDeleted })
+  await putImmutableBytes(bucket, pack.metadata.objectKey, pack.bytes, "application/zip")
+  const manifest: MarkdownManifest = { ...pointer, files, uploads, wpContent, wpContentDeleted, restorePack: pack.metadata }
   await bucket.put(manifestKey, JSON.stringify(manifest), {
     httpMetadata: { contentType: "application/json" },
   })
@@ -1950,20 +1990,25 @@ async function readMarkdownManifest(bucket: R2Bucket, pointer: MarkdownPointer, 
   validateUploadManifestFiles(manifest.uploads ?? [], site)
   validateWpContentManifestFiles(manifest.wpContent ?? [], site)
   validateWpContentDeletedPaths(manifest.wpContentDeleted ?? [])
+  if (manifest.restorePack !== undefined) validateCanonicalRestorePackMetadata(manifest.restorePack, siteStorageKeys(site).root, { markdown: manifest.files, uploads: manifest.uploads ?? [], wpContent: manifest.wpContent ?? [] })
   return manifest
 }
 
 function validateMarkdownManifestFiles(files: MarkdownManifestFile[], site: SiteContext): void {
   const prefix = `${siteStorageKeys(site).markdownObjectPrefix}/`
+  if (!Array.isArray(files) || files.length > MAX_MARKDOWN_FILES) throw new Error("Canonical Markdown manifest files are invalid.")
   const paths = new Set<string>()
+  let total = 0
   for (const file of files) {
     if (!file || typeof file !== "object" || !isCanonicalRelativePath(file.path) || paths.has(file.path)
       || typeof file.sha256 !== "string" || !/^[a-f0-9]{64}$/.test(file.sha256)
-      || file.objectKey !== `${prefix}${file.sha256}` || !Number.isSafeInteger(file.size) || file.size < 0) {
+      || file.objectKey !== `${prefix}${file.sha256}` || !Number.isSafeInteger(file.size) || file.size < 0 || file.size > MAX_MARKDOWN_FILE_BYTES) {
       throw new Error("Canonical Markdown manifest files are invalid.")
     }
     paths.add(file.path)
+    total += file.size
   }
+  if (total > MAX_MARKDOWN_TOTAL_BYTES) throw new Error("Canonical Markdown manifest files exceed their byte budget.")
 }
 
 function canonicalBootstrapSetupCode(passwordFile: string, origin: string): string {

--- a/scripts/cloudflare-local-gate.mjs
+++ b/scripts/cloudflare-local-gate.mjs
@@ -81,6 +81,7 @@ try {
   await stopWorker()
   await startWorker()
   const restartedAdmin = await assertAuthenticatedDashboard(new URL("/wp-admin/", origin))
+  await assertRestorePackHydration("repeated canonical mutations after restart")
   if (coordinator === "durable-object") {
     await assertCanonicalPost(post.id, updatedPost.title, restartedAdmin, "updated post after restart")
   }
@@ -137,7 +138,7 @@ try {
   if (conflicting.status !== "conflict" || conflictStateAfter.version !== duplicateStateBefore.version || conflictStateAfter.pointer?.revision !== duplicateStateBefore.pointer?.revision) throw new Error("Conflicting static artifact replay changed canonical state.")
   await assertTwoSiteIsolation()
   assertRuntimePhaseTraceSummaries()
-  console.log(`Cloudflare local runtime gate passed with ${coordinator} coordination: canonical full-boot probe, explanatory homepage, complete block styles, coordinator-free R2 publication reads, login, dashboard, post editor, concurrent canonical mutations, authenticated REST post and media creation, plugin ZIP installation and activation, direct R2 upload serving, frontend/admin/editor assets, cold-restart persistence, and bounded durable scheduled callback execution.`)
+  console.log(`Cloudflare local runtime gate passed with ${coordinator} coordination: canonical full-boot probe, one-pack restore hydration after repeated mutations, explanatory homepage, complete block styles, coordinator-free R2 publication reads, login, dashboard, post editor, concurrent canonical mutations, authenticated REST post and media creation, plugin ZIP installation and activation, direct R2 upload serving, frontend/admin/editor assets, cold-restart persistence, and bounded durable scheduled callback execution.`)
   }
 } finally {
   await stopWorker()
@@ -978,6 +979,23 @@ function assertRuntimePhaseTraceSummaries() {
     if (!phaseNames.has(phase)) throw new Error(`Cloudflare runtime gate did not emit the required ${phase} phase.`)
   }
   if (summaries.some((summary) => !Number.isFinite(summary.totalMs) || !Array.isArray(summary.phases) || summary.phases.reduce((total, phase) => total + phase.durationMs, 0) > summary.totalMs + 1)) throw new Error("Cloudflare runtime gate received an invalid phase trace summary.")
+}
+
+async function assertRestorePackHydration(label) {
+  const deadline = Date.now() + 2_000
+  let packHydrations = []
+  while (Date.now() < deadline) {
+    packHydrations = runtimePhaseTraceSummaries(output).filter((summary) => {
+      const fetch = summary.phases?.find((phase) => phase.name === "canonical.restore-pack.fetch")
+      const decode = summary.phases?.find((phase) => phase.name === "canonical.restore-pack.verify-decode")
+      const legacy = summary.phases?.find((phase) => phase.name === "canonical.objects.hydrate")
+      return !legacy && fetch?.evidence?.requests === 1 && decode?.evidence?.requests === 0 && Number.isSafeInteger(fetch.evidence?.bytes) && Number.isSafeInteger(decode.evidence?.files)
+    })
+    if (packHydrations.length) break
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  if (!packHydrations.length) throw new Error(`Cold restart did not prove one-pack canonical restore hydration for ${label}; expected exactly one R2 pack read and zero legacy object reads in the restore phases.`)
+  console.log(`Restore-pack hydration passed for ${coordinator}: ${label}; one R2 pack read replaced per-file canonical reads.`)
 }
 
 function runtimePhaseTraceSummaries(rawOutput) {

--- a/tests/cloudflare-runtime.test.ts
+++ b/tests/cloudflare-runtime.test.ts
@@ -8,6 +8,7 @@ import { decodeZip, encodeZip } from "@php-wasm/stream-compression"
 import { RUNTIME_COMMAND_RESULT_SCHEMA } from "../packages/runtime-core/src/runtime-contracts.js"
 import { CLOUDFLARE_RUNTIME_HEALTH_MARKER, CLOUDFLARE_RUNTIME_HEALTH_SCHEMA, cloudflareRuntimeHealthResponse } from "../packages/runtime-cloudflare/src/health-envelope.js"
 import { leaseRetryDelayMs } from "../packages/runtime-cloudflare/src/lease-retry.js"
+import { CANONICAL_RESTORE_PACK_SCHEMA, createCanonicalRestorePack, decodeCanonicalRestorePack, readCanonicalRestorePack, type CanonicalRestorePackFile, type CanonicalRestorePackMetadata } from "../packages/runtime-cloudflare/src/canonical-restore-pack.js"
 import { MUTATION_DIAGNOSTIC_SCHEMA, mutationRetentionContract } from "../packages/runtime-cloudflare/src/mutation-memory.js"
 import { selectOperatorCoordinator } from "../packages/runtime-cloudflare/src/operator-coordinator.js"
 import { canonicalPublicRoute, normalizePublishedRoutes, PUBLISHED_REVISION_SCHEMA, publishedPageObjectKey, publishedRevisionObjectKey, R2_PUBLISHED_CURRENT_KEY, validatePublishedRevision } from "../packages/runtime-cloudflare/src/published-reader.js"
@@ -71,6 +72,60 @@ test("Cloudflare wp-content manifests allow bounded user code and reject runtime
   assert.throws(() => validateWpContentManifestFiles([{ ...valid[0], objectKey: "sites/default/uploads/objects/foreign" }]), /invalid file/)
   assert.doesNotThrow(() => validateWpContentDeletedPaths(["themes/example/style.css"]))
   assert.throws(() => validateWpContentDeletedPaths(["themes/z/style.css", "themes/a/style.css"]), /non-deterministic/)
+})
+
+test("Cloudflare canonical restore packs are deterministic, fail closed, and use one R2 read", async () => {
+  const text = new TextEncoder()
+  const root = "sites/default"
+  const digest = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex")
+  const file = (path: string, value: string, prefix: string): CanonicalRestorePackFile => {
+    const bytes = text.encode(value)
+    const sha256 = digest(bytes)
+    return { path, size: bytes.byteLength, sha256, objectKey: `${prefix}/${sha256}` }
+  }
+  const markdown = [file("posts/hello.md", "hello", "sites/default/markdown/objects"), file("state/options.md", "options", "sites/default/markdown/objects")]
+  const uploads = [file("2026/07/image.txt", "image", "sites/default/uploads/objects")]
+  const wpContent = [file("plugins/example/plugin.php", "<?php", "sites/default/wp-content/objects")]
+  const files = { markdown, uploads, wpContent, wpContentDeleted: ["themes/example/style.css"] }
+  const contents = {
+    markdown: [{ path: markdown[0].path, bytes: text.encode("hello") }, { path: markdown[1].path, bytes: text.encode("options") }],
+    uploads: [{ path: uploads[0].path, bytes: text.encode("image") }],
+    wpContent: [{ path: wpContent[0].path, bytes: text.encode("<?php") }],
+    wpContentDeleted: files.wpContentDeleted,
+  }
+  const first = await createCanonicalRestorePack(root, contents)
+  const second = await createCanonicalRestorePack(root, { ...contents, markdown: [...contents.markdown].reverse(), uploads: [...contents.uploads].reverse(), wpContent: [...contents.wpContent].reverse() })
+  assert.deepEqual(first.bytes, second.bytes, "fixed timestamps and sorted entries make equivalent packs byte-identical")
+  assert.equal(first.metadata.schema, CANONICAL_RESTORE_PACK_SCHEMA)
+  let reads = 0
+  const restored = await readCanonicalRestorePack({ get: async (key) => {
+    reads++
+    return key === first.metadata.objectKey ? { size: first.bytes.byteLength, arrayBuffer: async () => first.bytes.slice().buffer } : null
+  } }, first.metadata, root, files)
+  assert.equal(reads, 1)
+  assert.deepEqual(restored, contents)
+  await assert.rejects(() => readCanonicalRestorePack({ get: async () => null }, first.metadata, root, files), /missing/)
+  await assert.rejects(() => decodeCanonicalRestorePack(first.metadata, root, files, new Uint8Array([...first.bytes, 0])), /integrity/)
+  await assert.rejects(() => decodeCanonicalRestorePack({ ...first.metadata, sha256: "a".repeat(64) }, root, files, first.bytes), /metadata/)
+
+  const metadata = async (bytes: Uint8Array): Promise<CanonicalRestorePackMetadata> => {
+    const sha256 = digest(bytes)
+    return { schema: CANONICAL_RESTORE_PACK_SCHEMA, objectKey: `${root}/restore-packs/${sha256}.zip`, sha256, size: bytes.byteLength, fileCount: 4, decodedBytes: 22 }
+  }
+  const zip = async (entries: Array<[string, string]>) => {
+    const stream = encodeZip(entries.map(([name, value]) => new File([value], name, { lastModified: 0 })))
+    return new Uint8Array(await new Response(stream).arrayBuffer())
+  }
+  const incomplete = await zip([[`markdown/${markdown[0].path}`, "hello"], [`markdown/${markdown[1].path}`, "options"], [`uploads/${uploads[0].path}`, "image"], ["metadata/wp-content-deleted.json", JSON.stringify({ wpContentDeleted: files.wpContentDeleted })]])
+  await assert.rejects(async () => decodeCanonicalRestorePack(await metadata(incomplete), root, files, incomplete), /incomplete/)
+  const mismatched = await zip([[`markdown/${markdown[0].path}`, "HELLO"], [`markdown/${markdown[1].path}`, "options"], [`uploads/${uploads[0].path}`, "image"], [`wp-content/${wpContent[0].path}`, "<?php"], ["metadata/wp-content-deleted.json", JSON.stringify({ wpContentDeleted: files.wpContentDeleted })]])
+  await assert.rejects(async () => decodeCanonicalRestorePack(await metadata(mismatched), root, files, mismatched), /integrity/)
+  const duplicate = await zip([[`markdown/${markdown[0].path}`, "hello"], [`markdown/${markdown[0].path}`, "hello"], [`markdown/${markdown[1].path}`, "options"], [`uploads/${uploads[0].path}`, "image"], [`wp-content/${wpContent[0].path}`, "<?php"], ["metadata/wp-content-deleted.json", JSON.stringify({ wpContentDeleted: files.wpContentDeleted })]])
+  await assert.rejects(async () => decodeCanonicalRestorePack(await metadata(duplicate), root, files, duplicate), /invalid ZIP entry/)
+  const traversal = await zip([["markdown/../escape.md", "hello"], [`markdown/${markdown[1].path}`, "options"], [`uploads/${uploads[0].path}`, "image"], [`wp-content/${wpContent[0].path}`, "<?php"], ["metadata/wp-content-deleted.json", JSON.stringify({ wpContentDeleted: files.wpContentDeleted })]])
+  await assert.rejects(async () => decodeCanonicalRestorePack(await metadata(traversal), root, files, traversal), /unexpected ZIP entry/)
+  const tombstoneMismatch = await zip([[`markdown/${markdown[0].path}`, "hello"], [`markdown/${markdown[1].path}`, "options"], [`uploads/${uploads[0].path}`, "image"], [`wp-content/${wpContent[0].path}`, "<?php"], ["metadata/wp-content-deleted.json", JSON.stringify({ wpContentDeleted: [] })]])
+  await assert.rejects(async () => decodeCanonicalRestorePack(await metadata(tombstoneMismatch), root, files, tombstoneMismatch), /tombstones/)
 })
 
 test("Cloudflare health response preserves the Codebox execution envelope", async () => {


### PR DESCRIPTION
## Summary
Replace per-file canonical cold hydration with one deterministic, content-addressed restore-pack read while preserving canonical R2 objects as authority.

## What changed
- Persist and strictly validate deterministic restore packs; hydrate pack-backed revisions through one R2 object read while retaining bounded legacy manifest hydration; add fail-closed corruption coverage and restart evidence for Durable Object and D1 coordinators.

## How to test
1. Run `npm run test:cloudflare-runtime`; expect Cloudflare unit and contract tests plus TypeScript pass.
2. Run `npm run cloudflare:local-gate`; expect Durable Object restart proves one restore-pack read and no legacy object hydration.
3. Run `npm run cloudflare:local-gate:d1`; expect D1 restart proves one restore-pack read and no legacy object hydration.

## Compatibility
Existing manifests without restore-pack metadata continue through bounded authoritative object hydration. Referenced missing, corrupt, or divergent packs fail closed. Canonical Markdown, upload, and wp-content objects remain independently written and authoritative.

## Evidence
- Base unchanged since verification: main remains at bfc6ef7dbf070c9c92ece9003d80157fe21ba508.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/wp-codebox/issues/2135
- Verified finalization base: main at bfc6ef7dbf070c9c92ece9003d80157fe21ba508
- cloudflare-runtime: passed (Full Cloudflare tests and TypeScript passed) (Passed)
- d1-restart: passed (One-pack restart hydration passed; cold 602ms, warm 4ms) (Passed)
- durable-object-restart: passed (One-pack restart hydration passed; cold 621ms, warm 4ms) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** I inspected the existing Cloudflare persistence and hydration paths, implemented the restore-pack contract, hardened integrity and extraction bounds after reviewing the diff, added behavioral coverage, and interpreted the local restart evidence; a second OpenCode review found no further code changes.

## Source relationships
- Closes #2135
