### PR TITLE
Support bundled Playground PHP extensions

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -223,6 +223,7 @@ export async function runRecipe(options: RecipeRunOptions, interruption?: Recipe
       blueprint: plan.runtime.blueprint,
       assets: resolveRecipeRuntimeAssets(recipe, recipeDirectory),
       extensions: resolveRecipeRuntimeExtensionManifests(recipe, recipeDirectory),
+      bundledExtensions: recipe.runtime?.bundledExtensions,
     }
     const effectivePreview = effectiveRecipePreview(recipe.runtime?.preview, options)
     const runtimeCreateSpec = {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { BROWSER_PROBE_CHROMIUM_PROFILE_IDS, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, browserEnvironment, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateRuntimePolicy, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { BROWSER_PROBE_CHROMIUM_PROFILE_IDS, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS, assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, browserEnvironment, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateRuntimePolicy, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { commandValidationDescriptorFor, effectivePolicyCommandsFor, type CommandArgValidationDescriptor } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPluginSource, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { loadConfiguredRuntimeOverlayDescriptors, registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
@@ -146,6 +146,7 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
   validateRecipeRuntimeOverlays(recipe.runtime?.overlays, recipePath)
   validateRecipeRuntimeAssets(recipe.runtime?.assets, recipePath)
   validateRecipeRuntimeExtensions(recipe.runtime?.extensions, recipePath)
+  validateRecipeRuntimeBundledExtensions(recipe.runtime?.bundledExtensions, recipePath)
   validateRecipeRuntimeWordPressInstallMode(recipe.runtime?.wordpressInstallMode, recipePath)
   validateRecipeRuntimePreview(recipe.runtime?.preview, recipePath)
   validateRecipeMounts(recipe.inputs?.mounts, "mounts", recipePath)
@@ -366,6 +367,16 @@ function validateRecipeRuntimeExtensions(extensions: NonNullable<WorkspaceRecipe
     }
     if (/^[a-z][a-z0-9+.-]*:/i.test(extension.manifest) && !/^https:\/\//i.test(extension.manifest)) {
       throw new Error(`Recipe runtime extensions[${index}] manifest URL must use HTTPS: ${recipePath}`)
+    }
+  }
+}
+
+function validateRecipeRuntimeBundledExtensions(extensions: NonNullable<WorkspaceRecipe["runtime"]>["bundledExtensions"] | undefined, recipePath: string): void {
+  if (extensions === undefined) return
+  if (!Array.isArray(extensions)) throw new Error(`Recipe runtime bundledExtensions must be an array: ${recipePath}`)
+  for (const [index, extension] of extensions.entries()) {
+    if (!RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS.includes(extension)) {
+      throw new Error(`Recipe runtime bundledExtensions[${index}] must be one of: ${RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS.join(", ")}: ${recipePath}`)
     }
   }
 }

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -138,6 +138,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             description: "External PHP.wasm extension manifests loaded before PHP starts. External extensions require a JSPI runtime.",
             items: { $ref: "#/$defs/phpWasmExtensionManifest" },
           },
+          bundledExtensions: {
+            type: "array",
+            description: "Allowlisted PHP extensions bundled with the Playground runtime.",
+            items: { enum: ["intl", "redis", "memcached", "xdebug"] },
+          },
           backendPackage: { $ref: "#/$defs/runtimeBackendPackage" },
           stack: { $ref: "#/$defs/runtimeStack" },
           overlays: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -3,7 +3,7 @@ import type { RuntimePolicy } from "./runtime-policy.js"
 import { SANDBOX_WORKSPACE_ROOT } from "./runtime-action-adapter.js"
 import type { ArtifactFileDigest, ArtifactManifestFile, ArtifactSpec, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import type { HostToolDefinition, HostToolRegistry } from "./host-tool-registry.js"
-import type { BackendNeutralRuntimeProvenance, RuntimePHPWasmExtensionManifest, RuntimeWorkerCount, RuntimeWordPressAssetSpec, RuntimeWordPressDatabaseSetupContract, RuntimeWordPressEnvironmentSpec, RuntimeWordPressInstallModeContract, RuntimeWordPressProvenance } from "./runtime-neutral-contracts.js"
+import type { BackendNeutralRuntimeProvenance, RuntimePHPWasmBundledExtension, RuntimePHPWasmExtensionManifest, RuntimeWorkerCount, RuntimeWordPressAssetSpec, RuntimeWordPressDatabaseSetupContract, RuntimeWordPressEnvironmentSpec, RuntimeWordPressInstallModeContract, RuntimeWordPressProvenance } from "./runtime-neutral-contracts.js"
 import type {
   RUNTIME_EPISODE_ACTION_SCHEMA,
   RUNTIME_EPISODE_OBSERVATION_SCHEMA,
@@ -654,6 +654,7 @@ export interface WorkspaceRecipe {
     preview?: RuntimePreviewSpec
     assets?: RuntimeAssetSpec
     extensions?: WorkspaceRecipePHPWasmExtensionManifest[]
+    bundledExtensions?: RuntimePHPWasmBundledExtension[]
     backendPackage?: WorkspaceRecipeRuntimeBackendPackage
     stack?: WorkspaceRecipeRuntimeStack
     overlays?: WorkspaceRecipeRuntimeOverlay[]

--- a/packages/runtime-core/src/runtime-neutral-contracts.ts
+++ b/packages/runtime-core/src/runtime-neutral-contracts.ts
@@ -59,6 +59,9 @@ export interface RuntimePHPWasmExtensionManifest {
   manifest: string
 }
 
+export const RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS = ["intl", "redis", "memcached", "xdebug"] as const
+export type RuntimePHPWasmBundledExtension = typeof RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS[number]
+
 export interface RuntimeWordPressEnvironmentSpec extends BackendNeutralEnvironmentSpec {
   blueprint?: unknown
   phpVersion?: string
@@ -67,6 +70,7 @@ export interface RuntimeWordPressEnvironmentSpec extends BackendNeutralEnvironme
   wordpressInstallMode?: RuntimeWordPressInstallModeContract
   databaseSetup?: RuntimeWordPressDatabaseSetupContract
   extensions?: RuntimePHPWasmExtensionManifest[]
+  bundledExtensions?: RuntimePHPWasmBundledExtension[]
 }
 
 export type BackendNeutralReplayStatus = "metadata-only" | "partial-replay" | "replayable-runtime-state" | "runtime-state-artifact" | "not-replayable" | (string & {})
@@ -122,6 +126,7 @@ export function normalizeRuntimeWordPressEnvironmentSpec(input: unknown): Runtim
     wordpressInstallMode: optionalString(value.wordpressInstallMode, "environment.wordpressInstallMode") as RuntimeWordPressInstallModeContract | undefined,
     databaseSetup: optionalString(value.databaseSetup, "environment.databaseSetup") as RuntimeWordPressDatabaseSetupContract | undefined,
     extensions: normalizeRuntimePHPWasmExtensionManifests(value.extensions),
+    bundledExtensions: normalizeRuntimePHPWasmBundledExtensions(value.bundledExtensions),
   })
 }
 
@@ -142,6 +147,17 @@ function normalizeRuntimePHPWasmExtensionManifests(input: unknown): RuntimePHPWa
     const manifest = requiredString(value.manifest, `environment.extensions[${index}].manifest`)
     if (manifest.includes("\0")) throw new Error(`environment.extensions[${index}].manifest must not contain a null byte.`)
     return { manifest }
+  })
+}
+
+function normalizeRuntimePHPWasmBundledExtensions(input: unknown): RuntimePHPWasmBundledExtension[] | undefined {
+  if (input === undefined) return undefined
+  if (!Array.isArray(input)) throw new Error("environment.bundledExtensions must be an array.")
+  return input.map((extension, index) => {
+    if (!RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS.includes(extension as RuntimePHPWasmBundledExtension)) {
+      throw new Error(`environment.bundledExtensions[${index}] must be one of: ${RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS.join(", ")}.`)
+    }
+    return extension as RuntimePHPWasmBundledExtension
   })
 }
 

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -37,6 +37,10 @@ export interface PlaygroundCliModule {
     phpIniEntries?: Record<string, string>
     phpEnv?: Record<string, string>
     phpExtension?: string[]
+    intl?: boolean
+    redis?: boolean
+    memcached?: boolean
+    xdebug?: boolean
   }): Promise<PlaygroundCliServer>
 }
 
