### PR TITLE
Share PHPUnit test listing behavior

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -374,6 +374,20 @@ function ${functionName}(array $argv) {
 }`
 }
 
+function phpunitPrintTestListPhp(functionName: string): string {
+  return `function ${functionName}($test) {
+    if ($test instanceof PHPUnit\\Framework\\TestSuite) {
+        foreach ($test->tests() as $child) {
+            ${functionName}($child);
+        }
+        return;
+    }
+    if ($test instanceof PHPUnit\\Framework\\TestCase) {
+        echo get_class($test) . '::' . $test->getName() . PHP_EOL;
+    }
+}`
+}
+
 function managedPhpunitConfigWriterPhp(): string {
   return `function pg_write_managed_test_config(array $extra_defines, string $table_prefix, string $database_type): string {
     $config_path = '/tmp/wp-tests-config.php';
@@ -1525,17 +1539,7 @@ foreach (array_diff($after_classes, $before_classes) as $class_name) {
 }
 pg_stage_ok('load_tests');
 
-function wp_codebox_phpunit_print_test_list($test) {
-    if ($test instanceof PHPUnit\\Framework\\TestSuite) {
-        foreach ($test->tests() as $child) {
-            wp_codebox_phpunit_print_test_list($child);
-        }
-        return;
-    }
-    if ($test instanceof PHPUnit\\Framework\\TestCase) {
-        echo get_class($test) . '::' . $test->getName() . PHP_EOL;
-    }
-}
+${phpunitPrintTestListPhp("wp_codebox_phpunit_print_test_list")}
 
 pg_stage_begin('run_tests');
 pg_log('RUNNING ' . count($test_files) . ' TEST FILES');
@@ -1846,10 +1850,19 @@ foreach (array_diff($after_classes, $before_classes) as $class_name) {
 }
 core_pg_stage_ok('load_tests');
 
+${phpunitPrintTestListPhp("core_pg_phpunit_print_test_list")}
+
 core_pg_stage_begin('run_tests');
 core_pg_log('RUNNING ' . count($test_files) . ' TEST FILES');
 try {
     $phpunit_args = core_pg_phpunit_args($argv ?? array());
+    if (!empty($phpunit_args['listTests'])) {
+        core_pg_phpunit_print_test_list($suite);
+        core_pg_log('ALL TESTS PASSED');
+        core_pg_log('TESTS: ' . $suite->count() . ' FAILURES: 0 ERRORS: 0');
+        core_pg_stage_ok('run_tests');
+        exit(0);
+    }
     $runner = new PHPUnit\\TextUI\\TestRunner();
     $result = $runner->run($suite, $phpunit_args);
     core_pg_log($result->wasSuccessful() ? 'ALL TESTS PASSED' : 'SOME TESTS FAILED');

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -414,7 +414,7 @@ class DiscoveredTest extends PHPUnit\\Framework\\TestCase {
 
   writeFileSync(scriptPath, `<?php
 namespace PHPUnit\\Framework {
-abstract class TestCase {}
+abstract class TestCase { public function getName(): string { return 'fixture'; } }
 final class TestSuite {
     private $name;
     private $tests = array();
@@ -443,7 +443,7 @@ final class TestRunner {
 namespace {
 $test_files = array(${phpString(testFile)});
 $phpunit_argv = array('phpunit');
-$phpunit_args = array();
+$phpunit_args = getenv('LIST_TESTS') ? array('listTests' => true) : array();
 $argv = array('phpunit');
 function ${stagePrefix}_stage_begin($stage) { file_put_contents(getenv('STAGE_LOG'), 'STAGE_BEGIN:' . $stage . "\\n", FILE_APPEND); }
 function ${stagePrefix}_stage_ok($stage) { file_put_contents(getenv('STAGE_LOG'), 'STAGE_OK:' . $stage . "\\n", FILE_APPEND); }
@@ -452,7 +452,7 @@ function ${stagePrefix}_stage_fail($stage, \\Throwable $e) {
     throw $e;
 }
 function ${stagePrefix}_log($message) {}
-${stagePrefix === "core_pg" ? "function core_pg_phpunit_args($args) { return array(); }" : ""}
+${stagePrefix === "core_pg" ? "function core_pg_phpunit_args($args) { return getenv('LIST_TESTS') ? array('listTests' => true) : array(); }" : ""}
 ${generatedHarnessTail}
 }
 `)
@@ -467,6 +467,14 @@ ${generatedHarnessTail}
   assert.match(stages, /STAGE_BEGIN:run_tests/)
   assert.match(stages, /STAGE_OK:run_tests/)
   assert.doesNotMatch(stages, /STAGE_FAIL:/)
+
+  rmSync(executionMarker)
+  const listed = execFileSync("php", [scriptPath], {
+    encoding: "utf8",
+    env: { ...process.env, EXECUTION_MARKER: executionMarker, STAGE_LOG: stageLog, LIST_TESTS: "1" },
+  })
+  assert.match(listed, /DiscoveredTest::fixture/)
+  assert.equal(existsSync(executionMarker), false, `${stagePrefix} --list-tests must not execute discovered tests`)
 }
 
 const recipe = buildWordPressPhpunitRecipe({


### PR DESCRIPTION
## Summary

- generate one PHPUnit test-list printer for plugin and core modes
- honor `--list-tests` in the core runner instead of executing discovered tests
- execute both generated harness modes in list mode and prove test methods are not invoked

Fixes #2160.

## Verification

- `npm run build`
- `npm exec -- tsx tests/phpunit-project-autoload.test.ts`
- `npm run test:phpunit-structured-evidence`
- `npm run test:phpunit-runtime-rejection`
- `npm exec -- tsx tests/playground-direct-mount-materialization.test.ts`
- `npm exec -- tsx tests/playground-readonly-mounts-integration.test.ts`

Combined full WPCOM compatibility run with the WPCOM Codebox simplification candidate: **677/677 suites passed** (674 WP Codebox + 3 native), zero failures and zero timeouts, at comparator SHA `7ae9ae21ca30f7fc9724aecfb54a16f674f82a23`.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode reviewed the merged PHPUnit paths, identified the core list-mode mismatch, shared the generated behavior, and ran focused and full compatibility verification. Chris Huber remains responsible for the change.