### PR TITLE
Declare Homeboy Cloudflare deployment policy

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,24 @@
     "nodejs": {}
   },
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
+  "deployment_provider": {
+    "extension": "cloudflare-workers",
+    "provider": "cloudflare-workers.deploy",
+    "policy": {
+      "wrangler": {
+        "binary": "./node_modules/.bin/wrangler",
+        "config": "packages/runtime-cloudflare/wrangler.d1.jsonc",
+        "config_ref": "packages/runtime-cloudflare/wrangler.d1.jsonc"
+      },
+      "expected_bindings": [
+        "WORDPRESS_RUNTIME_QUEUE",
+        "WORDPRESS_STATE_BUCKET",
+        "WORDPRESS_STATE_DATABASE"
+      ],
+      "predeploy_commands": [],
+      "timeout_ms": 300000
+    }
+  },
   "release": {
     "package_coverage": [
       {


### PR DESCRIPTION
## Summary

- declare the generic Cloudflare deployment provider for WP Codebox
- keep the Wrangler template path, expected D1-only bindings, executable, and timeout in repository policy
- leave Worker, account, D1, R2, queue, hostname, gate, and secret-descriptor identity to private Homeboy project configuration

## Verification

- `jq empty homeboy.json`
- `homeboy project components attach-path wp-codebox . --dry-run`
- `git diff --check`

Supports #2157.

Upstream private-resource dependency: https://github.com/Extra-Chill/homeboy-extensions/pull/2496
Canonical policy-digest dependency: https://github.com/Extra-Chill/homeboy/pull/10960

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol was used to define and validate the repository-owned provider policy while preserving private environment ownership. Chris Huber remains responsible for every line.