### PR TITLE
Add disposable browser preview lifecycle

### DIFF
--- a/docs/browser-contained-site-facade.md
+++ b/docs/browser-contained-site-facade.md
@@ -17,7 +17,7 @@ The contained-site facade is the product-facing browser lane for WordPress previ
 
 ## Boundary
 
-Consumers open or create the contained site, then call `window.wpCodeboxBrowser.v1.startBrowserPreview(response.preview_boot, { iframe })`. `preview_boot` is the public descriptor and requires one hydratable `blueprint_ref`; inline blueprint data is not a product response contract.
+Consumers open or create the contained site, then call `window.wpCodeboxBrowser.v1.startBrowserPreview(response.preview_boot, { iframe, signal })`. `preview_boot` is the public descriptor and requires one hydratable `blueprint_ref`; inline blueprint data is not a product response contract. A successful result preserves the existing `client` and result envelope and adds async `dispose()`. Disposal is idempotent, resets the supplied iframe to terminate its Playground context, and returns `wp-codebox/browser-preview-dispose-result/v1` cleanup evidence; it never removes the caller-owned iframe. Aborting the signal rejects startup with `browser_preview_aborted` and suppresses later Playground lifecycle callbacks.
 
 ## Diagnostics
 

--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -85,7 +85,9 @@ The product preview path is
 `window.wpCodeboxBrowser.v1.startBrowserPreview(response.preview_boot, { iframe })`.
 `preview_boot` is the canonical `wp-codebox/browser-preview-boot-config/v1` DTO;
 it contains a required hydratable `blueprint_ref` object. Consumers do not pass
-inline blueprints or import the raw browser backend `startPlaygroundWeb`.
+inline blueprints or import the raw browser backend `startPlaygroundWeb`. The
+optional `signal` cancels startup and an accepted start result exposes idempotent
+async `dispose()` cleanup without changing its `client` field or result envelope.
 
 Consumer-facing WordPress abilities use the `wp-codebox/*` namespace. Public
 docs and schemas describe the canonical Codebox-owned names that integrations

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -15,6 +15,7 @@
 		'runtime-task:create-request',
 		'runtime-task:run',
 		'browser-preview:start',
+		'browser-preview:lifecycle',
 		'browser-contained-site-sync:consume',
 		'browser-runtime:boot-executable-session',
 		'browser-runtime:parent-tool-bridge',
@@ -702,41 +703,139 @@
 		return module.startPlaygroundWeb;
 	};
 
