### PR TITLE
Fix Playground checkpoints after multisite conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
     "test:site-seed-multisite": "tsx tests/site-seed-multisite.test.ts",
     "test:playground-mapped-domain-multisite-integration": "tsx tests/playground-mapped-domain-multisite.integration.test.ts",
+    "test:playground-multisite-checkpoint-integration": "tsx tests/playground-multisite-checkpoint.integration.test.ts",
     "test:runtime-workers": "tsx tests/runtime-workers.test.ts",
     "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
     "test:recipe-runtime-setup-staged-materialization": "tsx tests/recipe-runtime-setup-staged-materialization.test.ts",

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -40,6 +40,7 @@ ${saveQueriesBootstrapPhp(args)}
 ${runtimeEnvPhp(spec, args)}
 ${secretEnvPhp(spec)}
 ${componentManifestPhp(spec)}
+${bootstrapMode === "runtime-only" ? "" : multisiteRequestBootstrapPhp()}
 ${bootstrapMode === "runtime-only" ? "" : "require_once '/wordpress/wp-load.php';"}
 ${failureDiagnosticFile ? phpFailureDiagnosticCompletionPhp() : ""}
 ${bootstrapMode === "runtime-only" ? "" : recipeActivePluginBootstrapPhp(spec, args)}
@@ -49,6 +50,21 @@ putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)
 ${command.body}`
 
   return failureDiagnosticFile && bootstrapMode !== "runtime-only" ? phpFailureDiagnosticWrapperPhp(bootstrapped, failureDiagnosticFile) : bootstrapped
+}
+
+function multisiteRequestBootstrapPhp(): string {
+  return `$wp_codebox_wp_config = @file_get_contents('/wordpress/wp-config.php');
+if (is_string($wp_codebox_wp_config)) {
+    if (preg_match('/define\\s*\\(\\s*([\\\'\"])DOMAIN_CURRENT_SITE\\1\\s*,\\s*([\\\'\"])([^\\\'\"]+)\\2\\s*\\)/', $wp_codebox_wp_config, $wp_codebox_domain_match)) {
+        $_SERVER['HTTP_HOST'] = $wp_codebox_domain_match[3];
+        $_SERVER['SERVER_NAME'] = $wp_codebox_domain_match[3];
+    }
+    if (preg_match('/define\\s*\\(\\s*([\\\'\"])PATH_CURRENT_SITE\\1\\s*,\\s*([\\\'\"])([^\\\'\"]+)\\2\\s*\\)/', $wp_codebox_wp_config, $wp_codebox_path_match)) {
+        $_SERVER['REQUEST_URI'] = $wp_codebox_path_match[3];
+    }
+}
+unset($wp_codebox_wp_config, $wp_codebox_domain_match, $wp_codebox_path_match);
+`
 }
 
 function phpFailureDiagnosticWrapperPhp(code: string, path: string): string {

--- a/tests/playground-multisite-checkpoint.integration.test.ts
+++ b/tests/playground-multisite-checkpoint.integration.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-multisite-checkpoint-"))
+const recipePath = join(root, "recipe.json")
+const artifactsPath = join(root, "artifacts")
+
+try {
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { backend: "wordpress-playground", wp: "latest", blueprint: { steps: [] } },
+    workflow: {
+      steps: [
+        { command: "wordpress.wp-cli", args: ["command=wp core multisite-convert --title=Checkpoint --base=/"] },
+        { command: "wordpress.wp-cli", args: ["command=wp site create --slug=second --title=Second --porcelain"] },
+        { command: "wordpress.run-php", args: ["code=update_option('checkpoint_value','baseline'); switch_to_blog(2); update_option('checkpoint_value','baseline'); restore_current_blog();"] },
+        { command: "wp-codebox.checkpoint-create", args: ["name=multisite-baseline"] },
+        { command: "wordpress.run-php", args: ["code=update_option('checkpoint_value','mutated'); switch_to_blog(2); update_option('checkpoint_value','mutated'); restore_current_blog();"] },
+        { command: "wp-codebox.checkpoint-restore", args: ["name=multisite-baseline"] },
+        { command: "wordpress.run-php", args: ["code=$second=get_sites(array('number'=>1,'path'=>'/second/'))[0]??null; if(get_option('checkpoint_value')!=='baseline'||!$second){exit(1);} switch_to_blog((int)$second->blog_id); $value=get_option('checkpoint_value'); restore_current_blog(); if($value!=='baseline'){exit(1);} echo 'restored';"] },
+      ],
+    },
+  })}\n`)
+
+  const output = await runRecipe()
+  if (output) {
+    assert.equal(output.success, true, JSON.stringify(output))
+    assert.equal(output.executions?.at(-1)?.stdout, "restored")
+  }
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+async function runRecipe(): Promise<RecipeRunOutput | undefined> {
+  try {
+    const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--artifacts", artifactsPath, "--json"], {
+      cwd: process.cwd(),
+      timeout: 300_000,
+      maxBuffer: 4 * 1024 * 1024,
+    })
+    return JSON.parse(result.stdout) as RecipeRunOutput
+  } catch (error) {
+    const output = recipeRunOutput(error && typeof error === "object" && "stdout" in error ? error.stdout : undefined)
+    const message = output?.phaseEvidence?.find((phase) => phase.name === "runtime_startup")?.error?.message ?? ""
+    if (/Unable to resolve Playground startup asset.*fetch failed|Could not resolve host|network is unreachable/i.test(message)) {
+      console.log("playground multisite checkpoint integration skipped: WordPress runtime source unavailable")
+      return undefined
+    }
+    throw error
+  }
+}
+
+function recipeRunOutput(value: unknown): RecipeRunOutput | undefined {
+  if (typeof value !== "string") return undefined
+  try { return JSON.parse(value) as RecipeRunOutput } catch { return undefined }
+}
+
+interface RecipeRunOutput {
+  success?: boolean
+  executions?: Array<{ stdout: string }>
+  phaseEvidence?: Array<{ name?: string; error?: { message?: string } }>
+}
+
+console.log("playground multisite checkpoint integration ok")


