### PR TITLE
Remove dead mount materialization helpers

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -34,25 +34,6 @@ export interface MountMaterializationResult {
 
 export type StagedInputMaterializationResult = MountMaterializationResult
 
-export function directMountedPlaygroundStagedInputs(mounts: MountSpec[]): StagedInputMaterializationResult {
-  return {
-    materialized: 0,
-    deleted: 0,
-    skipped: 0,
-    phaseResult: materializationPhaseResult({
-      phase: "playground-staged-input-materialization",
-      status: mounts.length > 0 ? "completed" : "skipped",
-      metadata: {
-        materialized: 0,
-        deleted: 0,
-        skipped: 0,
-        mounts: mounts.length,
-        transport: "direct-nodefs-mount",
-      },
-    }),
-  }
-}
-
 export interface ReadonlyMountStaging {
   mounts: MountSpec[]
   diagnostics: MaterializationDiagnostic[]
@@ -284,10 +265,6 @@ function nestedMountPaths(mounts: MountSpec[], mountIndex: number, parentTarget:
 
 function mountMaterializesVfsToHost(mount: MountSpec): boolean {
   return Boolean(mount.metadata && typeof mount.metadata === "object" && !Array.isArray(mount.metadata) && mount.metadata.materializeVfsToHost === true)
-}
-
-export async function materializePlaygroundMountsToVfs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<MountMaterializationResult> {
-  return await materializePlaygroundStagedInputs(server, mounts)
 }
 
 export async function materializePlaygroundStagedInputs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<StagedInputMaterializationResult> {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -3,7 +3,7 @@ import { AsyncLocalStorage } from "node:async_hooks"
 import { mkdir, readFile, realpath, unlink, writeFile } from "node:fs/promises"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
-import { HostToolRegistry, PREVIEW_LEASE_SCHEMA, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, RuntimeActionExecutionError, assertRuntimeCommandAllowed, assertRuntimeSecretEnvTargetsAvailable, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, previewLease, resolveArtifactPath, resolveCommandPath, runtimeCommandResultEnvelopeFromOutput, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
+import { HostToolRegistry, PREVIEW_LEASE_SCHEMA, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, RuntimeActionExecutionError, assertRuntimeCommandAllowed, assertRuntimeSecretEnvTargetsAvailable, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, materializationPhaseResult, parseCommandAgentRunRequest, previewLease, resolveArtifactPath, resolveCommandPath, runtimeCommandResultEnvelopeFromOutput, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserArtifactFileManifest, browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact, type BrowserArtifactFiles } from "./browser-artifacts.js"
@@ -21,7 +21,7 @@ import { PlaygroundCommandCrashError, assertPlaygroundResponseOk, errorMessage, 
 import { startPlaygroundCliServer, type PlaygroundCliModule } from "./playground-cli-runner.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { collectPlaygroundArtifacts } from "./runtime-artifact-helpers.js"
-import { directMountedPlaygroundStagedInputs, materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
+import { materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
 import { runAbilityCommand, runAdminActionInventoryCommand, runBenchCommand, runCacheChurnObservationCommand, runCorePhpunitCommand, runHttpRequestCommand, runPageLoadCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runPluginSetupCommand, runPluginStateCommand, runRestPerformanceObservationCommand, runRestRequestCommand, runRuntimeDiscoveryCommand, runRuntimeInventoryCommand, runServerPageLoadCommand, runThemeCheckCommand, runThemeSetupCommand, runWordPressExecutionActionCommand } from "./wordpress-command-runners.js"
 import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPayload, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact, type RuntimeSnapshotExportOptions } from "./runtime-snapshot.js"
 import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
@@ -338,7 +338,16 @@ class PlaygroundRuntime implements Runtime {
     }
 
     await this.bootPlayground()
-    const materialization = directMountedPlaygroundStagedInputs(mounts)
+    const materialization = {
+      materialized: 0,
+      deleted: 0,
+      skipped: 0,
+      phaseResult: materializationPhaseResult({
+        phase: "playground-staged-input-materialization",
+        status: "completed",
+        metadata: { materialized: 0, deleted: 0, skipped: 0, mounts: mounts.length, transport: "direct-nodefs-mount" },
+      }),
+    }
     this.recordEvent("runtime.staged-inputs.materialized", { ...materialization, source: "direct-nodefs-mount" })
     return materialization
   }


### PR DESCRIPTION
## Summary

- remove the uncalled `materializePlaygroundMountsToVfs` alias
- inline the one-use direct NODEFS materialization result into the Playground lifecycle
- preserve the publicly exported host-to-VFS materializer until a versioned API decision

Organization-wide code search found no external Automattic callers for the removed alias or the still-exported legacy materializer.

## Verification

- `npm run build`
- `npm exec -- tsx tests/playground-direct-mount-materialization.test.ts`
- `npm exec -- tsx tests/staged-input-materialization.test.ts`
- `npm exec -- tsx tests/mount-materialization.test.ts`

Combined full WPCOM compatibility run: **677/677 suites passed**, zero failures and zero timeouts, at comparator SHA `7ae9ae21ca30f7fc9724aecfb54a16f674f82a23`.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode traced package and organization-wide callers, removed only dead/internal mount helpers, and ran focused plus full compatibility verification. Chris Huber remains responsible for the change.