### PR TITLE
Add disposable MySQL storage policy

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -803,14 +803,14 @@ function validateRecipeRuntimeServices(recipe: WorkspaceRecipe, addIssue: (code:
         const name = service.configuration[field]
         if (name && exposedEnvironment.has(name)) addIssue("runtime-service-admin-env-exposed", `${path}.configuration.${field}`, `External service administration environment must remain host-only: ${name}`)
       }
-      for (const field of ["image", "rootAuthentication", "foreignKeyTargetPolicy"] as const) {
+      for (const field of ["image", "storage", "rootAuthentication", "foreignKeyTargetPolicy"] as const) {
         if (service.configuration[field] !== undefined) addIssue("unsupported-external-runtime-service-option", `${path}.configuration.${field}`, `External MySQL services do not support ${field}.`)
       }
     }
     if (service.configuration?.provider === "native") {
       if (service.kind !== "mysql") addIssue("unsupported-runtime-service-provider", `${path}.configuration.provider`, "The native provider supports only MySQL-compatible services.")
       if (service.configuration.engine !== "mariadb") addIssue("unsupported-native-runtime-service-engine", `${path}.configuration.engine`, "The native provider requires engine=mariadb.")
-      for (const field of ["externalService", "hostEnv", "portEnv", "usernameEnv", "passwordEnv", "image", "rootAuthentication", "foreignKeyTargetPolicy", "responseStatus", "responseBody"] as const) {
+      for (const field of ["externalService", "hostEnv", "portEnv", "usernameEnv", "passwordEnv", "image", "storage", "rootAuthentication", "foreignKeyTargetPolicy", "responseStatus", "responseBody"] as const) {
         if (service.configuration[field] !== undefined) addIssue("unsupported-native-runtime-service-option", `${path}.configuration.${field}`, `Native MariaDB services do not accept ${field}.`)
       }
     }

--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -37,6 +37,7 @@ export interface RuntimeServiceEvidence {
   }
   controls?: RuntimeServiceControlResult[]
   memory?: { budgetMiB: number; observedRssMiB?: number }
+  storage?: "tmpfs" | "disk"
 }
 
 export class RuntimeServiceProvisionError extends Error {
@@ -109,11 +110,12 @@ const defaultDependencies: RuntimeServiceDependencies = {
   environment: process.env,
 }
 
-export function runtimeServicePlan(services: WorkspaceRecipeRuntimeService[]): Array<{ id: string; kind: string; provider: string; version: string; bind: "loopback" | "configured"; port: "ephemeral" | "configured"; persistentVolume: false; configuration?: WorkspaceRecipeRuntimeService["configuration"]; outputs: Record<string, string> }> {
+export function runtimeServicePlan(services: WorkspaceRecipeRuntimeService[]): Array<{ id: string; kind: string; provider: string; version: string; bind: "loopback" | "configured"; port: "ephemeral" | "configured"; persistentVolume: false; storage?: "tmpfs" | "disk"; configuration?: WorkspaceRecipeRuntimeService["configuration"]; outputs: Record<string, string> }> {
   return services.map((service) => {
     const provider = runtimeServiceProvider(service)
     const external = provider.name === "external"
-    return { id: service.id, kind: service.kind, provider: provider.name, version: provider.version(service), bind: external ? "configured" : "loopback", port: external ? "configured" : "ephemeral", persistentVolume: false, ...(service.configuration ? { configuration: service.configuration } : {}), outputs: service.outputs }
+    const storage = provider === mysqlDockerProvider ? service.configuration?.storage ?? "tmpfs" : undefined
+    return { id: service.id, kind: service.kind, provider: provider.name, version: provider.version(service), bind: external ? "configured" : "loopback", port: external ? "configured" : "ephemeral", persistentVolume: false, ...(storage ? { storage } : {}), ...(service.configuration ? { configuration: service.configuration } : {}), outputs: service.outputs }
   })
 }
 
@@ -255,8 +257,9 @@ function runtimeServiceProvider(service: WorkspaceRecipeRuntimeService): Runtime
 async function provisionMysqlDockerService(service: WorkspaceRecipeRuntimeService, dependencies: RuntimeServiceDependencies, context: RuntimeServiceProvisionContext, evidenceList: RuntimeServiceEvidence[]): Promise<ManagedRuntimeService> {
   const { signal } = context
   const engine = service.configuration?.engine ?? "mysql"
+  const storage = service.configuration?.storage ?? "tmpfs"
   const image = mysqlDockerImage(service)
-  const evidence: RuntimeServiceEvidence = { id: service.id, kind: service.kind, provider: "docker", version: image, readiness: "pending", lifecycle: "provisioning" }
+  const evidence: RuntimeServiceEvidence = { id: service.id, kind: service.kind, provider: "docker", version: image, readiness: "pending", lifecycle: "provisioning", storage }
   evidenceList.push(evidence)
   const container = `wp-codebox-${service.id}-${dependencies.randomBytes(6).toString("hex")}`
   const password = dependencies.randomBytes(24).toString("base64url")
@@ -267,7 +270,8 @@ async function provisionMysqlDockerService(service: WorkspaceRecipeRuntimeServic
   const childEnvironment = { ...process.env, [`${environmentPrefix}_DATABASE`]: "runtime", [`${environmentPrefix}_USER`]: "runtime", [`${environmentPrefix}_PASSWORD`]: password, ...rootEnvironment }
   const foreignKeyTargetPolicy = service.configuration?.foreignKeyTargetPolicy
   const mysqlArguments = engine === "mysql" && foreignKeyTargetPolicy ? [`--restrict-fk-on-non-standard-key=${foreignKeyTargetPolicy === "indexed" ? "OFF" : "ON"}`] : []
-  const runArgs = ["run", "--detach", "--name", container, "--label", "wp-codebox.managed=true", "--publish", "127.0.0.1::3306", "--tmpfs", "/var/lib/mysql", "--env", `${environmentPrefix}_DATABASE`, "--env", `${environmentPrefix}_USER`, "--env", `${environmentPrefix}_PASSWORD`, "--env", rootEnvironmentName, image, ...mysqlArguments]
+  const storageArgs = storage === "disk" ? ["--mount", "type=volume,destination=/var/lib/mysql"] : ["--tmpfs", "/var/lib/mysql"]
+  const runArgs = ["run", "--detach", "--name", container, "--label", "wp-codebox.managed=true", "--publish", "127.0.0.1::3306", ...storageArgs, "--env", `${environmentPrefix}_DATABASE`, "--env", `${environmentPrefix}_USER`, "--env", `${environmentPrefix}_PASSWORD`, "--env", rootEnvironmentName, image, ...mysqlArguments]
   let started = false
   try {
     throwIfAborted(signal)
@@ -1439,7 +1443,7 @@ async function releaseServices(services: ManagedRuntimeService[]): Promise<void>
 async function releaseService(container: string, evidence: RuntimeServiceEvidence, dependencies: RuntimeServiceDependencies, signal?: AbortSignal): Promise<void> {
   if (evidence.teardown === "completed") return
   try {
-    await dependencies.execute("docker", ["rm", "--force", container], { signal, timeout: 30_000 })
+    await dependencies.execute("docker", ["rm", "--force", "--volumes", container], { signal, timeout: 30_000 })
     evidence.lifecycle = "released"
     evidence.teardown = "completed"
   } catch (error) {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -952,6 +952,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
               provider: { enum: ["docker", "external", "native"] },
               externalService: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
               engine: { enum: ["mysql", "mariadb"] },
+              storage: { enum: ["tmpfs", "disk"] },
               rootAuthentication: { enum: ["generated-password", "empty-password"] },
               foreignKeyTargetPolicy: { enum: ["unique-only", "indexed"] },
               hostEnv: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -144,6 +144,7 @@ export interface WorkspaceRecipeRuntimeService {
     provider?: "docker" | "external" | "native"
     externalService?: string
     engine?: "mysql" | "mariadb"
+    storage?: "tmpfs" | "disk"
     rootAuthentication?: "generated-password" | "empty-password"
     foreignKeyTargetPolicy?: "unique-only" | "indexed"
     hostEnv?: string

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -13,7 +13,7 @@ import { validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../pack
 
 const service = { id: "test-db", kind: "mysql", outputs: { host: "DB_HOST", port: "DB_PORT", password: "DB_PASSWORD" } } as const
 const plan = runtimeServicePlan([service])
-assert.deepEqual(plan, [{ id: "test-db", kind: "mysql", provider: "docker", version: "mysql:8.4", bind: "loopback", port: "ephemeral", persistentVolume: false, outputs: service.outputs }])
+assert.deepEqual(plan, [{ id: "test-db", kind: "mysql", provider: "docker", version: "mysql:8.4", bind: "loopback", port: "ephemeral", persistentVolume: false, storage: "tmpfs", outputs: service.outputs }])
 assert.equal(parseLoopbackPort("127.0.0.1:44001\n"), 44001)
 assert.throws(() => parseLoopbackPort("0.0.0.0:3306"), /loopback/)
 const auxiliaryServices = [
@@ -32,6 +32,9 @@ const emptyRootService = { ...service, configuration: { rootAuthentication: "emp
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [emptyRootService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
 const indexedForeignKeyService = { ...service, configuration: { foreignKeyTargetPolicy: "indexed" as const } }
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [indexedForeignKeyService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+const diskStorageService = { ...service, configuration: { storage: "disk" as const } }
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [diskStorageService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+assert.deepEqual(runtimeServicePlan([diskStorageService])[0]?.storage, "disk")
 const mariaDbService = { ...service, configuration: { engine: "mariadb" as const, rootAuthentication: "empty-password" as const } }
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [mariaDbService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
 assert.equal(runtimeServicePlan([mariaDbService])[0]?.version, "mariadb:11.4")
@@ -139,6 +142,22 @@ assert.equal(calls[0]?.args[0], "image", "the provider checks the image before s
 await provisioned.release()
 await provisioned.release()
 assert.equal(calls.filter((call) => call.args[0] === "rm").length, 1, "release is idempotent")
+assert.deepEqual(calls.find((call) => call.args[0] === "rm")?.args.slice(0, 3), ["rm", "--force", "--volumes"])
+
+const diskCalls: Array<{ args: string[] }> = []
+const diskProvisioned = await provisionRuntimeServices([diskStorageService], { dependencies: {
+  ...dependencies,
+  async execute(command, args, options) {
+    diskCalls.push({ args })
+    return await dependencies.execute(command, args, options)
+  },
+} })
+assert.deepEqual(diskProvisioned.evidence[0]?.storage, "disk")
+const diskRunCall = diskCalls.find((call) => call.args[0] === "run")
+assert.deepEqual(diskRunCall?.args.slice(diskRunCall.args.indexOf("--mount"), diskRunCall.args.indexOf("--mount") + 2), ["--mount", "type=volume,destination=/var/lib/mysql"])
+assert.equal(diskRunCall?.args.includes("--tmpfs"), false, "disk storage does not allocate a tmpfs datadir")
+await diskProvisioned.release()
+assert.deepEqual(diskCalls.find((call) => call.args[0] === "rm")?.args.slice(0, 3), ["rm", "--force", "--volumes"], "release removes anonymous Docker volumes")
 
 const missingProviderDependencies: RuntimeServiceDependencies = {
   ...dependencies,


### PR DESCRIPTION
## Summary
Let Docker MySQL recipes choose default tmpfs or disposable disk-backed storage while preserving provider-owned cleanup.

## What changed
- Added a typed tmpfs-or-disk storage policy to recipe contracts, planning, and evidence; disk mode uses an anonymous Docker volume; teardown removes managed volumes idempotently.

## How to test
1. Run `npx tsx tests/runtime-services.test.ts`; expect Disk mode emits an anonymous volume mount, omits tmpfs, records storage evidence, and removes volumes during teardown..
2. Run `npm run test:runtime-services-lifecycle`; expect Success and failure cleanup remain idempotent..

## Compatibility
The default remains tmpfs. External and native MySQL providers explicitly reject the Docker-only storage field. Existing lifecycle ownership remains unchanged, with volume removal added to Docker teardown.

## Evidence
- Base unchanged since verification: main remains at 89cb2f9a91fb12afeb0b8ecd6c55816e1a8a1cac.
- CI expected: WP Codebox pull-request checks
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/wp-codebox/issues/2143
- Verified finalization base: main at 89cb2f9a91fb12afeb0b8ecd6c55816e1a8a1cac
- build: passed (Passed)
- docker-runtime-services: passed (Passed)
- runtime-service-lifecycle: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenAI GPT-5.6 Terra inspected the Docker runtime-service provider, drafted the generic storage-policy implementation and tests, and assisted with deterministic verification; Chris Huber reviewed the diff and owns the final change.

## Source relationships
- Closes #2143
