### PR TITLE
Use path-keyed browser blueprint refs

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -139,6 +139,15 @@ final class WP_Codebox_Abilities {
 		);
 		register_rest_route(
 			'wp-codebox/v1',
+			'/browser-blueprint-ref/(?P<ref>prepared:[A-Za-z0-9_-]+:[a-f0-9]{64})',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( self::class, 'rest_browser_blueprint_ref' ),
+				'permission_callback' => array( self::class, 'can_hydrate_browser_blueprint_ref' ),
+			)
+		);
+		register_rest_route(
+			'wp-codebox/v1',
 			'/preview-boot-ref',
 			array(
 				'methods'             => 'POST',

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -1071,9 +1071,9 @@ final class WP_Codebox_Browser_Task_Builder {
 			return '';
 		}
 
-		$endpoint = '/wp-codebox/v1/browser-blueprint-ref?ref=' . rawurlencode( $ref );
+		$endpoint = '/wp-codebox/v1/browser-blueprint-ref/' . $ref;
 		if ( function_exists( 'wp_create_nonce' ) ) {
-			$endpoint .= '&_wpnonce=' . rawurlencode( wp_create_nonce( 'wp_rest' ) );
+			$endpoint .= '?_wpnonce=' . rawurlencode( wp_create_nonce( 'wp_rest' ) );
 		}
 
 		return $endpoint;

--- a/tests/browser-blueprint-ref-endpoint.test.ts
+++ b/tests/browser-blueprint-ref-endpoint.test.ts
@@ -56,9 +56,9 @@ echo json_encode( array( 'blueprint_ref' => $blueprint_ref, 'runtime_ref' => $ru
 
 assert.equal(result.blueprint_ref.schema, "wp-codebox/browser-blueprint-ref/v1")
 assert.equal(result.blueprint_ref.ref, "prepared:studio-proof:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-assert.match(result.blueprint_ref.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\?ref=prepared%3Astudio-proof%3A[a]{64}&_wpnonce=test-rest-nonce$/)
+assert.match(result.blueprint_ref.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\/prepared:studio-proof:[a]{64}\?_wpnonce=test-rest-nonce$/)
 assert.equal(result.runtime_ref.ref, "prepared:runtime-proof:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 assert.equal(result.boot_config.blueprint_ref.ref, "prepared:boot-runtime-proof:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
-assert.match(result.boot_config.blueprint_ref.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\?ref=prepared%3Aboot-runtime-proof%3A[c]{64}&_wpnonce=test-rest-nonce$/)
+assert.match(result.boot_config.blueprint_ref.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\/prepared:boot-runtime-proof:[c]{64}\?_wpnonce=test-rest-nonce$/)
 
 console.log("browser blueprint ref endpoint ok")


### PR DESCRIPTION
## Summary
- emit browser blueprint hydration refs as path-keyed REST URLs
- retain the legacy query route for existing callers
- register the prepared-ref path route through the WordPress REST API
- update endpoint contract coverage

## Root cause
The self-hosted Playground service worker matched cached responses with `ignoreSearch: true`. Query-keyed hydration refs could therefore alias distinct prepared blueprints. Path-keyed refs provide distinct cache identities independently of service-worker query behavior.

Related upstream issue: WordPress/wordpress-playground#4223.

## Verification
- browser blueprint ref endpoint tests
- browser task-builder tests
- contained-site contract tests
- PHP contract smoke coverage
- deployed proof commit to the WordPress Build runtime
- downstream two-project content-identity lane passed twice across cold import and OPFS resume

## AI assistance
- **AI assistance:** Yes
- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Contract investigation, path-keyed route implementation, regression coverage, deployment proof, and downstream E2E verification; all changes reviewed by Chris Huber.