### PR TITLE
Index retained runtime snapshots in artifact manifests

### DIFF
--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -152,11 +152,11 @@ export class ArtifactBundleBuilder {
         source.spec.environment.blueprint,
       )
       : undefined
-    const runtimeSnapshots = spec.includeRuntimeSnapshotBundles ? source.snapshots : []
+    const runtimeSnapshots = source.snapshots
     const runtimeSnapshotFiles = runtimeSnapshots.flatMap((snapshot) =>
       (snapshot.artifactRefs ?? [])
         .filter((ref): ref is typeof ref & { path: string } => typeof ref.path === "string" && ref.path.length > 0)
-        .map((ref) => artifactManifestFile(join(source.artifactRoot, ref.path), "runtime-snapshot", "application/json")),
+        .map((ref) => artifactManifestFile(join(source.artifactRoot, ref.path), "runtime-snapshot-artifact", "application/json")),
     )
     const replayExportPackageFiles = replayExportPackageManifestFiles(source.artifactRoot, source.commands)
     const capturedMounts = await source.captureMountedFiles(filesDirectory, redactor)

--- a/tests/runtime-snapshot-artifact-lifecycle.test.ts
+++ b/tests/runtime-snapshot-artifact-lifecycle.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict"
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { artifactFileDigest, type ArtifactManifest, type RuntimeReplayReferenceIndex, type RuntimeReferenceManifest, type Snapshot } from "../packages/runtime-core/src/public.js"
+import { verifyArtifactBundle } from "../packages/runtime-core/src/artifact-bundle-verifier.js"
+import { ArtifactBundleBuilder } from "../packages/runtime-playground/src/artifact-bundle-builder.js"
+import { captureMountedFiles, captureMountDiffs } from "../packages/runtime-playground/src/mounted-artifact-capture.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-runtime-snapshot-lifecycle-"))
+const artifactRoot = join(root, "artifacts")
+const snapshotPath = "files/runtime-snapshots/snapshot-checkpoint.json"
+const snapshotContent = `${JSON.stringify({ schema: "wp-codebox/wordpress-runtime-snapshot/v1", id: "snapshot-checkpoint" }, null, 2)}\n`
+const snapshotDigest = artifactFileDigest(snapshotContent)
+const snapshot: Snapshot = {
+  schema: "wp-codebox/runtime-episode-snapshot/v1",
+  id: "snapshot-checkpoint",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  semantics: "runtime-state-artifact",
+  metadata: {},
+  artifactRefs: [{ kind: "runtime-snapshot-artifact", id: "snapshot-checkpoint", path: snapshotPath, digest: snapshotDigest }],
+}
+
+try {
+  await mkdir(join(artifactRoot, "files/runtime-snapshots"), { recursive: true })
+  await writeFile(join(artifactRoot, snapshotPath), snapshotContent)
+
+  await new ArtifactBundleBuilder({
+    artifactRoot,
+    runtimeId: "runtime-snapshot-lifecycle",
+    runtimeCreatedAt: "2026-01-01T00:00:00.000Z",
+    spec: { environment: { blueprint: {} } },
+    mounts: [],
+    commands: [],
+    observations: [],
+    snapshots: [snapshot],
+    events: [],
+    info: async () => ({ id: "runtime-snapshot-lifecycle", backend: "wordpress-playground", status: "ready", createdAt: "2026-01-01T00:00:00.000Z", environment: { kind: "wordpress" } }),
+    previewInfo: async () => undefined,
+    browserReviewSummary: () => undefined,
+    browserArtifacts: () => [],
+    captureMountedFiles: (filesDirectory, redactor) => captureMountedFiles(filesDirectory, [], redactor),
+    captureMountDiffs: (filesDirectory, redactor) => captureMountDiffs(artifactRoot, filesDirectory, [], redactor),
+    redactBrowserArtifacts: async () => {},
+    redactPluginCheckArtifacts: async () => {},
+    redactThemeCheckArtifacts: async () => {},
+    browserManifestFiles: () => [],
+    pluginCheckArtifactPaths: () => [],
+    themeCheckArtifactPaths: () => [],
+    observationManifestFiles: () => [],
+    pluginCheckManifestFiles: () => [],
+    themeCheckManifestFiles: () => [],
+    formatRuntimeLog: () => "",
+    formatCommandsLog: () => "",
+    recordArtifactsCollected: () => {},
+  } as any).build()
+
+  const manifest = JSON.parse(await readFile(join(artifactRoot, "manifest.json"), "utf8")) as ArtifactManifest
+  const snapshotFile = manifest.files.find((file) => file.path === snapshotPath)
+  assert.equal(snapshotFile?.kind, "runtime-snapshot-artifact")
+  assert.equal(snapshotFile?.contentType, "application/json")
+  assert.deepEqual(snapshotFile?.sha256, snapshotDigest)
+  assert.equal((await verifyArtifactBundle(artifactRoot)).valid, true)
+
+  const runtimeReferences = JSON.parse(await readFile(join(artifactRoot, "files/runtime-reference-manifest.json"), "utf8")) as RuntimeReferenceManifest
+  const replayReferences = JSON.parse(await readFile(join(artifactRoot, "files/runtime-replay-index.json"), "utf8")) as RuntimeReplayReferenceIndex
+  assert.deepEqual(runtimeReferences.snapshots[0]?.artifactRefs[0], { kind: "runtime-snapshot-artifact", id: "snapshot-checkpoint", path: snapshotPath, digest: snapshotDigest })
+  assert.deepEqual(replayReferences.snapshots[0]?.artifactRefs[0], { kind: "runtime-snapshot-artifact", id: "snapshot-checkpoint", path: snapshotPath, digest: snapshotDigest })
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("runtime snapshot artifact lifecycle ok")


### PR DESCRIPTION
## Summary
- index every runtime snapshot already retained under the artifact root during bundle finalization
- record snapshot files with the canonical `runtime-snapshot-artifact` kind, JSON content type, and refreshed SHA-256
- cover whole-bundle verification plus runtime reference manifest and replay index snapshot refs

## Root cause
Checkpoint creation calls the Playground runtime snapshot primitive before artifact collection. That primitive writes `files/runtime-snapshots/<id>.json` immediately and retains the snapshot on the runtime. Artifact bundle finalization previously only considered retained snapshots when `includeRuntimeSnapshotBundles` was true, so normal checkpoint-backed adversarial collection left the file on disk but omitted it from `manifest.json`.

## Artifact lifecycle ordering
The snapshot write correctly occurs when the checkpoint is created so the checkpoint can be restored during the campaign. Bundle finalization now always indexes snapshots that already exist in runtime state. `includeRuntimeSnapshotBundles` remains responsible for requesting an additional collection-time snapshot and generating the replayable blueprint; it no longer controls whether an already-retained file is represented in the bundle manifest and runtime reference indexes.

## Verifier behavior
Before this change, `wp-codebox artifacts verify` reported `orphaned-file` for the retained checkpoint snapshot and marked an otherwise successful campaign bundle invalid. After this change, finalization records the snapshot with its canonical kind, content type, and computed digest, so the complete bundle verifies while orphan detection remains unchanged.

## Test evidence
- `npx tsx tests/runtime-snapshot-artifact-lifecycle.test.ts`
- `npm run test:adversarial-runtime`
- `npx tsx scripts/artifact-bundle-verifier-smoke.ts`
- `npm run build`

Fixes #2179