-	const startBrowserPreview = async ( input, options = {} ) => {
-		const boot = browserPreviewBootConfig( input );
-		const startPlaygroundWeb = await resolveStartPlaygroundWeb( boot, options );
-		const blueprint = await hydrateBrowserPreviewBlueprint( boot, options );
-		const iframe = options.iframe || input?.iframe || ( typeof document !== 'undefined' && options.iframeSelector ? document.querySelector( options.iframeSelector ) : null );
-		const request = {
-			...( options.startOptions && typeof options.startOptions === 'object' ? options.startOptions : {} ),
-			...( iframe ? { iframe } : {} ),
-			...( boot.remote_url ? { remoteUrl: boot.remote_url } : {} ),
-			...( boot.cors_proxy_url ? { corsProxyUrl: boot.cors_proxy_url } : {} ),
-			...( boot.scope ? { scope: boot.scope } : {} ),
-			blueprint,
-		};
-		const client = await startPlaygroundWeb( request );
+	const browserPreviewLifecycles = new Map();
+	const browserPreviewAbortError = () => runtimeError( 'browser_preview_start', 'browser_preview_aborted', 'Browser preview start was aborted.' );
 
-		if ( typeof options.onClientConnected === 'function' ) {
-			options.onClientConnected( client );
+	const resetBrowserPreviewIframe = ( iframe ) => {
+		if ( iframe && typeof iframe === 'object' && 'src' in iframe ) {
+			iframe.src = 'about:blank';
+			return true;
 		}
 
-		return {
-			schema: 'wp-codebox/browser-preview-start-result/v1',
-			success: true,
-			status: 'started',
-			session_id: boot.session_id || '',
-			preview: boot.preview || null,
-			boot,
-			request: {
-				remoteUrl: request.remoteUrl || null,
-				corsProxyUrl: request.corsProxyUrl || null,
-				scope: request.scope || null,
-				hasIframe: !! request.iframe,
-				hasBlueprint: !! request.blueprint,
+		return false;
+	};
+
+	const createBrowserPreviewLifecycle = ( scope, iframe, signal ) => {
+		let active = true;
+		let cancelled = false;
+		let cleanup;
+		let abortListener;
+		let rejectCancellation;
+		const cancellation = new Promise( ( unused, reject ) => {
+			rejectCancellation = reject;
+		} );
+		const lifecycle = {
+			isActive: () => active,
+			wait: ( promise ) => Promise.race( [ promise, cancellation ] ),
+			dispose: async () => {
+				if ( cleanup ) {
+					return cleanup;
+				}
+
+				active = false;
+				cleanup = Promise.resolve().then( () => {
+					if ( signal && abortListener && typeof signal.removeEventListener === 'function' ) {
+						signal.removeEventListener( 'abort', abortListener );
+					}
+					if ( scope && browserPreviewLifecycles.get( scope ) === lifecycle ) {
+						browserPreviewLifecycles.delete( scope );
+					}
+					return Object.freeze( {
+						schema: 'wp-codebox/browser-preview-dispose-result/v1',
+						success: true,
+						status: 'disposed',
+						scope: scope || null,
+						iframe_reset: resetBrowserPreviewIframe( iframe ),
+						listeners_released: true,
+						pending_work_cancelled: true,
+						lifecycle_released: true,
+					} );
+				} );
+				return cleanup;
 			},
-			client,
+			cancel: () => {
+				if ( cancelled ) {
+					return;
+				}
+				cancelled = true;
+				rejectCancellation( browserPreviewAbortError() );
+				void lifecycle.dispose();
+			},
 		};
+
+		if ( signal && typeof signal.addEventListener === 'function' ) {
+			abortListener = () => lifecycle.cancel();
+			signal.addEventListener( 'abort', abortListener, { once: true } );
+		}
+
+		return lifecycle;
+	};
+
+	const startBrowserPreview = async ( input, options = {} ) => {
+		if ( options.signal?.aborted ) {
+			throw browserPreviewAbortError();
+		}
+		const boot = browserPreviewBootConfig( input );
+		const iframe = options.iframe || input?.iframe || ( typeof document !== 'undefined' && options.iframeSelector ? document.querySelector( options.iframeSelector ) : null );
+		const scope = String( boot.scope || '' );
+		const previousLifecycle = scope ? browserPreviewLifecycles.get( scope ) : null;
+		if ( previousLifecycle ) {
+			await previousLifecycle.dispose();
+		}
+		const lifecycle = createBrowserPreviewLifecycle( scope, iframe, options.signal );
+		if ( options.signal?.aborted ) {
+			await lifecycle.dispose();
+			throw browserPreviewAbortError();
+		}
+		if ( scope ) {
+			browserPreviewLifecycles.set( scope, lifecycle );
+		}
+
+		try {
+			const startPlaygroundWeb = await lifecycle.wait( resolveStartPlaygroundWeb( boot, options ) );
+			const blueprint = await lifecycle.wait( hydrateBrowserPreviewBlueprint( boot, options ) );
+			const startOptions = options.startOptions && typeof options.startOptions === 'object' ? options.startOptions : {};
+			const guardedStartOptions = { ...startOptions };
+			for ( const name of [ 'onBlueprintStepCompleted', 'onBlueprintValidated', 'onClientConnected' ] ) {
+				if ( typeof startOptions[ name ] === 'function' ) {
+					guardedStartOptions[ name ] = ( ...args ) => lifecycle.isActive() && startOptions[ name ]( ...args );
+				}
+			}
+			const request = {
+				...guardedStartOptions,
+				...( iframe ? { iframe } : {} ),
+				...( boot.remote_url ? { remoteUrl: boot.remote_url } : {} ),
+				...( boot.cors_proxy_url ? { corsProxyUrl: boot.cors_proxy_url } : {} ),
+				...( boot.scope ? { scope: boot.scope } : {} ),
+				blueprint,
+			};
+			const client = await lifecycle.wait( startPlaygroundWeb( request ) );
+
+			if ( lifecycle.isActive() && typeof options.onClientConnected === 'function' ) {
+				options.onClientConnected( client );
+			}
+
+			return {
+				schema: 'wp-codebox/browser-preview-start-result/v1',
+				success: true,
+				status: 'started',
+				session_id: boot.session_id || '',
+				preview: boot.preview || null,
+				boot,
+				request: {
+					remoteUrl: request.remoteUrl || null,
+					corsProxyUrl: request.corsProxyUrl || null,
+					scope: request.scope || null,
+					hasIframe: !! request.iframe,
+					hasBlueprint: !! request.blueprint,
+				},
+				client,
+				dispose: lifecycle.dispose,
+			};
+		} catch ( error ) {
+			await lifecycle.dispose();
+			throw error;
+		}
 	};
 
 	const browserSdkContract = Object.freeze( [

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -46,6 +46,7 @@ assert.deepEqual(plain(api.v1.info()), {
     "runtime-task:create-request",
     "runtime-task:run",
     "browser-preview:start",
+    "browser-preview:lifecycle",
     "browser-contained-site-sync:consume",
     "browser-runtime:boot-executable-session",
     "browser-runtime:parent-tool-bridge",
@@ -556,6 +557,7 @@ assert.equal(previewStart.status, "started")
 assert.equal(previewStart.session_id, "preview-session-1")
 assert.deepEqual(plain(previewStart.request), { remoteUrl: "https://playground.wordpress.net/remote.html", corsProxyUrl: "https://playground.wordpress.net/proxy.php", scope: "preview-session-1", hasIframe: true, hasBlueprint: true })
 assert.deepEqual(plain(previewStarts), [{ iframe: { tagName: "IFRAME" }, remoteUrl: "https://playground.wordpress.net/remote.html", corsProxyUrl: "https://playground.wordpress.net/proxy.php", scope: "preview-session-1", blueprint: { steps: [{ step: "login" }] } }])
+assert.equal(typeof previewStart.dispose, "function", "successful previews expose async disposal without changing the result envelope")
 const apiFetchRequests: any[] = []
 const restRelativePreviewBoot = {
   ...previewFixture.response.preview_boot,
@@ -589,6 +591,97 @@ await assert.rejects(
     return true
   },
 )
+
+const lifecycleBoot = {
+  ...previewFixture.response.preview_boot,
+  scope: "preview-lifecycle-test",
+}
+const preAborted = new AbortController()
+preAborted.abort()
+let preAbortStarted = false
+await assert.rejects(
+  () => api.v1.startBrowserPreview(lifecycleBoot, {
+    signal: preAborted.signal,
+    hydrateBlueprintRef: async () => ({ blueprint: { steps: [] } }),
+    startPlaygroundWeb: async () => {
+      preAbortStarted = true
+      return {}
+    },
+  }),
+  (error: any) => error.code === "browser_preview_aborted",
+)
+assert.equal(preAbortStarted, false, "a pre-aborted signal does not start Playground")
+
+let finishHydration: ((value: unknown) => void) | undefined
+let duringAbortStarted = false
+const duringAbort = new AbortController()
+const duringAbortIframe: { src: string } = { src: "https://playground.example/remote.html" }
+const duringAbortStart = api.v1.startBrowserPreview({ ...lifecycleBoot, scope: "preview-abort-during-startup" }, {
+  iframe: duringAbortIframe,
+  signal: duringAbort.signal,
+  hydrateBlueprintRef: () => new Promise((resolve) => {
+    finishHydration = resolve
+  }),
+  startPlaygroundWeb: async () => {
+    duringAbortStarted = true
+    return {}
+  },
+})
+duringAbort.abort()
+await assert.rejects(duringAbortStart, (error: any) => error.code === "browser_preview_aborted")
+finishHydration?.({ blueprint: { steps: [] } })
+await new Promise((resolve) => setTimeout(resolve, 0))
+assert.equal(duringAbortStarted, false, "aborting startup suppresses work after hydration")
+assert.equal(duringAbortIframe.src, "about:blank", "aborting startup resets the associated iframe")
+
+const lifecycleCallbacks: Record<string, (...args: any[]) => unknown> = {}
+const lifecycleIframe: { src: string } = { src: "https://playground.example/remote.html" }
+let callbackMutations = 0
+const lifecyclePreview = await api.v1.startBrowserPreview(lifecycleBoot, {
+  iframe: lifecycleIframe,
+  hydrateBlueprintRef: async () => ({ blueprint: { steps: [] } }),
+  startOptions: {
+    onBlueprintStepCompleted: () => { callbackMutations += 1 },
+    onBlueprintValidated: () => { callbackMutations += 1 },
+    onClientConnected: () => { callbackMutations += 1 },
+  },
+  startPlaygroundWeb: async (request: Record<string, any>) => {
+    Object.assign(lifecycleCallbacks, {
+      onBlueprintStepCompleted: request.onBlueprintStepCompleted,
+      onBlueprintValidated: request.onBlueprintValidated,
+      onClientConnected: request.onClientConnected,
+    })
+    return { client: "lifecycle-playground" }
+  },
+})
+lifecycleCallbacks.onBlueprintStepCompleted()
+lifecycleCallbacks.onBlueprintValidated()
+lifecycleCallbacks.onClientConnected()
+assert.equal(callbackMutations, 3, "Playground lifecycle callbacks retain existing behavior while active")
+const disposed = await lifecyclePreview.dispose()
+assert.deepEqual(plain(disposed), {
+  schema: "wp-codebox/browser-preview-dispose-result/v1",
+  success: true,
+  status: "disposed",
+  scope: "preview-lifecycle-test",
+  iframe_reset: true,
+  listeners_released: true,
+  pending_work_cancelled: true,
+  lifecycle_released: true,
+})
+assert.equal(await lifecyclePreview.dispose(), disposed, "preview disposal is idempotent")
+assert.equal(lifecycleIframe.src, "about:blank", "disposal resets but does not remove the caller-owned iframe")
+lifecycleCallbacks.onBlueprintStepCompleted()
+lifecycleCallbacks.onBlueprintValidated()
+lifecycleCallbacks.onClientConnected()
+assert.equal(callbackMutations, 3, "disposed previews suppress late Playground lifecycle callbacks")
+const replacementPreview = await api.v1.startBrowserPreview(lifecycleBoot, {
+  iframe: { src: "https://playground.example/remote.html" },
+  hydrateBlueprintRef: async () => ({ blueprint: { steps: [] } }),
+  startPlaygroundWeb: async () => ({ client: "replacement-playground" }),
+})
+assert.equal(replacementPreview.client.client, "replacement-playground", "disposing releases a scope for a replacement preview")
+await replacementPreview.dispose()
 
 const parentRequest = api.v1.createParentToolRequest(executableSession, "workspace.read", "read", { path: "README.md" })
 assert.equal(parentRequest.schema, "wp-codebox/parent-tool-request/v1")


### PR DESCRIPTION
## Summary
Add a product-neutral abortable and disposable lifecycle to browser preview startup, preventing late Playground callbacks and releasing iframe-owned runtime resources.

## What changed
- Runtime source: packages/wordpress-plugin/assets/browser-runtime.js. Change kind: lifecycle contract. startBrowserPreview now accepts AbortSignal, rejects with deterministic browser\_preview\_aborted, guards documented Playground lifecycle callbacks, exposes idempotent async dispose(), resets only the supplied iframe, releases scoped lifecycle/listeners, and returns deterministic cleanup evidence. Evidence boundary: browser-side Codebox ownership only; no caller iframe removal or product/cache behavior added.
- SDK facade source: packages/wordpress-plugin/assets/browser-runtime.js. Change kind: capability declaration. Added browser-preview:lifecycle while preserving existing v1 method shape, start result envelope, and client field. Evidence boundary: capability metadata only.
- Tests: tests/browser-sdk-facade.test.ts. Change kind: high-signal contract coverage. Verifies pre-abort, abort during startup, suppression of late callbacks, disposal evidence/idempotency, iframe reset, replacement start with the same scope, and existing start behavior. Verification capability: npm run test:browser-sdk-facade passed after npm ci restored declared dependencies.
- Documentation: docs/browser-contained-site-facade.md and docs/public-api-contract.md. Change kind: public lifecycle contract documentation. Evidence boundary: documents only the generic signal/dispose behavior.
- AI assistance disclosure: OpenCode inspected existing runtime contracts and Playground callback types, implemented the bounded lifecycle change, and ran the targeted verification; human review remains responsible for merge approval.

## How to test
1. Run `npx tsx tests/browser-sdk-facade.test.ts`; expect passes as recorded by Cook's deterministic gate.
2. Run `npm run build`; expect passes as recorded by Cook's deterministic gate.
3. Run `git diff --check`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Existing callers that omit signal and dispose retain startBrowserPreview behavior and the unchanged result fields, including client. Successful starts gain an additive dispose function and SDK capability. Disposal resets but never removes caller-owned iframes.

## Evidence
- Base unchanged since verification: main remains at fdb3da6be0b332ea0d0d18c4e76dcb3bf30a0260.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 3 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/wp-codebox/issues/2175
- Task objective: Implement Automattic/wp-codebox#2175 in this existing managed worktree. Add a generic lifecycle contract around packages/wordpress-plugin/assets/browser-runtime.js startBrowserPreview: accept an AbortSignal, reject promptly and deterministically when aborted, suppress late callbacks, and return an idempotent async dispose operation/preview handle on successful starts while preserving the existing result envelope and .client behavior. Disposal must release Codebox-owned listeners and lifecycle state, cancel/suppress pending work, reset the associated iframe so its browsing context and owned Playground workers terminate, and report deterministic cleanup evidence. Do not remove a caller-owned iframe. Keep compatibility for existing callers that do not pass a signal or call dispose. Wrap the known Playground lifecycle callbacks passed through startOptions so cancellation/disposal prevents late consumer mutation. Extend the browser SDK facade contract and high-signal tests to prove pre-abort, abort during startup, no late callbacks, successful idempotent disposal, iframe reset, replacement start using the same scope, and unchanged existing behavior. Keep the primitive product-neutral; do not add wp-build concepts or cache policy. Inspect current repository conventions and make the smallest coherent implementation. Include concrete AI assistance disclosure in the PR description.
- Verified candidate scope: 4 changed file(s): docs/browser-contained-site-facade.md, docs/public-api-contract.md, packages/wordpress-plugin/assets/browser-runtime.js, tests/browser-sdk-facade.test.ts.
- Verified finalization base: main at fdb3da6be0b332ea0d0d18c4e76dcb3bf30a0260
- deterministic gate passed: sh -lc git diff --check (Passed)
- deterministic gate passed: sh -lc npm run build (Passed)
- deterministic gate passed: sh -lc npx tsx tests/browser-sdk-facade.test.ts (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Inspected nearby browser SDK contracts and existing facade tests, checked the current Playground start option callback types, implemented the smallest scoped lifecycle state, restored lockfile dependencies with npm ci, and ran the focused SDK facade test plus JavaScript syntax/diff checks.