### PR DESCRIPTION
## Summary
- bootstrap direct Playground PHP commands against the network's configured primary domain and path before loading WordPress
- preserve the advertised checkpoint-per-case contract after a valid `wp core multisite-convert` workflow
- add a real Playground regression covering checkpoint creation, mutation, and restoration across the main site and a subsite

## Root cause
Playground direct PHP workers retain their transient runtime host. After `wp core multisite-convert`, WordPress multisite resolves requests against `DOMAIN_CURRENT_SITE` and `PATH_CURRENT_SITE` from `wp-config.php`. The transient host did not match the installed network, so `wp-load.php` terminated before snapshot exporter code ran. Playground returned exit code 0 with an empty body, and the checkpoint layer consequently reported `Runtime snapshot export did not return a supported manifest.`

The shared Playground PHP bootstrap now reads the literal multisite constants written by WordPress, sets `HTTP_HOST`, `SERVER_NAME`, and `REQUEST_URI` to the network's main-site context, and then loads WordPress. Single-site and runtime-only bootstraps remain unchanged.

## Public contract impact
The public descriptor already advertises `checkpoint-per-case` for the Playground backend. This restores that existing contract for converted multisite runtimes rather than adding a consumer exception or changing capability reporting.

## Minimized reproduction
1. Start a `wordpress-playground` recipe.
2. Run `wp core multisite-convert --base=/`.
3. Create `/second/` and seed distinct state in both sites.
4. Create a runtime checkpoint.
5. Mutate both sites, restore the checkpoint, and verify both values returned to baseline.

Before this change, checkpoint creation failed before exporter execution with an unsupported-manifest error. After this change, the checkpoint captures all network tables and restores state in both blogs.

## Test evidence
Passed:
- `npm run test:playground-multisite-checkpoint-integration`
- `npm run test:playground-mapped-domain-multisite-integration`
- `npm run test:runtime-sources-playground-integration`
- `npx tsx tests/runtime-checkpoint-primitives.test.ts`
- `npx tsx tests/runtime-snapshot-export-memory-limit.test.ts`
- `npx tsx tests/playground-public-runtime-primitives.test.ts`
- `npm run test:site-seed-multisite`
- `npm run build`
- `npm run test:production-boundary-enforcement`

`npm run check` reaches the known unchanged #1745 baseline failure in `command-registry-smoke`: `wordpress.collect-workload-result outputShape should mention outputSchema id`. Neither the command registry nor its smoke script differs from `origin/main`.

## AI assistance
- AI assistance: Yes
- Tool: OpenCode
- Used for: investigation, implementation, regression coverage, verification, and PR drafting

Fixes #2177