### PR TITLE
Constrain PHPUnit discovery to selected suites

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -102,7 +102,7 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
   const suffixAssignment = options.replaceDefaultMatchers ? "$suffixes = $config_suffixes;" : "$suffixes = array_merge($suffixes, $config_suffixes);"
   const prefixAssignment = options.replaceDefaultMatchers ? "$prefixes = $config_prefixes;" : "$prefixes = array_merge($prefixes, $config_prefixes);"
 
-  return `function ${options.functionName}($xml_path, $test_dir_default) {
+  return `function ${options.functionName}($xml_path, $test_dir_default, array $selected_testsuites = array()) {
     $directories = array($test_dir_default);
     $suffixes = array('Test.php');
     $prefixes = array('test-');
@@ -124,35 +124,53 @@ function phpunitConfigDiscoveryPhp(options: PhpunitConfigDiscoveryPhpOptions): s
         throw new RuntimeException('PHPUnit config could not be parsed at ' . $xml_path . ': ' . $first);
     }
     $base = ${options.basePathExpression};
+    $testsuites = $xml->xpath('//testsuite') ?: array();
+    if (!empty($selected_testsuites)) {
+        $selected = array_fill_keys($selected_testsuites, true);
+        $available = array();
+        $testsuites = array_values(array_filter($testsuites, static function($testsuite) use ($selected, &$available): bool {
+            $name = trim((string) ($testsuite['name'] ?? ''));
+            if ($name !== '') {
+                $available[$name] = true;
+            }
+            return isset($selected[$name]);
+        }));
+        $missing = array_values(array_diff($selected_testsuites, array_keys($available)));
+        if (!empty($missing)) {
+            throw new RuntimeException('Requested PHPUnit testsuite not found in config: ' . implode(', ', $missing));
+        }
+    }
     $config_dirs = array();
     $config_suffixes = array();
     $config_prefixes = array();
