### PR TITLE
Disable Composer plugins when hydrating source packages

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -315,6 +315,32 @@ export function composerManagedHostEnv(): Record<string, string> {
   }
 }
 
+/**
+ * Default arguments for hydrating a source package's Composer dependencies.
+ *
+ * Hydration exists to produce an autoloader and vendor tree. It must not run
+ * package-supplied code, and it must not depend on ambient host state:
+ *
+ * - `--no-scripts` keeps package scripts from executing.
+ * - `--no-plugins` keeps Composer plugins from executing. Plugins are a
+ *   strictly more powerful hook than scripts, so allowing them would leave the
+ *   larger hole open. It also decouples hydration from the host's
+ *   `allow-plugins` policy: `composer/installers` is required by nearly every
+ *   `"type": "wordpress-plugin"` package, and without this flag Composer aborts
+ *   with `PluginManager` errors unless the host has pre-authorized it. Its only
+ *   job — relocating packages inside a real WordPress tree — is irrelevant
+ *   here, because callers mount the package at its sandbox path explicitly.
+ */
+export const COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS: readonly string[] = [
+  "install",
+  "--no-dev",
+  "--prefer-dist",
+  "--no-interaction",
+  "--no-progress",
+  "--no-scripts",
+  "--no-plugins",
+]
+
 export function composerManagedHostCommandConfig(options: {
   cwd: string
   allowedCwdRoots: string[]
@@ -325,7 +351,7 @@ export function composerManagedHostCommandConfig(options: {
 }): ManagedHostCommandConfig {
   return {
     command: "composer",
-    args: options.args ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts"],
+    args: options.args ?? [...COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS],
     cwd: options.cwd,
     env: composerManagedHostEnv(),
     allowedCwdRoots: options.allowedCwdRoots,
@@ -366,7 +392,7 @@ function installComposerDependenciesForSourcePackageSync(source: string, slug: s
   const config = composerManagedHostCommandConfig({
     cwd: source,
     allowedCwdRoots: [allowedRoot],
-    args: composerInstallArgs ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts"],
+    args: composerInstallArgs ?? [...COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS],
     label: `hydrate Composer source package ${slug}`,
   })
   const result = spawnSync(config.command, config.args, {

--- a/tests/source-package-compiler-primitives.test.ts
+++ b/tests/source-package-compiler-primitives.test.ts
@@ -3,6 +3,7 @@ import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { withTempDir } from "../scripts/test-kit.js"
 import {
+  COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS,
   compileRecipeTemplate,
   composerManagedHostCommandConfig,
   fixtureImportDeterministicIdPlan,
@@ -29,6 +30,15 @@ const composerPolicy = composerManagedHostCommandConfig({ cwd: process.cwd(), al
 assert.equal(composerPolicy.command, "composer")
 assert.deepEqual(composerPolicy.inheritedEnv, ["HOME", "COMPOSER_HOME"])
 assert.equal(composerPolicy.allowedCwdRoots?.[0], process.cwd())
+
+// Hydration produces an autoloader; it must never execute package-supplied
+// code, and must not depend on the host's `allow-plugins` configuration.
+// Without `--no-plugins`, any `"type": "wordpress-plugin"` package requiring
+// `composer/installers` aborts with a PluginManager error.
+assert.ok(composerPolicy.args?.includes("--no-scripts"), "composer hydration must not run package scripts")
+assert.ok(composerPolicy.args?.includes("--no-plugins"), "composer hydration must not run Composer plugins")
+assert.deepEqual(composerPolicy.args, [...COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS])
+assert.ok(COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS.includes("--no-plugins"))
 
 await withTempDir("wp-codebox-composer-source-", async (composerSourceRoot) => {
   await writeFile(join(composerSourceRoot, "composer.json"), JSON.stringify({ name: "example/plugin" }))


### PR DESCRIPTION
Fixes #2165

## Problem

Source-package hydration already passed `--no-scripts`, establishing the intent that hydration must not execute package-supplied code. Composer **plugins** are a strictly more powerful hook than scripts, and they were still permitted.

The practical consequence: `composer/installers` is required by nearly every `"type": "wordpress-plugin"` package. Without `--no-plugins`, hydration aborts unless the host has pre-authorized it:

```
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking composer/installers (v1.12.0)

In PluginManager.php line 752:

  composer/installers contains a Composer plugin which is blocked by your allow-plugins
  config. You may add it to the list if you consider it safe.
```

The sandbox then fatals during plugin activation and the run is lost.

## Why there was no host-side workaround

`composerManagedHostEnv()` pins Composer's home:

```ts
...(process.env.COMPOSER_HOME ? { COMPOSER_HOME: process.env.COMPOSER_HOME } : home ? { COMPOSER_HOME: join(home, ".composer") } : {}),
```

So `composer config --global allow-plugins.composer/installers true` writes to the standard global config location, which this path does not read. Configuring the pinned home instead would make sandbox reproducibility depend on ambient host state — the opposite of the guarantee a sandbox exists to provide.

## Change

Hydration needs an autoloader and vendor tree. `composer/installers`' entire job is relocating packages inside a real WordPress tree, which is irrelevant here because callers mount packages at their sandbox paths explicitly.

The default argument list was duplicated at two call sites (`composerManagedHostCommandConfig` and `installComposerDependenciesForSourcePackageSync`), which is how they could silently drift. Extracted into one exported `COMPOSER_SOURCE_PACKAGE_INSTALL_ARGS` constant with `--no-plugins` added, so both stay in agreement.

Callers passing explicit `args` / `composerInstallArgs` are unaffected.

## Verification

Extended `tests/source-package-compiler-primitives.test.ts`, which already asserted the composer policy but never its arguments. It now pins both `--no-scripts` and `--no-plugins`, and asserts the config matches the shared constant. I confirmed the test genuinely fails without the fix:

```
AssertionError [ERR_ASSERTION]: composer hydration must not run Composer plugins
```

Full `npm run build` compiles clean. Related suites pass unchanged:

- `test:source-package-compiler-primitives`
- `test:recipe-source-packages`
- `test:composer-package-overlay-revision` (real hydration smoke)
- `test:composer-package-overlay-autoload-layout`
- `test:recipe-extra-plugin-composer-autoloaders`
- `test:source-root-preparation`

## End-to-end

Reproduced against the original failure — a `homeboy` release mounting bbPress as a validation dependency. Before, the run died on `PluginManager`. After, hydration completes and the plugin activates:

```json
{ "command": "install-composer-autoloaders",
  "plugins": ["bbpress/bbpress.php"],
  "autoloaders": ["bbpress/vendor/autoload_packages.php"] }
{"activated":"bbpress\/bbpress.php"}
```

The consuming component still fails its own gate for an unrelated reason (it collects 0 PHPUnit tests because its suite is standalone host smokes without the matching backend configured) — that is a consumer configuration gap, not this path.