### PR TITLE
Bound recipe workflow step execution

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -125,6 +125,7 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
     assertResolvedInputMountPathArgs(resolvedArgs, options.inputMountPathMap, `Recipe command ${step.command}`)
     return {
       ...spec,
+      ...(step.timeoutMs !== undefined && spec.timeoutMs === undefined ? { timeoutMs: step.timeoutMs } : {}),
       args: resolvedArgs,
       originalCommand: step.command,
       originalArgs: [...originalArgs],
@@ -183,7 +184,11 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
     })
   }
 
-  return finish({ command: resolvedStep.command, args: [...(resolvedStep.args ?? []), ...commandDiagnosticsCaptureArgs(resolvedStep.diagnostics)], diagnostics: resolvedStep.diagnostics })
+  return finish({
+    command: resolvedStep.command,
+    args: [...(resolvedStep.args ?? []), ...commandDiagnosticsCaptureArgs(resolvedStep.diagnostics)],
+    diagnostics: resolvedStep.diagnostics,
+  })
 }
 
 function rewriteRecipeExecutionArgs(command: string, args: readonly string[], recipeDirectory: string, inputMountPathMap: readonly InputMountPathMapping[] = []): string[] {

--- a/packages/cli/src/commands/recipe-run-phase-executor.ts
+++ b/packages/cli/src/commands/recipe-run-phase-executor.ts
@@ -15,12 +15,13 @@ export class RecipeRunPhaseExecutor {
 
   constructor(private readonly options: RecipeRunPhaseExecutorOptions) {}
 
-  async operation<T>(operation: string, promiseOrFactory: Promise<T> | (() => Promise<T>), timeoutMs = remainingRecipeTimeoutMs(this.options.context.startedAtMs, this.options.timeoutMs)): Promise<T> {
+  async operation<T>(operation: string, promiseOrFactory: Promise<T> | (() => Promise<T>), timeoutMs?: number): Promise<T> {
     const { artifactPointer, startedAtMs } = this.options.context
+    const timeout = recipeOperationTimeout(startedAtMs, this.options.timeoutMs, timeoutMs)
     await artifactPointer.update({ command: operation, commandStatus: "running", phases: this.tracker.list() })
     try {
       const promise = typeof promiseOrFactory === "function" ? promiseOrFactory() : promiseOrFactory
-      const guarded = watchRecipeOperation(operation, promise, startedAtMs, timeoutMs, this.options.timeoutMs)
+      const guarded = watchRecipeOperation(operation, promise, startedAtMs, timeout.timeoutMs, timeout.configuredTimeoutMs)
       const result = await (this.options.interruption ? this.options.interruption.interruptible(guarded) : guarded)
       await artifactPointer.update({ command: operation, commandStatus: "completed", phases: this.tracker.list() })
       return result
@@ -32,4 +33,12 @@ export class RecipeRunPhaseExecutor {
       throw error
     }
   }
+}
+
+export function recipeOperationTimeout(startedAtMs: number, recipeTimeoutMs: number, stepTimeoutMs?: number): { timeoutMs: number; configuredTimeoutMs: number } {
+  const remainingTimeoutMs = remainingRecipeTimeoutMs(startedAtMs, recipeTimeoutMs)
+  if (stepTimeoutMs === undefined || stepTimeoutMs >= remainingTimeoutMs) {
+    return { timeoutMs: remainingTimeoutMs, configuredTimeoutMs: recipeTimeoutMs }
+  }
+  return { timeoutMs: stepTimeoutMs, configuredTimeoutMs: stepTimeoutMs }
 }

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -318,7 +318,7 @@ export async function runRecipe(options: RecipeRunOptions, interruption?: Recipe
         try {
           const execution = await awaitRecipe(operation, async () => workflowStep.step.command === "wordpress.collect-workload-result"
             ? withRecipeExecutionPhase(executeRecipeCollectWorkloadResult(workflowStep.step, executions, new Date().toISOString()), workflowStep.phase, workflowStep.index, workflowStep.step.command, recipeWorkflowArgsEvidence(workflowStep.step.args, workflowStep.step.args), workflowStep.step.metadata)
-            : executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options, inputMountPathMap))
+            : executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options, inputMountPathMap), workflowStep.step.timeoutMs)
           executions.push({ ...execution, ...(recipeWorkflowStepIsAdvisory(workflowStep.step) ? { recipeAdvisory: true } : {}) })
           interruption?.throwIfInterrupted()
         } catch (error) {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -104,6 +104,10 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
       throw new Error(`Recipe workflow ${phase} args must be arrays: ${recipePath}`)
     }
 
+    if (step.timeoutMs !== undefined && (!Number.isSafeInteger(step.timeoutMs) || step.timeoutMs <= 0)) {
+      throw new Error(`Recipe workflow ${phase} timeoutMs must be a positive integer: ${recipePath}`)
+    }
+
     if (step.diagnostics !== undefined && (!step.diagnostics || typeof step.diagnostics !== "object" || Array.isArray(step.diagnostics))) {
       throw new Error(`Recipe workflow ${phase} diagnostics must be an object: ${recipePath}`)
     }

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -176,6 +176,7 @@ function normalizeRecipeSteps(steps: readonly WorkspaceRecipeStep[], label: stri
     return {
       command: step.command,
       ...(step.args !== undefined ? { args: step.args } : {}),
+      ...(step.timeoutMs !== undefined ? { timeoutMs: step.timeoutMs } : {}),
       ...(step.metadata !== undefined ? { metadata: step.metadata } : {}),
       ...(step.allowFailure !== undefined ? { allowFailure: step.allowFailure } : {}),
       ...(step.advisory !== undefined ? { advisory: step.advisory } : {}),

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -1219,6 +1219,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { type: "string" },
           },
+          timeoutMs: { type: "integer", minimum: 1 },
           diagnostics: { $ref: "#/$defs/commandDiagnosticsCapture" },
           metadata: { $ref: "#/$defs/metadata" },
           allowFailure: { type: "boolean" },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -286,6 +286,7 @@ export interface WorkspaceRecipeSourcePackage {
 export interface WorkspaceRecipeStep {
   command: string
   args?: string[]
+  timeoutMs?: number
   diagnostics?: RuntimeCommandDiagnosticsCaptureSpec
   metadata?: Record<string, unknown>
   allowFailure?: boolean

--- a/packages/runtime-core/src/wordpress-workload-primitives.ts
+++ b/packages/runtime-core/src/wordpress-workload-primitives.ts
@@ -146,6 +146,7 @@ function normalizeRecipeSteps(steps: WorkspaceRecipeStep[] | undefined): Workspa
     return stripUndefined({
       command,
       args: Array.isArray(step.args) ? step.args.map((arg) => String(arg)) : undefined,
+      timeoutMs: step.timeoutMs,
       allowFailure: step.allowFailure,
       advisory: step.advisory,
     }) as WorkspaceRecipeStep

--- a/tests/recipe-step-metadata.test.ts
+++ b/tests/recipe-step-metadata.test.ts
@@ -2,17 +2,23 @@ import assert from "node:assert/strict"
 
 import { normalizeRecipeRunSummary, validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
 import { RecipeRunTimeoutError } from "../packages/cli/src/commands/recipe-run-output.js"
+import { RecipeRunPhaseExecutor, recipeOperationTimeout } from "../packages/cli/src/commands/recipe-run-phase-executor.js"
+import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.js"
 import { recipeStepFailure, withRecipeExecutionPhase } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
 
 const recipe: WorkspaceRecipe = {
   schema: "wp-codebox/workspace-recipe/v1",
   workflow: {
-    steps: [{ command: "host/fixture", args: [], metadata: { fixture: "alpha", matrixIndex: 2 } }],
+    steps: [{ command: "host/fixture", args: [], timeoutMs: 250, metadata: { fixture: "alpha", matrixIndex: 2 } }],
   },
 }
 
 assert.equal(validateWorkspaceRecipeJsonSchema(recipe).valid, true)
 assert.equal(validateWorkspaceRecipeJsonSchema({ ...recipe, workflow: { steps: [{ command: "host/fixture", metadata: [] }] } }).valid, false)
+assert.equal(validateWorkspaceRecipeJsonSchema({ ...recipe, workflow: { steps: [{ command: "host/fixture", timeoutMs: 0 }] } }).valid, false)
+
+const executionSpec = await recipeExecutionSpec(recipe.workflow.steps[0]!, process.cwd())
+assert.equal(executionSpec.timeoutMs, 250)
 
 const execution = withRecipeExecutionPhase({ command: "host/fixture", args: [], exitCode: 0, stdout: "", stderr: "" }, "steps", 0, "host/fixture", undefined, recipe.workflow.steps[0]!.metadata)
 assert.deepEqual(execution.recipeStepMetadata, { fixture: "alpha", matrixIndex: 2 })
@@ -38,5 +44,28 @@ assert.equal(failure.finishedAt, "2026-01-01T00:00:00.250Z")
 assert.equal(failure.durationMs, 250)
 assert.equal(failure.classification, "timeout")
 assert.equal(failure.timeoutMs, 250)
+
+const now = Date.now()
+assert.deepEqual(recipeOperationTimeout(now, 25_000, 250), { timeoutMs: 250, configuredTimeoutMs: 250 })
+const globallyBounded = recipeOperationTimeout(now - 24_900, 25_000, 500)
+assert.ok(globallyBounded.timeoutMs > 0 && globallyBounded.timeoutMs <= 100)
+assert.equal(globallyBounded.configuredTimeoutMs, 25_000)
+
+let destroyedRuntime = false
+const phaseExecutor = new RecipeRunPhaseExecutor({
+  context: { startedAtMs: Date.now(), artifactPointer: { update: async () => undefined } } as never,
+  timeoutMs: 1_000,
+  destroyActiveRuntime: async () => { destroyedRuntime = true },
+})
+const keepAlive = setTimeout(() => undefined, 100)
+try {
+  await assert.rejects(
+    phaseExecutor.operation("workflow.steps[0]:wordpress.wp-cli", new Promise<never>(() => undefined), 10),
+    (error: unknown) => error instanceof RecipeRunTimeoutError && error.timeoutMs === 10,
+  )
+} finally {
+  clearTimeout(keepAlive)
+}
+assert.equal(destroyedRuntime, true)
 
 console.log("recipe step metadata contract ok")


### PR DESCRIPTION
## Summary

- add a positive `timeoutMs` contract to recipe workflow steps
- preserve step timeouts through recipe builders and execution-spec lowering
- cap each workflow operation by its declared timeout and the remaining recipe budget
- retain deterministic timeout and runtime-cleanup evidence

## Evidence

- `npx tsx tests/recipe-step-metadata.test.ts`
- `npx tsx tests/recipe-builder-bench-steps.test.ts`
- `npx tsx tests/wordpress-workload-primitives.test.ts`
- `npx tsx tests/recipe-validation-descriptors.test.ts`
- `npm run build`
- `npm run smoke -- --group package` (passes; Docker-backed MySQL E2E skips because Docker is unavailable)

Fixes #2183.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the dropped timeout contract, drafted the implementation and deterministic tests, and ran the verification commands. Chris Huber reviewed and is responsible for the change.