### PR TITLE
Reuse Playground direct input mounts

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -34,6 +34,25 @@ export interface MountMaterializationResult {
 
 export type StagedInputMaterializationResult = MountMaterializationResult
 
+export function directMountedPlaygroundStagedInputs(mounts: MountSpec[]): StagedInputMaterializationResult {
+  return {
+    materialized: 0,
+    deleted: 0,
+    skipped: 0,
+    phaseResult: materializationPhaseResult({
+      phase: "playground-staged-input-materialization",
+      status: mounts.length > 0 ? "completed" : "skipped",
+      metadata: {
+        materialized: 0,
+        deleted: 0,
+        skipped: 0,
+        mounts: mounts.length,
+        transport: "direct-nodefs-mount",
+      },
+    }),
+  }
+}
+
 export interface ReadonlyMountStaging {
   mounts: MountSpec[]
   diagnostics: MaterializationDiagnostic[]

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -21,7 +21,7 @@ import { PlaygroundCommandCrashError, assertPlaygroundResponseOk, errorMessage, 
 import { startPlaygroundCliServer, type PlaygroundCliModule } from "./playground-cli-runner.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { collectPlaygroundArtifacts } from "./runtime-artifact-helpers.js"
-import { materializePlaygroundMountsFromVfs, materializePlaygroundStagedInputs } from "./mount-materialization.js"
+import { directMountedPlaygroundStagedInputs, materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
 import { runAbilityCommand, runAdminActionInventoryCommand, runBenchCommand, runCacheChurnObservationCommand, runCorePhpunitCommand, runHttpRequestCommand, runPageLoadCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runPluginSetupCommand, runPluginStateCommand, runRestPerformanceObservationCommand, runRestRequestCommand, runRuntimeDiscoveryCommand, runRuntimeInventoryCommand, runServerPageLoadCommand, runThemeCheckCommand, runThemeSetupCommand, runWordPressExecutionActionCommand } from "./wordpress-command-runners.js"
 import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPayload, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact, type RuntimeSnapshotExportOptions } from "./runtime-snapshot.js"
 import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
@@ -337,8 +337,9 @@ class PlaygroundRuntime implements Runtime {
       return undefined
     }
 
-    const materialization = await materializePlaygroundStagedInputs(await this.bootPlayground(), mounts)
-    this.recordEvent("runtime.staged-inputs.materialized", { ...materialization, source: "host-to-vfs" })
+    await this.bootPlayground()
+    const materialization = directMountedPlaygroundStagedInputs(mounts)
+    this.recordEvent("runtime.staged-inputs.materialized", { ...materialization, source: "direct-nodefs-mount" })
     return materialization
   }
 

--- a/tests/playground-direct-mount-materialization.test.ts
+++ b/tests/playground-direct-mount-materialization.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import { access, mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { createRuntime } from "../packages/runtime-core/src/index.js"
+import { createPlaygroundRuntimeBackend } from "../packages/runtime-playground/src/index.js"
+import type { PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+await withTempDir("wp-codebox-direct-mount-materialization-", async (root) => {
+  const source = join(root, "source")
+  const wordpressDirectory = join(root, "wordpress")
+  await mkdir(source)
+  await mkdir(wordpressDirectory)
+  await writeFile(join(source, "fixture.txt"), "direct mount fixture")
+
+  let directWrites = 0
+  let mountedHostPath = ""
+  const cliModule: PlaygroundCliModule = {
+    async runCLI(options) {
+      const mount = options.mount.find((candidate) => candidate.vfsPath === "/workspace/fixture")
+      assert.ok(mount)
+      mountedHostPath = mount.hostPath
+      assert.equal(await readFile(join(mount.hostPath, "fixture.txt"), "utf8"), "direct mount fixture")
+      return {
+        serverUrl: "http://127.0.0.1:9404",
+        playground: {
+          async run() { return { text: "" } },
+          async writeFile() { directWrites++ },
+        },
+        async [Symbol.asyncDispose]() {},
+      }
+    },
+  }
+
+  const runtime = await createRuntime({
+    backend: "wordpress-playground",
+    artifactsDirectory: join(root, "artifacts"),
+    environment: {
+      kind: "wordpress",
+      name: "direct-mount-materialization",
+      version: "mounted-wordpress-source",
+      phpVersion: "8.4",
+      wordpressInstallMode: "do-not-attempt-installing",
+      assets: { wordpressDirectory },
+      blueprint: {},
+    },
+    policy: {
+      network: "deny",
+      filesystem: "readonly-mounts",
+      commands: [],
+      secrets: "none",
+      approvals: "never",
+    },
+  }, createPlaygroundRuntimeBackend({ cliModule }))
+
+  const mount = { type: "directory" as const, source, target: "/workspace/fixture", mode: "readonly" as const }
+  try {
+    await runtime.mount(mount)
+    const result = await runtime.materializeStagedInputs?.([mount]) as { phaseResult?: { status?: string; metadata?: Record<string, unknown> } }
+    assert.equal(directWrites, 0, "mounted files are not rewritten through the Playground API")
+    assert.notEqual(mountedHostPath, source, "readonly isolation still uses a private staged source")
+    assert.equal(result.phaseResult?.status, "completed")
+    assert.deepEqual(result.phaseResult?.metadata, {
+      materialized: 0,
+      deleted: 0,
+      skipped: 0,
+      mounts: 1,
+      transport: "direct-nodefs-mount",
+    })
+  } finally {
+    await runtime.destroy()
+  }
+
+  await assert.rejects(access(mountedHostPath), /ENOENT/, "readonly staging is removed with the runtime")
+})
+
+console.log("Playground staged inputs use direct NODEFS mounts")


### PR DESCRIPTION
## Summary

- treat Playground CLI NODEFS mounts as the staged-input transport instead of rewriting every mounted file through `playground.writeFile()`
- preserve readonly isolation through the existing private host-side staging layer
- emit explicit `direct-nodefs-mount` materialization evidence
- cover zero VFS rewrites, private staged sources, and runtime cleanup

Fixes #2090.

## Verification

- `npm run build`
- `npm exec -- tsx tests/playground-direct-mount-materialization.test.ts`
- `npm exec -- tsx tests/staged-input-materialization.test.ts`
- `npm exec -- tsx tests/playground-readonly-mounts.test.ts`
- `npm exec -- tsx tests/mount-materialization.test.ts`
- Full WPCOM TeamCity parity at comparator SHA `7ae9ae21ca30f7fc9724aecfb54a16f674f82a23`: **677/677 passed**, including **674/674 WP Codebox** and **3/3 native**, with zero failures and zero timeouts
- Topology: 4 shards x 6 workers, timeout multiplier 3
- Reproduction: run `node scripts/run-wpcom-teamcity-parity.mjs --mode execute --allow-execute true --manifest artifacts/phpunit-profiles/teamcity-parity-manifest-7ae9ae21-corrected.json --concurrency 6 --shards 4 --timeout-multiplier 3` from the WPCOM Codebox parity workspace with the certified runtime inputs

The full proof ran this commit combined with the independently merged PHPUnit suite-selection fix in #2153. Raw run artifacts remain in private Lab storage and are intentionally not linked as public evidence.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode implemented and tested the direct-mount change, composed it with #2153 in Lab, and ran the projected and full WPCOM parity matrices. Chris Huber remains responsible for the change.