@@ -170,6 +174,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           php: spec.environment.phpVersion,
           skipSqliteSetup: spec.environment.databaseSetup === "external",
           ...(spec.environment.extensions?.length ? { phpExtension: spec.environment.extensions.map((extension) => extension.manifest) } : {}),
+          ...playgroundBundledExtensionOptions(spec),
           phpIniEntries: pluginRuntimePhpIniEntries(spec),
           phpEnv: connectorSecretEnvironment(spec),
           "site-url": playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl,
@@ -222,6 +227,10 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
 
     throw error
   }
+}
+
+function playgroundBundledExtensionOptions(spec: RuntimeCreateSpec): { intl?: true; redis?: true; memcached?: true; xdebug?: true } {
+  return Object.fromEntries((spec.environment.bundledExtensions ?? []).map((extension) => [extension, true]))
 }
 
 async function withPreviewLeaseProvider(server: PlaygroundCliServer, spec: RuntimeCreateSpec): Promise<PlaygroundCliServer> {

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -12,7 +12,7 @@ import { playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 const { createNodeFsMountHandler, loadNodeRuntime } = PHPWasmNode as unknown as {
   createNodeFsMountHandler(localPath: string): unknown
-  loadNodeRuntime(phpVersion: AllPHPVersion, options?: { followSymlinks?: boolean; emscriptenOptions?: { processId?: number }; extensions?: Array<{ source: { format: "manifest"; manifestUrl: string } }> }): Promise<number>
+  loadNodeRuntime(phpVersion: AllPHPVersion, options?: { followSymlinks?: boolean; emscriptenOptions?: { processId?: number }; extensions?: Array<string | { source: { format: "manifest"; manifestUrl: string } }> }): Promise<number>
 }
 
 type AllPHPVersion = "8.5" | "8.4" | "8.3" | "8.2" | "8.1" | "8.0" | "7.4" | "5.2"
@@ -107,8 +107,11 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
   }
 }
 
