### PR TITLE
Support runtime service output aliases

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -781,10 +781,12 @@ function validateRecipeRuntimeServices(recipe: WorkspaceRecipe, addIssue: (code:
   const environment = new Set(exposedEnvironment)
   const outputOwners = new Map<string, Array<{ serviceIndex: number; output: string }>>()
   for (const [serviceIndex, service] of services.entries()) {
-    for (const [output, name] of Object.entries(service.outputs)) {
-      const owners = outputOwners.get(name) ?? []
-      owners.push({ serviceIndex, output })
-      outputOwners.set(name, owners)
+    for (const [output, names] of Object.entries(service.outputs)) {
+      for (const name of runtimeServiceOutputNames(names)) {
+        const owners = outputOwners.get(name) ?? []
+        owners.push({ serviceIndex, output })
+        outputOwners.set(name, owners)
+      }
     }
   }
   const connectorTargets = new Set<string>()
@@ -797,7 +799,9 @@ function validateRecipeRuntimeServices(recipe: WorkspaceRecipe, addIssue: (code:
     if (service.kind === "mysql" && service.outputs.password) {
       const target = "DB_PASSWORD"
       if (exposedEnvironment.has(target)) addIssue("runtime-service-secret-target-collision", `${path}.outputs.password`, `Managed connector secret target is already injected by recipe environment: ${target}`)
-      const conflictingOutput = (outputOwners.get(target) ?? []).some((owner) => !(owner.serviceIndex === index && owner.output === "password" && service.outputs.password === target))
+      const passwordOutputs = runtimeServiceOutputNames(service.outputs.password)
+      const source = passwordOutputs.includes(target) ? target : passwordOutputs[0]
+      const conflictingOutput = (outputOwners.get(target) ?? []).some((owner) => !(owner.serviceIndex === index && owner.output === "password" && source === target))
       if (conflictingOutput) addIssue("runtime-service-secret-target-collision", `${path}.outputs.password`, `Managed connector secret target collides with a managed output: ${target}`)
       if (connectorTargets.has(target)) addIssue("ambiguous-runtime-service-secret-target", `${path}.outputs.password`, `Multiple managed connectors target the same runtime environment name: ${target}`)
       connectorTargets.add(target)
@@ -831,13 +835,19 @@ function validateRecipeRuntimeServices(recipe: WorkspaceRecipe, addIssue: (code:
       smtp: /^(host|port|httpPort|url)$/,
       http: /^(host|port|url)$/,
     }
-    for (const [output, name] of Object.entries(service.outputs)) {
+    for (const [output, names] of Object.entries(service.outputs)) {
       if (!(supportedOutputs[service.kind] ?? /^$/).test(output)) addIssue("unknown-runtime-service-output", `${path}.outputs.${output}`, `Unsupported ${service.kind} service output: ${output}`)
-      if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) addIssue("invalid-runtime-service-env", `${path}.outputs.${output}`, "Runtime service environment variable names must match /^[A-Z_][A-Z0-9_]*$/.")
-      if (environment.has(name)) addIssue("duplicate-runtime-service-env", `${path}.outputs.${output}`, `Runtime service output environment variable is already declared: ${name}`)
-      environment.add(name)
+      for (const name of runtimeServiceOutputNames(names)) {
+        if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) addIssue("invalid-runtime-service-env", `${path}.outputs.${output}`, "Runtime service environment variable names must match /^[A-Z_][A-Z0-9_]*$/.")
+        if (environment.has(name)) addIssue("duplicate-runtime-service-env", `${path}.outputs.${output}`, `Runtime service output environment variable is already declared: ${name}`)
+        environment.add(name)
+      }
     }
   }
+}
+
+function runtimeServiceOutputNames(value: string | string[] | undefined): string[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value]
 }
 
 function policyHostListIncludes(policyHosts: readonly string[], boundaryHost: string): boolean {

--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -110,7 +110,7 @@ const defaultDependencies: RuntimeServiceDependencies = {
   environment: process.env,
 }
 
-export function runtimeServicePlan(services: WorkspaceRecipeRuntimeService[]): Array<{ id: string; kind: string; provider: string; version: string; bind: "loopback" | "configured"; port: "ephemeral" | "configured"; persistentVolume: false; storage?: "tmpfs" | "disk"; configuration?: WorkspaceRecipeRuntimeService["configuration"]; outputs: Record<string, string> }> {
+export function runtimeServicePlan(services: WorkspaceRecipeRuntimeService[]): Array<{ id: string; kind: string; provider: string; version: string; bind: "loopback" | "configured"; port: "ephemeral" | "configured"; persistentVolume: false; storage?: "tmpfs" | "disk"; configuration?: WorkspaceRecipeRuntimeService["configuration"]; outputs: Record<string, string | string[]> }> {
   return services.map((service) => {
     const provider = runtimeServiceProvider(service)
     const external = provider.name === "external"
@@ -238,7 +238,8 @@ function mysqlDockerImage(service: WorkspaceRecipeRuntimeService): string {
 }
 
 function mysqlRuntimeServiceSecretTargets(service: WorkspaceRecipeRuntimeService): Record<string, string> {
-  return service.outputs.password ? { DB_PASSWORD: service.outputs.password } : {}
+  const names = runtimeServiceOutputNames(service.outputs.password)
+  return names.length > 0 ? { DB_PASSWORD: names.includes("DB_PASSWORD") ? "DB_PASSWORD" : names[0] as string } : {}
 }
 
 function runtimeServiceProvider(service: WorkspaceRecipeRuntimeService): RuntimeServiceProvider {
@@ -288,7 +289,7 @@ async function provisionMysqlDockerService(service: WorkspaceRecipeRuntimeServic
     const values: Record<string, string> = { host: "127.0.0.1", port: String(port), username: "runtime", password, database: "runtime" }
     return {
       env: runtimeServiceOutputEnvironment(service, values, new Set(["password"])),
-      secretEnv: service.outputs.password ? { [service.outputs.password]: password } : {},
+      secretEnv: runtimeServiceOutputAliases(service.outputs.password, password),
       secretEnvTargets: mysqlRuntimeServiceSecretTargets(service),
       evidence,
       async control(action, options) { return await controlDockerService(container, evidence, dependencies, action, options, async (customAction) => {
@@ -498,7 +499,7 @@ async function provisionMysqlNativeService(service: WorkspaceRecipeRuntimeServic
     const values: Record<string, string> = { host: "127.0.0.1", port: String(port), username: "runtime", password, database: "runtime" }
     return {
       env: runtimeServiceOutputEnvironment(service, values, new Set(["password"])),
-      secretEnv: service.outputs.password ? { [service.outputs.password]: password } : {},
+      secretEnv: runtimeServiceOutputAliases(service.outputs.password, password),
       secretEnvTargets: mysqlRuntimeServiceSecretTargets(service),
       evidence,
       async control(action) {
@@ -1157,7 +1158,7 @@ async function provisionMysqlExternalService(service: WorkspaceRecipeRuntimeServ
     const values: Record<string, string> = { host: connection.host, port: String(connection.port), username, password, database }
     return {
       env: runtimeServiceOutputEnvironment(service, values, new Set(["password"])),
-      secretEnv: service.outputs.password ? { [service.outputs.password]: password } : {},
+      secretEnv: runtimeServiceOutputAliases(service.outputs.password, password),
       secretEnvTargets: mysqlRuntimeServiceSecretTargets(service),
       evidence,
       async control(action) {
@@ -1227,17 +1228,27 @@ function mysqlConnectionArgs(host: string, port: number, username: string): stri
 function runtimeServiceOutputEnvironment(service: WorkspaceRecipeRuntimeService, values: Record<string, string>, secretOutputs: ReadonlySet<string> = new Set()): Record<string, string> {
   return Object.fromEntries(Object.entries(service.outputs)
     .filter(([output]) => !secretOutputs.has(output))
-    .map(([output, name]) => [name, values[output] ?? ""]))
+    .flatMap(([output, names]) => runtimeServiceOutputNames(names).map((name) => [name, values[output] ?? ""])))
+}
+
+function runtimeServiceOutputAliases(names: string | string[] | undefined, value: string): Record<string, string> {
+  return Object.fromEntries(runtimeServiceOutputNames(names).map((name) => [name, value]))
+}
+
+function runtimeServiceOutputNames(value: string | string[] | undefined): string[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value]
 }
 
 function validateDeclaredRuntimeServiceSecretTargets(services: readonly WorkspaceRecipeRuntimeService[], reservedEnvNames: readonly string[]): void {
   const reserved = new Set(reservedEnvNames)
   const outputOwners = new Map<string, Array<{ serviceIndex: number; output: string }>>()
   for (const [serviceIndex, service] of services.entries()) {
-    for (const [output, name] of Object.entries(service.outputs)) {
-      const owners = outputOwners.get(name) ?? []
-      owners.push({ serviceIndex, output })
-      outputOwners.set(name, owners)
+    for (const [output, names] of Object.entries(service.outputs)) {
+      for (const name of runtimeServiceOutputNames(names)) {
+        const owners = outputOwners.get(name) ?? []
+        owners.push({ serviceIndex, output })
+        outputOwners.set(name, owners)
+      }
     }
   }
   const targets = new Map<string, string>()
@@ -1360,7 +1371,7 @@ async function provisionSimpleDockerService(
     evidence.lifecycle = "provisioned"
     const values = spec.values(ports)
     return {
-      env: Object.fromEntries(Object.entries(service.outputs).map(([output, name]) => [name, values[output] ?? ""])),
+      env: runtimeServiceOutputEnvironment(service, values),
       secretEnv: {},
       secretEnvTargets: {},
       evidence,

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -979,7 +979,12 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           outputs: {
             type: "object",
             minProperties: 1,
-            additionalProperties: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },
+            additionalProperties: {
+              anyOf: [
+                { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },
+                { type: "array", minItems: 1, uniqueItems: true, items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" } },
+              ],
+            },
           },
         },
       },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -155,8 +155,8 @@ export interface WorkspaceRecipeRuntimeService {
     responseStatus?: number
     responseBody?: string
   }
-  /** Explicit map from a provider output (for example `port`) to a runtime env name. */
-  outputs: Record<string, string>
+  /** Explicit map from a provider output (for example `port`) to one or more runtime env names. */
+  outputs: Record<string, string | string[]>
 }
 
 export interface WorkspaceRecipeRuntimeStack {

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -9,7 +9,7 @@ import { executeRuntimeServiceProcess, parseLoopbackPort, provisionRuntimeServic
 import { planWorkspaceRecipe } from "../packages/cli/src/recipe-dry-run.ts"
 import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.ts"
 import { buildWordPressPhpunitRecipe } from "../packages/runtime-core/src/recipe-builders.ts"
-import { validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.ts"
+import { validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe, type WorkspaceRecipeRuntimeService } from "../packages/runtime-core/src/index.ts"
 
 const service = { id: "test-db", kind: "mysql", outputs: { host: "DB_HOST", port: "DB_PORT", password: "DB_PASSWORD" } } as const
 const plan = runtimeServicePlan([service])
@@ -25,6 +25,12 @@ assert.deepEqual(runtimeServicePlan(auxiliaryServices).map(({ kind, version }) =
 
 const valid = validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [service] }, workflow: { steps: [{ command: "wordpress.run-php" }] } })
 assert.equal(valid.valid, true)
+const aliasedPortService: WorkspaceRecipeRuntimeService = { ...service, outputs: { ...service.outputs, port: ["DB_PORT", "TC_MYSQL_PORT"] } }
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [aliasedPortService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+const aliasedPasswordService: WorkspaceRecipeRuntimeService = { ...service, outputs: { ...service.outputs, password: ["MYSQL_PASSWORD", "DB_PASSWORD"] } }
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [aliasedPasswordService] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [{ ...service, outputs: { port: [] } }] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, false)
+assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [{ ...service, outputs: { port: ["DB_PORT", "DB_PORT"] } }] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, false)
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: auxiliaryServices }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
 const unsafe = validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [{ ...service, outputs: { port: "bad-name" } }] }, workflow: { steps: [{ command: "wordpress.run-php" }] } })
 assert.equal(unsafe.valid, false)
@@ -126,6 +132,15 @@ assert.equal(provisioned.env.DB_PORT, "41001")
 assert.equal(provisioned.env.DB_PASSWORD, undefined, "password is excluded from the non-secret output channel")
 assert.equal(provisioned.secretEnv.DB_PASSWORD, provisionedPassword)
 assert.deepEqual(provisioned.secretEnvTargets, { DB_PASSWORD: "DB_PASSWORD" })
+const aliasedProvisioned = await provisionRuntimeServices([aliasedPortService], { dependencies })
+assert.equal(aliasedProvisioned.env.DB_PORT, "41001")
+assert.equal(aliasedProvisioned.env.TC_MYSQL_PORT, "41001")
+await aliasedProvisioned.release()
+const aliasedPasswordProvisioned = await provisionRuntimeServices([aliasedPasswordService], { dependencies })
+assert.equal(aliasedPasswordProvisioned.secretEnv.MYSQL_PASSWORD, provisionedPassword)
+assert.equal(aliasedPasswordProvisioned.secretEnv.DB_PASSWORD, provisionedPassword)
+assert.deepEqual(aliasedPasswordProvisioned.secretEnvTargets, { DB_PASSWORD: "DB_PASSWORD" })
+await aliasedPasswordProvisioned.release()
 const runCall = calls.find((call) => call.args[0] === "run")
 assert.ok(runCall?.args.includes("MYSQL_PASSWORD"))
 assert.ok(runCall?.args.includes("127.0.0.1::3306"), "Docker publishes MySQL on a loopback ephemeral port")
@@ -141,7 +156,7 @@ assert.equal(runCall?.env?.DOCKER_HOST, process.env.DOCKER_HOST, "Docker provide
 assert.equal(calls[0]?.args[0], "image", "the provider checks the image before starting the service")
 await provisioned.release()
 await provisioned.release()
-assert.equal(calls.filter((call) => call.args[0] === "rm").length, 1, "release is idempotent")
+assert.equal(calls.filter((call) => call.args[0] === "rm").length, 3, "each service is released exactly once")
 assert.deepEqual(calls.find((call) => call.args[0] === "rm")?.args.slice(0, 3), ["rm", "--force", "--volumes"])
 
 const diskCalls: Array<{ args: string[] }> = []


### PR DESCRIPTION
## Summary

- allow each managed runtime-service output to populate one or more explicit environment names
- keep aliases consistent across recipe schema validation, semantic collision checks, runtime planning, and Docker/native/external providers
- preserve secret-channel handling when MySQL password outputs use aliases
- retain existing single-string output mappings

Fixes #2147.

## Verification

- `npm run build`
- `npm run test:schema-parity`
- focused `tests/runtime-services.test.ts` passes locally and on Lab
- `tests/external-mysql-runtime-service.test.ts` passes locally and on Lab
- the exact WPCOM TeamCity shard recipe that previously failed with `outputs.port must be string` now returns `valid: true` with zero issues on Lab

`npm run test:runtime-services` reaches an unrelated native MariaDB host-toolchain failure after the focused and external-provider tests pass. Locally the native readiness probe reports `bounded-filesystem-unavailable`; on Lab its unprivileged child cannot resolve `node`.

## AI Assistance

OpenAI `gpt-5.6-sol` through OpenCode identified the compiler/runner schema mismatch, implemented the generic output-alias contract, and drafted the regression tests and PR description. Chris Huber directed the work and remains responsible for the change.
