### PR TITLE
fix: preserve Playground preview upstream host

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -163,7 +163,7 @@ function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
 
 function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
   return new Promise((resolve) => {
-    const requestTarget = previewProxyRequestTarget(incoming)
+    const requestTarget = previewProxyRequestTarget(incoming, target)
     let settled = false
     let targetResponse: IncomingMessage | undefined
     const settle = () => {
@@ -215,19 +215,21 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
 }
 
 interface PreviewProxyRequestTarget {
-  host: string
+  upstreamHost: string
+  visibleHost: string
   path: string
   port: string
   protocol: "http:" | "https:"
 }
 
-function previewProxyRequestTarget(incoming: IncomingMessage): PreviewProxyRequestTarget {
+function previewProxyRequestTarget(incoming: IncomingMessage, target: URL): PreviewProxyRequestTarget {
   const rawUrl = incoming.url ?? "/"
   try {
     const url = new URL(rawUrl)
     if (url.protocol === "http:" || url.protocol === "https:") {
       return {
-        host: url.host,
+        upstreamHost: url.host,
+        visibleHost: url.host,
         path: `${url.pathname}${url.search}`,
         port: url.port || (url.protocol === "https:" ? "443" : "80"),
         protocol: url.protocol,
@@ -238,7 +240,7 @@ function previewProxyRequestTarget(incoming: IncomingMessage): PreviewProxyReque
   }
   const host = incoming.headers.host ?? "localhost"
   const authority = new URL(`http://${host}`)
-  return { host: authority.host, path: rawUrl, port: authority.port || "80", protocol: "http:" }
+  return { upstreamHost: target.host, visibleHost: authority.host, path: rawUrl, port: authority.port || "80", protocol: "http:" }
 }
 
 function createPreviewProxyQueue(): (task: () => Promise<void>) => Promise<void> {
@@ -309,8 +311,8 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: Previe
 
   return {
     ...forwarded,
-    host: requestTarget.host,
-    "x-forwarded-host": requestTarget.host,
+    host: requestTarget.upstreamHost,
+    "x-forwarded-host": requestTarget.visibleHost,
     "x-forwarded-port": requestTarget.port,
     "x-forwarded-proto": requestTarget.protocol.slice(0, -1),
   }
@@ -326,7 +328,7 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: Previ
       const location = new URL(forwarded.location, target)
       if (location.origin === target.origin) {
         location.protocol = requestTarget.protocol
-        const visible = new URL(`${requestTarget.protocol}//${requestTarget.host}`)
+        const visible = new URL(`${requestTarget.protocol}//${requestTarget.visibleHost}`)
         location.hostname = visible.hostname
         location.port = visible.port
         forwarded.location = location.toString()

--- a/tests/browser-canonical-preview-origin.test.ts
+++ b/tests/browser-canonical-preview-origin.test.ts
@@ -60,6 +60,12 @@ const topology = browserPreviewTopology(
 const browser = await launchChromiumBrowser()
 
 try {
+  const directResponse = await fetch(`${proxy.serverUrl}/direct-preview/`)
+  assert.equal(directResponse.status, 200)
+  const proxyOrigin = new URL(proxy.serverUrl)
+  const upstreamOrigin = new URL(upstreamUrl)
+  assert(requests.some((request) => request.url === "/direct-preview/" && request.host === upstreamOrigin.host && request.forwardedHost === proxyOrigin.host && request.forwardedPort === proxyOrigin.port && request.forwardedProto === "http"))
+
   const context = await browser.newContext({
     ...topology.contextOptions(),
     extraHTTPHeaders: {

--- a/tests/playground-mapped-domain-multisite.integration.test.ts
+++ b/tests/playground-mapped-domain-multisite.integration.test.ts
@@ -42,6 +42,8 @@ try {
   await rm(root, { recursive: true, force: true })
 }
 
+await verifyConvertedPathMultisitePreview()
+
 function mappedTopologyRecipe(): Record<string, unknown> {
   const probeScript = `
 const rest = await fetch('/wp-json/wp-codebox/v1/mapped-site').then((response) => response.json());
@@ -136,4 +138,50 @@ interface RecipeRunOutput {
   siteSeeds?: Array<{ topology?: { effective?: { multisite?: boolean; install?: string; sites?: Array<{ domain: string; path: string }> }; browser?: { routeHosts?: string[] }; auth?: { anonymous?: string; crossDomainCookieParity?: string } } }>
   executions?: Array<{ command?: string; stdout: string }>
   phaseEvidence?: Array<{ name?: string; error?: { message?: string } }>
+}
+
+async function verifyConvertedPathMultisitePreview(): Promise<void> {
+  const pathRoot = await mkdtemp(join(tmpdir(), "wp-codebox-path-multisite-preview-"))
+  const pathRecipe = join(pathRoot, "recipe.json")
+  const pathArtifacts = join(pathRoot, "artifacts")
+  try {
+    await writeFile(pathRecipe, `${JSON.stringify({
+      schema: "wp-codebox/workspace-recipe/v1",
+      runtime: { backend: "wordpress-playground", wp: "6.5" },
+      workflow: {
+        steps: [
+          { command: "wordpress.wp-cli", args: ["command=wp core multisite-convert --title=\"Path Network\" --base=\"/\""] },
+          { command: "wordpress.run-php", args: ["code=$network = get_network(); $site_id = wp_insert_site( array( 'domain' => $network->domain, 'path' => '/community/', 'network_id' => $network->id, 'title' => 'Community' ) ); if ( is_wp_error( $site_id ) ) { throw new RuntimeException( $site_id->get_error_message() ); } update_blog_option( $site_id, 'home', 'http://' . $network->domain . '/community/' ); update_blog_option( $site_id, 'siteurl', 'http://' . $network->domain . '/community/' ); update_blog_option( $site_id, 'blogname', 'Community' );"] },
+          { command: "wordpress.browser-probe", args: ["url=/community/", "wait-for=load", "script=return { pathname: location.pathname };", "capture=network"] },
+          { command: "wordpress.browser-probe", args: ["url=/community/wp-login.php", "wait-for=load", "script=return { pathname: location.pathname };", "capture=network"] },
+        ],
+      },
+    })}\n`)
+
+    let output: RecipeRunOutput | undefined
+    try {
+      const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", pathRecipe, "--artifacts", pathArtifacts, "--json"], { cwd: process.cwd(), timeout: 300_000, maxBuffer: 4 * 1024 * 1024 })
+      output = JSON.parse(result.stdout) as RecipeRunOutput
+    } catch (error) {
+      const failedOutput = recipeRunOutput(error && typeof error === "object" && "stdout" in error ? error.stdout : undefined)
+      const message = failedOutput?.phaseEvidence?.find((phase) => phase.name === "runtime_startup")?.error?.message ?? ""
+      if (/Unable to resolve Playground startup asset.*fetch failed|Could not resolve host|network is unreachable/i.test(message)) {
+        console.log("playground path multisite preview integration skipped: WordPress runtime source unavailable")
+        return
+      }
+      throw error
+    }
+
+    assert.equal(output.success, true, JSON.stringify(output))
+    const probes = output.executions?.filter((execution) => execution.command === "wordpress.browser-probe") ?? []
+    assert.equal(probes.length, 2)
+    const community = JSON.parse(probes[0]!.stdout)
+    const login = JSON.parse(probes[1]!.stdout)
+    assert.equal(new URL(community.finalUrl).pathname, "/community/")
+    assert.deepEqual(community.summary.scriptResult, { pathname: "/community/" })
+    assert.equal(new URL(login.finalUrl).pathname, "/community/wp-login.php")
+    assert.deepEqual(login.summary.scriptResult, { pathname: "/community/wp-login.php" })
+  } finally {
+    await rm(pathRoot, { recursive: true, force: true })
+  }
 }


### PR DESCRIPTION
## Summary
- preserve the Playground runtime authority as the upstream `Host` for origin-form reviewer proxy requests while retaining the reviewer authority in forwarded headers and response redirects
- preserve existing absolute-form mapped-domain routing, where the declared browser host remains both the upstream and visible authority
- cover converted path-based multisite navigation through the real Playground reviewer proxy

## Root cause
The reviewer proxy forwarded its ephemeral public authority as the upstream `Host` for normal origin-form browser requests. After `wp core multisite-convert`, WordPress keyed the network to the separate internal Playground authority. WordPress canonicalized the mismatched request back to the internal authority, the proxy rewrote that redirect to the reviewer authority, and the cycle repeated until Playwright raised `ERR_TOO_MANY_REDIRECTS`.

## Origin identities
Before:
- browser/reviewer origin: ephemeral proxy origin, for example `http://127.0.0.1:33823`
- runtime/network origin: internal Playground origin, for example `http://127.0.0.1:56096`
- upstream `Host`: reviewer authority (`127.0.0.1:33823`)

After:
- browser-visible and forwarded authority remains the reviewer origin
- origin-form upstream `Host` is the internal Playground authority (`127.0.0.1:56096`)
- absolute-form mapped-domain requests still use their declared mapped authority upstream
- redirects from the internal runtime origin are still rewritten to the browser-visible reviewer origin

## Minimized browser reproduction
The integration regression boots WordPress 6.5 in Playground, runs `wp core multisite-convert --base=\"/\"`, inserts a `/community/` path site, and loads both `/community/` and `/community/wp-login.php` through `wordpress.browser-probe`. Both navigations complete at their requested paths without `ERR_TOO_MANY_REDIRECTS`; no consumer state is rewritten to the transient reviewer port.

## Finding classification impact
The infrastructure redirect loop no longer reaches the adversarial runtime as a failed browser action, so it cannot generate a product-looking `runtime-status` finding. Genuine browser failures remain classified by the existing browser/adversarial paths.

## Test evidence
- `npm run build`
- `npm run test:browser-canonical-preview-origin`
- `npm run test:browser-preview-routing` (14 passed)
- `npm run test:browser-callback-materialization-contracts`
- `npm run test:playground-mapped-domain-multisite-integration`

Fixes #2178