-export function programmaticNodeRuntimeOptions(spec: RuntimeCreateSpec, processId: number): { followSymlinks: true; emscriptenOptions: { processId: number }; extensions?: Array<{ source: { format: "manifest"; manifestUrl: string } }> } {
-  const extensions = spec.environment.extensions?.map((extension) => ({ source: { format: "manifest" as const, manifestUrl: extension.manifest } }))
+export function programmaticNodeRuntimeOptions(spec: RuntimeCreateSpec, processId: number): { followSymlinks: true; emscriptenOptions: { processId: number }; extensions?: Array<string | { source: { format: "manifest"; manifestUrl: string } }> } {
+  const extensions = [
+    ...(spec.environment.bundledExtensions ?? []),
+    ...(spec.environment.extensions?.map((extension) => ({ source: { format: "manifest" as const, manifestUrl: extension.manifest } })) ?? []),
+  ]
   return {
     followSymlinks: true,
     emscriptenOptions: { processId },

--- a/tests/php-wasm-extension-manifests.test.ts
+++ b/tests/php-wasm-extension-manifests.test.ts
@@ -1,19 +1,22 @@
 import assert from "node:assert/strict"
 
 import { normalizeRuntimeWordPressEnvironmentSpec, validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { parseWorkspaceRecipe } from "../packages/cli/src/recipe-validation.js"
 import { resolveRecipeRuntimeExtensionManifests } from "../packages/cli/src/commands/recipe-run.js"
 import { assertPhpWasmExternalExtensionsSupported, PhpWasmExternalExtensionCapabilityError } from "../packages/runtime-playground/src/php-wasm-preflight.js"
 import { programmaticNodeRuntimeOptions } from "../packages/runtime-playground/src/programmatic-playground-runner.js"
 
 const recipe: WorkspaceRecipe = {
   schema: "wp-codebox/workspace-recipe/v1",
-  runtime: { extensions: [{ manifest: "extensions/parser/manifest.json" }] },
+  runtime: { extensions: [{ manifest: "extensions/parser/manifest.json" }], bundledExtensions: ["intl"] },
   workflow: { steps: [{ command: "wordpress.run-php" }] },
 }
 
 assert.equal(validateWorkspaceRecipeJsonSchema(recipe).valid, true)
 assert.equal(validateWorkspaceRecipeJsonSchema({ ...recipe, runtime: { extensions: [{ manifest: "", unexpected: true }] } }).valid, false)
-assert.deepEqual(normalizeRuntimeWordPressEnvironmentSpec({ kind: "wordpress", extensions: recipe.runtime?.extensions }), { kind: "wordpress", extensions: [{ manifest: "extensions/parser/manifest.json" }] })
+assert.equal(validateWorkspaceRecipeJsonSchema({ ...recipe, runtime: { bundledExtensions: ["imagick"] } }).valid, false)
+assert.throws(() => parseWorkspaceRecipe(JSON.stringify({ ...recipe, runtime: { bundledExtensions: ["imagick"] } }), "/tmp/recipe.json"), /bundledExtensions\[0\] must be one of/)
+assert.deepEqual(normalizeRuntimeWordPressEnvironmentSpec({ kind: "wordpress", extensions: recipe.runtime?.extensions, bundledExtensions: recipe.runtime?.bundledExtensions }), { kind: "wordpress", extensions: [{ manifest: "extensions/parser/manifest.json" }], bundledExtensions: ["intl"] })
 
 const resolved = resolveRecipeRuntimeExtensionManifests(recipe, "/tmp/recipe")
 assert.deepEqual(resolved, [{ manifest: "/tmp/recipe/extensions/parser/manifest.json" }])
@@ -21,12 +24,12 @@ assert.throws(() => resolveRecipeRuntimeExtensionManifests({ ...recipe, runtime:
 
 const runtimeSpec = {
   backend: "wordpress-playground",
-  environment: { kind: "wordpress", extensions: resolved },
+  environment: { kind: "wordpress", extensions: resolved, bundledExtensions: ["intl"] },
   policy: { network: "deny", filesystem: "readwrite-mounts", commands: [], secrets: "none", approvals: "never" },
 } as const
 const firstInstance = programmaticNodeRuntimeOptions(runtimeSpec, 1)
 const pooledInstance = programmaticNodeRuntimeOptions(runtimeSpec, 2)
-assert.deepEqual(firstInstance.extensions, [{ source: { format: "manifest", manifestUrl: "/tmp/recipe/extensions/parser/manifest.json" } }])
+assert.deepEqual(firstInstance.extensions, ["intl", { source: { format: "manifest", manifestUrl: "/tmp/recipe/extensions/parser/manifest.json" } }])
 assert.deepEqual(pooledInstance.extensions, firstInstance.extensions)
 assert.equal(firstInstance.emscriptenOptions.processId, 1)
 assert.equal(pooledInstance.emscriptenOptions.processId, 2)

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -38,6 +38,7 @@ try {
       databaseSetup: "external",
       assets: { wordpressDirectory: wordpressDevelopDirectory },
       extensions: [{ manifest: "/tmp/sodium/manifest.json" }],
+      bundledExtensions: ["intl", "redis"],
       blueprint: {},
     },
     policy: {
@@ -92,6 +93,9 @@ try {
   assert.equal(shouldUseProgrammaticPlaygroundRunner(spec), false)
   assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
   assert.deepEqual(calls[0].phpExtension, ["/tmp/sodium/manifest.json"])
+  assert.equal(calls[0].intl, true)
+  assert.equal(calls[0].redis, true)
+  assert.equal(calls[0].memcached, undefined)
   const sharedPhpIniPath = calls[0]["mount-before-install"]?.[0]?.hostPath
   const sharedAutoPrependPath = calls[0]["mount-before-install"]?.[1]?.hostPath
   assert.equal(typeof sharedPhpIniPath, "string")


### PR DESCRIPTION
## Summary
Allow recipes to select allowlisted PHP extensions bundled by the Playground backend independently from external manifests.

## What changed
- Added the intl, redis, memcached, and xdebug bundled-extension contract; validated recipe and normalized runtime inputs; mapped names to Playground CLI booleans and programmatic Node runtime extension identifiers.

## How to test
1. Run `npm run test:php-wasm-extension-manifests`; expect Allowlisted bundled names normalize and map independently while unknown names fail..
2. Run `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts`; expect Playground CLI receives native boolean options while external manifests remain phpExtension entries..

## Compatibility
External manifest handling remains unchanged and can be combined with bundled extensions. Unknown bundled names fail validation. Recipes without bundledExtensions produce the prior runtime options.

## Evidence
- Base unchanged since verification: main remains at 89cb2f9a91fb12afeb0b8ecd6c55816e1a8a1cac.
- CI expected: WP Codebox pull-request checks
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/wp-codebox/issues/2144
- Verified finalization base: main at 89cb2f9a91fb12afeb0b8ecd6c55816e1a8a1cac
- build: passed (Passed)
- extension-contracts: passed (Passed)
- playground-cli-mapping: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenAI GPT-5.6 Terra inspected the Playground backend contracts, drafted the bundled-extension schema and adapter mappings, and assisted with deterministic verification; Chris Huber reviewed the diff and owns the final change.

## Source relationships
- Closes #2144
