### PR TITLE
Resolve preview hydration through the WordPress REST root

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -651,6 +651,11 @@
 		let hydrated;
 		if ( typeof options.hydrateBlueprintRef === 'function' ) {
 			hydrated = await options.hydrateBlueprintRef( request, boot );
+		} else if ( window.wp?.apiFetch && typeof blueprintRef.hydration_endpoint === 'string' && blueprintRef.hydration_endpoint.startsWith( '/' ) && ! blueprintRef.hydration_endpoint.startsWith( '//' ) ) {
+			hydrated = await window.wp.apiFetch( {
+				path: blueprintRef.hydration_endpoint,
+				method: 'GET',
+			} );
 		} else if ( typeof fetch === 'function' && blueprintRef.hydration_endpoint ) {
 			const endpoint = new URL( blueprintRef.hydration_endpoint, window.location.href );
 			endpoint.searchParams.set( 'ref', ref );

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -556,6 +556,29 @@ assert.equal(previewStart.status, "started")
 assert.equal(previewStart.session_id, "preview-session-1")
 assert.deepEqual(plain(previewStart.request), { remoteUrl: "https://playground.wordpress.net/remote.html", corsProxyUrl: "https://playground.wordpress.net/proxy.php", scope: "preview-session-1", hasIframe: true, hasBlueprint: true })
 assert.deepEqual(plain(previewStarts), [{ iframe: { tagName: "IFRAME" }, remoteUrl: "https://playground.wordpress.net/remote.html", corsProxyUrl: "https://playground.wordpress.net/proxy.php", scope: "preview-session-1", blueprint: { steps: [{ step: "login" }] } }])
+const apiFetchRequests: any[] = []
+const restRelativePreviewBoot = {
+  ...previewFixture.response.preview_boot,
+  blueprint_ref: {
+    ...previewFixture.response.preview_boot.blueprint_ref,
+    hydration_endpoint: "/wp-codebox/v1/browser-blueprint-ref?ref=prepared%3Apreview%3Aabc",
+  },
+}
+sandbox.window.wp = {
+  apiFetch: async (request: any) => {
+    apiFetchRequests.push(request)
+    return { schema: "wp-codebox/browser-blueprint-hydration/v1", blueprint: { steps: [{ step: "login" }] } }
+  },
+}
+await api.v1.startBrowserPreview(restRelativePreviewBoot, {
+  iframe: { tagName: "IFRAME" },
+  startPlaygroundWeb: async () => ({ client: "playground" }),
+})
+assert.deepEqual(plain(apiFetchRequests), [{
+  path: restRelativePreviewBoot.blueprint_ref.hydration_endpoint,
+  method: "GET",
+}])
+delete sandbox.window.wp
 await assert.rejects(
   () => api.v1.startBrowserPreview({
     ...previewFixture.response.preview_boot,


### PR DESCRIPTION
## Summary
- route REST-relative browser blueprint hydration endpoints through `window.wp.apiFetch`
- preserve raw fetch behavior for absolute hydration endpoints
- prove the canonical `/wp-codebox/v1/...` endpoint remains a REST path instead of becoming a site-root request

Fixes #2170.

This unblocks live acceptance for https://github.a8c.com/chubes4/wp-build/issues/1274 and https://github.a8c.com/chubes4/wp-build/pull/1277.

## Verification
- `npm run test:browser-sdk-facade`
- `npm run test:browser-task-builder`
- `npm run test:browser-contained-site-status`
- `npm run test:release-package-coverage`
- `npm run package:wordpress-plugin`
- `node --check packages/wordpress-plugin/assets/browser-runtime.js`

## AI assistance
- **AI assistance:** Yes
- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Production diagnosis, implementation, focused coverage, and verification; all changes reviewed by Chris Huber.