-    foreach ($xml->xpath('//testsuite/directory') ?: array() as $dir) {
-        $raw = trim((string) $dir);${directoryRestriction}
-        $config_dirs[] = $raw[0] === '/' ? rtrim($raw, '/') : rtrim($base . '/' . $raw, '/');
-        foreach (explode(',', (string) ($dir['suffix'] ?? '')) as $suffix) {
-            $suffix = trim($suffix);
-            if ($suffix !== '') {
-                $config_suffixes[] = $suffix;
+    foreach ($testsuites as $testsuite) {
+        foreach ($testsuite->directory as $dir) {
+            $raw = trim((string) $dir);${directoryRestriction}
+            $config_dirs[] = $raw[0] === '/' ? rtrim($raw, '/') : rtrim($base . '/' . $raw, '/');
+            foreach (explode(',', (string) ($dir['suffix'] ?? '')) as $suffix) {
+                $suffix = trim($suffix);
+                if ($suffix !== '') {
+                    $config_suffixes[] = $suffix;
+                }
+            }
+            foreach (explode(',', (string) ($dir['prefix'] ?? '')) as $prefix) {
+                $prefix = trim($prefix);
+                if ($prefix !== '') {
+                    $config_prefixes[] = $prefix;
+                }
             }
         }
-        foreach (explode(',', (string) ($dir['prefix'] ?? '')) as $prefix) {
-            $prefix = trim($prefix);
-            if ($prefix !== '') {
-                $config_prefixes[] = $prefix;
+        foreach ($testsuite->exclude as $exclude) {
+            $raw = trim((string) $exclude);
+            if ($raw !== '') {
+                $excludes[] = $raw[0] === '/' ? rtrim($raw, '/') : rtrim($base . '/' . $raw, '/');
             }
         }
-    }
-    foreach ($xml->xpath('//testsuite/exclude') ?: array() as $exclude) {
-        $raw = trim((string) $exclude);
-        if ($raw !== '') {
-            $excludes[] = $raw[0] === '/' ? rtrim($raw, '/') : rtrim($base . '/' . $raw, '/');
-        }
-    }
-    foreach ($xml->xpath('//testsuite/file') ?: array() as $file) {
-        $raw = trim((string) $file);
-        if ($raw !== '') {
-            $files[] = $raw[0] === '/' ? $raw : $base . '/' . $raw;
+        foreach ($testsuite->file as $file) {
+            $raw = trim((string) $file);
+            if ($raw !== '') {
+                $files[] = $raw[0] === '/' ? $raw : $base . '/' . $raw;
+            }
         }
     }
     if (!empty($config_dirs)) {
@@ -338,6 +356,31 @@ function ${functionName}(array $argv) {
 }`
 }
 
+function phpunitSelectedTestsuitesPhp(functionName: string): string {
+  return `function ${functionName}(array $argv): array {
+    $selected = array();
+    $args = array_slice($argv, 1);
+    for ($i = 0; $i < count($args); $i++) {
+        $value = null;
+        if ($args[$i] === '--testsuite' && isset($args[$i + 1])) {
+            $value = $args[++$i];
+        } elseif (strpos($args[$i], '--testsuite=') === 0) {
+            $value = substr($args[$i], strlen('--testsuite='));
+        }
+        if ($value === null) {
+            continue;
+        }
+        foreach (explode(',', (string) $value) as $name) {
+            $name = trim($name);
+            if ($name !== '') {
+                $selected[$name] = true;
+            }
+        }
+    }
+    return array_keys($selected);
+}`
+}
+
 function managedPhpunitConfigWriterPhp(): string {
   return `function pg_write_managed_test_config(array $extra_defines, string $table_prefix, string $database_type): string {
     $config_path = '/tmp/wp-tests-config.php';
@@ -480,6 +523,8 @@ function pg_build_phpunit_argv($raw): array {
     }
     return $phpunit_argv;
 }
+
+${phpunitSelectedTestsuitesPhp("pg_selected_phpunit_testsuites")}
 
 @file_put_contents($result_file, '');
 
@@ -1423,7 +1468,7 @@ try {
     if (!is_dir($test_dir)) {
         throw new RuntimeException('configured PHPUnit test root is not a readable directory: ' . $test_dir);
     }
-    list($directories, $suffixes, $prefixes, $excludes, $configured_files) = wp_codebox_phpunit_parse_config(${JSON.stringify(options.phpunitXml)}, $test_dir);
+    list($directories, $suffixes, $prefixes, $excludes, $configured_files) = wp_codebox_phpunit_parse_config(${JSON.stringify(options.phpunitXml)}, $test_dir, pg_selected_phpunit_testsuites($phpunit_argv));
     $test_files = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes, $configured_files);
     $test_files = pg_filter_changed_test_files($test_files, $changed_test_files_raw, $test_dir);
     if ($selected_test_file !== '') {

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -154,12 +154,14 @@ function assertPhpunitConfigurationAndDiscoveryFailures(source: string, function
   const explicitAdjacentXml = join(tempDir, "missing.xml")
   const defaultXml = join(tempDir, "default", "phpunit.xml.dist")
   const adjacentXml = join(tempDir, "default", "phpunit.xml")
+  const selectedXml = join(tempDir, "selected.xml")
   const scriptPath = join(tempDir, "assert-phpunit-config.php")
   writeFileSync(malformedXml, "<phpunit><testsuites>")
   writeFileSync(malformedAdjacentXml, "<phpunit><testsuites><testsuite><directory>must-not-mask-malformed</directory></testsuite></testsuites></phpunit>")
   writeFileSync(explicitAdjacentXml, "<phpunit><testsuites><testsuite><directory>must-not-fallback</directory></testsuite></testsuites></phpunit>")
   mkdirSync(join(tempDir, "default"), { recursive: true })
   writeFileSync(adjacentXml, "<phpunit><testsuites><testsuite><directory>fallback-tests</directory></testsuite></testsuites></phpunit>")
+  writeFileSync(selectedXml, '<phpunit><testsuites><testsuite name="first"><directory suffix="FirstTest.php">first-tests</directory></testsuite><testsuite name="second"><directory suffix="SecondTest.php">second-tests</directory></testsuite></testsuites></phpunit>')
 
   const parseConfigFunction = extractPhpFunction(source, functionName)
   const discoveryFunction = extractPhpFunction(source, discoveryFunctionName)
@@ -183,6 +185,15 @@ ${!supportsImplicitFallback ? `assert_phpunit_error(function() { ${functionName}
 assert_phpunit_error(function() { ${functionName}(${phpString(malformedXml)}, ${phpString(join(tempDir, "tests"))}); }, 'PHPUnit config could not be parsed', 'malformed config');
 assert_phpunit_error(function() { ${discoveryFunctionName}(array(${phpString(join(tempDir, "missing-tests"))}), array('Test.php'), array('test-'), array()); }, 'configured PHPUnit test directory is not a readable directory', 'missing configured directory');
 assert_phpunit_error(function() { ${discoveryFunctionName}(array(), array('Test.php'), array('test-'), array(), array(${phpString(join(tempDir, "MissingTest.php"))})); }, 'configured PHPUnit test file is not a readable PHP file', 'missing configured file');
+$selected = ${functionName}(${phpString(selectedXml)}, ${phpString(join(tempDir, "tests"))}, array('second'));
+if ($selected[0] !== array(${phpString(join(tempDir, "second-tests"))}) || !in_array('SecondTest.php', $selected[1], true) || in_array('FirstTest.php', $selected[1], true)) {
+    throw new RuntimeException('selected testsuite discovery mismatch: ' . json_encode($selected));
+}
+$multiple = ${functionName}(${phpString(selectedXml)}, ${phpString(join(tempDir, "tests"))}, array('first', 'second'));
+if ($multiple[0] !== array(${phpString(join(tempDir, "first-tests"))}, ${phpString(join(tempDir, "second-tests"))})) {
+    throw new RuntimeException('multiple testsuite discovery mismatch: ' . json_encode($multiple));
+}
+assert_phpunit_error(function() { ${functionName}(${phpString(selectedXml)}, ${phpString(join(tempDir, "tests"))}, array('missing')); }, 'Requested PHPUnit testsuite not found in config: missing', 'unknown selected testsuite');
 ${supportsImplicitFallback ? `
 $fallback = ${functionName}(${phpString(defaultXml)}, ${phpString(join(tempDir, "tests"))});
 if ($fallback[0] !== array(${phpString(join(tempDir, "default", "fallback-tests"))})) {
@@ -565,7 +576,7 @@ assert.ok(projectModeCode.includes("$base_dir = dirname($xml_real);"))
 assert.ok(projectModeCode.includes("$bootstrap_real = pg_project_bootstrap_real_path($bootstrap, $phpunit_xml, $from_config);"))
 assert.ok(projectModeCode.includes("function pg_project_bootstrap_from_config(string &$xml_path, bool $xml_is_default): string"))
 assertProjectBootstrapConfigResolution(projectModeCode, implicitProjectConfigCode)
-assert.ok(projectModeCode.includes("foreach ($xml->xpath('//testsuite/file') ?: array() as $file)"))
+assert.ok(projectModeCode.includes("foreach ($testsuite->file as $file)"))
 assert.ok(projectModeCode.includes("list($directories, $suffixes, $prefixes, $excludes, $configured_files) = wp_codebox_phpunit_parse_config"))
 assert.ok(projectModeCode.includes("$test_files = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes, $configured_files);"))
 assert.ok(projectModeCode.includes("' files=' . count($configured_files)"))
@@ -896,27 +907,32 @@ assert.ok(externalMysqlMultisiteRecipe.workflow.steps[0].args.includes("multisit
 
 const phpunitCacheAllocator = extractPhpFunction(managedModeCode, "wp_codebox_phpunit_args_private_cache_result_file")
 const phpunitArgsFunction = extractPhpFunction(managedModeCode, "wp_codebox_phpunit_args")
+const selectedTestsuitesFunction = extractPhpFunction(managedModeCode, "pg_selected_phpunit_testsuites")
 const phpunitArgsProbe = join(mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-cache-args-")), "probe.php")
 writeFileSync(phpunitArgsProbe, `<?php
 function pg_log($message) {}
 ${phpunitCacheAllocator}
 ${phpunitArgsFunction}
+${selectedTestsuitesFunction}
 echo json_encode(array(
   'first' => wp_codebox_phpunit_args(array('phpunit', '--filter', 'OnlyTest', '--cache-result-file=/wordpress/ignored.cache')),
   'second' => wp_codebox_phpunit_args(array('phpunit', '--cache-result-file', 'ignored.cache')),
   'firstMode' => fileperms(wp_codebox_phpunit_args(array('phpunit'))['cacheResultFile']) & 0777,
+  'selectedSuites' => pg_selected_phpunit_testsuites(array('phpunit', '--testsuite', 'first, second', '--testsuite=third', '--testsuite=first')),
 ));
 `)
 const phpunitArgs = JSON.parse(execFileSync("php", [phpunitArgsProbe], { encoding: "utf8" })) as {
   first: Record<string, unknown>
   second: Record<string, unknown>
   firstMode: number
+  selectedSuites: string[]
 }
 for (const argumentSet of [phpunitArgs.first, phpunitArgs.second]) {
   assert.equal(argumentSet.cacheResult, false, "PHPUnit result caching must start disabled")
   assert.match(String(argumentSet.cacheResultFile), /^\/tmp\/wp-codebox-phpunit-[a-f0-9]{48}\.cache$/, "cache file must be privately allocated under /tmp")
 }
 assert.equal(phpunitArgs.first.filter, "OnlyTest", "unrecognized caller cache options must not affect supported PHPUnit options")
+assert.deepEqual(phpunitArgs.selectedSuites, ["first", "second", "third"], "PHPUnit testsuite selectors support both CLI forms, comma lists, and stable deduplication")
 assert.notEqual(phpunitArgs.first.cacheResultFile, phpunitArgs.second.cacheResultFile, "each PHPUnit invocation must receive an unpredictable cache path")
 assert.equal(phpunitArgs.firstMode, 0o600, "the internal cache file must be private to the sandbox process")
 assert.equal(existsSync(String(phpunitArgs.first.cacheResultFile)), false, "the internal cache must be removed at PHP shutdown")


### PR DESCRIPTION
## Summary

- parse `--testsuite name` and `--testsuite=name` before XML-backed file discovery
- support comma-separated suite names with stable deduplication
- constrain suite directories, files, excludes, and matchers before loading tests
- fail deterministically when a requested suite is absent

Fixes #2150.

## Verification

- `npm run build`
- `npm exec -- tsx tests/phpunit-project-autoload.test.ts`
- `npm run test:phpunit-structured-evidence`
- `npm run test:phpunit-runtime-rejection`
- `npm run test:playground-worker-runtime-rejection`
- WPCOM comparator SHA `7ae9ae21ca30f7fc9724aecfb54a16f674f82a23`: `api-v2-agentic-commerce` discovery changed from 7,018 API-v2 tests to exactly 6 files under `bin/tests/api-v2/suites/AgenticCommerce`
- Combined with #2154, the full parity execution passed **677/677 suites**: 674 WP Codebox and 3 native, with zero failures and zero timeouts at 4 shards x 6 workers
- Reproduction: run `node scripts/run-wpcom-teamcity-parity.mjs --mode execute --allow-execute true --manifest artifacts/phpunit-profiles/teamcity-parity-manifest-7ae9ae21-corrected.json --concurrency 6 --shards 4 --timeout-multiplier 3` from the WPCOM Codebox parity workspace with the certified runtime inputs

Two broader diagnostics commands remained red on unchanged `origin/main` behavior: the exact generated-wrapper shape assertion and the local Playground fixture mount visibility integration. Raw run artifacts remain in private Lab storage and are intentionally not linked as public evidence.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode implemented the change, added executable generated-PHP regression coverage, ran local verification, and executed the Lab WPCOM proof. Chris Huber remains responsible for the change.