### PR TITLE
Deploy Cloudflare runtime through Homeboy

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,11 @@
     "nodejs": {}
   },
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
+  "deployment_provider": {
+    "extension": "cloudflare-workers",
+    "provider": "cloudflare-workers.deploy",
+    "contract": "packages/runtime-cloudflare/deploy.production.json"
+  },
   "release": {
     "package_coverage": [
       {

--- a/packages/runtime-cloudflare/deploy.production.json
+++ b/packages/runtime-cloudflare/deploy.production.json
@@ -1,0 +1,52 @@
+{
+  "schema": "homeboy/cloudflare-worker-deploy-contract/v1",
+  "repository": {
+    "worktree": ".",
+    "revision": "HEAD"
+  },
+  "wrangler": {
+    "binary": "node_modules/.bin/wrangler",
+    "config": "packages/runtime-cloudflare/wrangler.d1.jsonc",
+    "config_ref": "packages/runtime-cloudflare/wrangler.d1.jsonc"
+  },
+  "target": {
+    "worker": "wp-codebox-cloudflare-runtime",
+    "account_id": "f2248e657cd8e3f095a18e5eb92f56fc"
+  },
+  "expected_bindings": [
+    "WORDPRESS_RUNTIME_QUEUE",
+    "WORDPRESS_STATE_BUCKET",
+    "WORDPRESS_STATE_DATABASE"
+  ],
+  "secrets": [],
+  "gates": [
+    {
+      "id": "wordpress-runtime-health",
+      "url": "https://wp-codebox-cloudflare-runtime.chubes.workers.dev/?phase=health",
+      "expected_status": 200,
+      "expected_text": "wp-codebox-cloudflare-runtime-health",
+      "timeout_ms": 300000,
+      "retry": {
+        "attempts": 3,
+        "retry_delay_ms": 2000,
+        "transient_statuses": [500, 502, 503, 504]
+      }
+    },
+    {
+      "id": "d1-canonical-state",
+      "url": "https://wp-codebox-cloudflare-runtime.chubes.workers.dev/?phase=r2-state",
+      "expected_status": 200,
+      "expected_text": "\"store\":\"d1\"",
+      "timeout_ms": 30000,
+      "retry": {
+        "attempts": 3,
+        "retry_delay_ms": 1000,
+        "transient_statuses": [500, 502, 503, 504]
+      }
+    }
+  ],
+  "durability": {
+    "redeploy_same_revision": true
+  },
+  "timeout_ms": 600000
+}

--- a/packages/runtime-cloudflare/wrangler.d1.jsonc
+++ b/packages/runtime-cloudflare/wrangler.d1.jsonc
@@ -1,6 +1,7 @@
 // ChatGPT Sites profile: D1 coordinates revisions; R2 stores canonical and published artifacts.
 {
   "name": "wp-codebox-cloudflare-runtime",
+  "account_id": "f2248e657cd8e3f095a18e5eb92f56fc",
   "main": "src/worker-d1.ts",
   "compatibility_date": "2026-07-18",
   "compatibility_flags": ["nodejs_compat"],
@@ -17,7 +18,7 @@
 		{
 			"binding": "WORDPRESS_STATE_DATABASE",
 			"database_name": "wp-codebox-runtime-state",
-			"database_id": "00000000-0000-0000-0000-000000000000"
+			"database_id": "25858208-50ff-46f4-b79d-458f2f6f93c4"
 		}
 	],
 	"rules": [

--- a/tests/cloudflare-principal-credential-operator.test.mjs
+++ b/tests/cloudflare-principal-credential-operator.test.mjs
@@ -56,7 +56,7 @@ test("credential operator uses an atomic parameterized D1 API batch remotely", a
     const request = JSON.parse(await readFile(capture, "utf8"))
     const body = JSON.parse(request.body)
     assert.equal(result.status, 0, result.stderr)
-    assert.match(request.url, /accounts\/a{32}\/d1\/database\/00000000-0000-0000-0000-000000000000\/query$/)
+    assert.match(request.url, /accounts\/a{32}\/d1\/database\/25858208-50ff-46f4-b79d-458f2f6f93c4\/query$/)
     assert.equal(request.headers.authorization, "Bearer cloudflare-test-token")
     assert.equal(Array.isArray(body.batch), true)
     assert.equal(request.body.includes(bearer), false)


### PR DESCRIPTION
## Summary\n\n- attach WP Codebox's component to Homeboy's Cloudflare deployment provider\n- commit the production D1 account/database identity and portable immutable deployment contract\n- require queue, D1, and R2 bindings with WordPress health and D1-state gates\n- require a same-revision durability redeploy\n\n## Verification\n\n- `npm run test:cloudflare-runtime`\n- `npm exec -- wrangler deploy --dry-run --config packages/runtime-cloudflare/wrangler.d1.jsonc --name wp-codebox-cloudflare-runtime`\n- Wrangler reported only queue, D1, and R2 bindings\n- `git diff --check origin/main...HEAD`\n\nThe Homeboy provider-level dry-run and production deployment evidence will be added after the currently active unrelated Homeboy deployment releases the shared registry lock.\n\nProgresses #2157.\n\nUpstream portable-contract repair: https://github.com/Extra-Chill/homeboy-extensions/pull/2486\n\n## AI Assistance\n\nOpenCode with OpenAI GPT-5.6 Sol was used to diagnose the deployment contracts, implement the configuration, and run verification. Chris Huber remains responsible for every line.