### PR TITLE
fix: require redirect evidence for loop diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "test:browser-actions-environment": "tsx --test tests/browser-actions-environment.browser.test.ts",
     "test:browser-recipe-file-payloads-integration": "tsx tests/browser-recipe-file-payloads.integration.test.ts",
     "test:browser-diagnostic-providers": "tsx tests/browser-diagnostic-providers.test.ts",
+    "test:browser-redirect-diagnostics": "tsx tests/browser-redirect-diagnostics.test.ts",
     "test:browser-capture-html-diagnostics-reliability": "tsx tests/browser-capture-html-diagnostics-reliability.test.ts",
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
     "test:browser-provider-bridge-inheritance": "tsx tests/browser-provider-bridge-inheritance.test.ts",

--- a/packages/runtime-playground/src/browser-probe-support.ts
+++ b/packages/runtime-playground/src/browser-probe-support.ts
@@ -335,9 +335,9 @@ export function browserRedirectDiagnosticsArtifact({
   const repeatedUrls = repeatedBrowserRedirectValues(chain.map((entry) => entry.url), "url")
   const repeatedHosts = repeatedBrowserRedirectValues(chain.map((entry) => entry.host).filter((host): host is string => Boolean(host)), "host")
   const repeatedPaths = repeatedBrowserRedirectValues(chain.map((entry) => entry.path).filter((path): path is string => Boolean(path)), "path")
-  const hasRepeatedTarget = repeatedUrls.length > 0 || repeatedHosts.length > 0 || repeatedPaths.length > 0
+  const repeatedRedirectUrls = repeatedBrowserRedirectValues(redirectResponses.map((record) => browserRedirectSafeUrl(record.url)), "url")
 
-  if (!tooManyRedirects && redirectResponses.length === 0 && !hasRepeatedTarget) {
+  if (!tooManyRedirects && redirectResponses.length === 0) {
     return undefined
   }
 
@@ -346,10 +346,10 @@ export function browserRedirectDiagnosticsArtifact({
   const lastUrl = chain.at(-1)?.url ?? finalAttempted
   const sanitizedQueryKeys = [...new Set(chain.flatMap((entry) => entry.queryKeys))].sort()
   const redactedQueryKeys = [...new Set(chain.flatMap((entry) => entry.redactedQueryKeys))].sort()
-  const classification: BrowserRedirectDiagnosticsSummary["classification"] = tooManyRedirects || hasRepeatedTarget ? "redirect-loop" : "redirect-chain"
+  const classification: BrowserRedirectDiagnosticsSummary["classification"] = tooManyRedirects || repeatedRedirectUrls.length > 0 ? "redirect-loop" : "redirect-chain"
   const reason = tooManyRedirects
     ? "playwright reported ERR_TOO_MANY_REDIRECTS"
-    : hasRepeatedTarget ? "document navigation repeated URL, host, or path values" : "document navigation included redirect responses"
+    : repeatedRedirectUrls.length > 0 ? "redirect responses repeated document URL values" : "document navigation included redirect responses"
   const summary: BrowserRedirectDiagnosticsSummary = {
     status: "captured",
     artifact: artifactPath,

--- a/tests/browser-redirect-diagnostics.test.ts
+++ b/tests/browser-redirect-diagnostics.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+
+import type { BrowserProbeNetworkRecord } from "../packages/runtime-playground/src/browser-artifacts.js"
+import { browserRedirectDiagnosticsArtifact } from "../packages/runtime-playground/src/browser-probe-support.js"
+
+const response = (url: string, status: number, timestamp: string): BrowserProbeNetworkRecord => ({
+  type: "response",
+  method: "GET",
+  url,
+  resourceType: "document",
+  status,
+  timestamp,
+})
+
+const artifact = (network: BrowserProbeNetworkRecord[], error?: Error) => browserRedirectDiagnosticsArtifact({
+  artifactPath: "files/browser/redirect-diagnostics.json",
+  error,
+  finalAttemptedUrl: network.at(-1)?.url ?? "https://example.test/",
+  network,
+  requestedUrl: network[0]?.url ?? "https://example.test/",
+})
+
+const repeatedSuccessfulVisits = artifact([
+  response("https://example.test/community/", 200, "2026-08-01T00:00:00.000Z"),
+  response("https://example.test/community/", 200, "2026-08-01T00:00:01.000Z"),
+  response("https://example.test/community/", 200, "2026-08-01T00:00:02.000Z"),
+])
+assert.equal(repeatedSuccessfulVisits, undefined)
+
+const redirectChain = artifact([
+  response("https://example.test/start", 301, "2026-08-01T00:00:00.000Z"),
+  response("https://example.test/next", 302, "2026-08-01T00:00:01.000Z"),
+  response("https://example.test/final", 200, "2026-08-01T00:00:02.000Z"),
+])
+assert.equal(redirectChain?.classification, "redirect-chain")
+assert.equal(redirectChain?.summary.redirectResponses, 2)
+assert.deepEqual(redirectChain?.summary.repeatedHosts, [{ host: "example.test", count: 3 }])
+
+const redirectThenRepeatedSuccessfulVisits = artifact([
+  response("https://example.test/start", 302, "2026-08-01T00:00:00.000Z"),
+  response("https://example.test/community/", 200, "2026-08-01T00:00:01.000Z"),
+  response("https://example.test/community/", 200, "2026-08-01T00:00:02.000Z"),
+])
+assert.equal(redirectThenRepeatedSuccessfulVisits?.classification, "redirect-chain")
+assert.deepEqual(redirectThenRepeatedSuccessfulVisits?.summary.repeatedUrls, [{ url: "https://example.test/community/", count: 2 }])
+
+const redirectLoop = artifact([
+  response("https://example.test/first", 302, "2026-08-01T00:00:00.000Z"),
+  response("https://example.test/second", 302, "2026-08-01T00:00:01.000Z"),
+  response("https://example.test/first", 302, "2026-08-01T00:00:02.000Z"),
+])
+assert.equal(redirectLoop?.classification, "redirect-loop")
+assert.equal(redirectLoop?.reason, "redirect responses repeated document URL values")
+assert.equal(redirectLoop?.summary.redirectResponses, 3)
+assert.deepEqual(redirectLoop?.summary.repeatedUrls, [{ url: "https://example.test/first", count: 2 }])
+
+const browserReportedLoop = artifact([], new Error("page.goto: net::ERR_TOO_MANY_REDIRECTS at https://example.test/loop"))
+assert.equal(browserReportedLoop?.classification, "redirect-loop")
+assert.equal(browserReportedLoop?.summary.redirectResponses, 0)
+
+console.log("browser redirect diagnostics ok")


### PR DESCRIPTION
## Summary

- stop repeated successful document visits from producing redirect diagnostics or a `redirect-loop` classification
- classify a captured chain as a loop only when Playwright reports `ERR_TOO_MANY_REDIRECTS` or redirect responses repeat a document URL
- retain the existing `browser-redirect-diagnostics/v1` summary shape and repetition details for real redirect chains and loops

## Root cause

`browserRedirectDiagnosticsArtifact()` treated repeated URL, host, or path values as both sufficient reason to emit a redirect artifact and sufficient evidence of a loop. Adaptive exploration can legitimately revisit the same document, so three independent `200 OK` responses to `/community/` met that threshold despite `redirectResponses: 0`.

## Classifier semantics

Before:

- emit diagnostics for any repeated document URL, host, or path, any 3xx document response, or `ERR_TOO_MANY_REDIRECTS`
- classify any repetition as `redirect-loop`, including ordinary repeated 200 visits and same-host redirect chains

After:

- emit diagnostics only when document responses contain 3xx evidence or Playwright reports `ERR_TOO_MANY_REDIRECTS`
- classify as `redirect-loop` only for Playwright's explicit loop signal or a repeated URL among the redirect responses themselves
- classify non-cyclic 3xx navigation as `redirect-chain`
- preserve existing artifact paths, schema/version, summary fields, and optional action/probe summary integration

## Regression tests

Added deterministic coverage for:

- three repeated `200 OK` document visits producing no redirect diagnostic
- an ordinary same-host redirect chain remaining `redirect-chain`
- a redirect followed by repeated successful visits remaining `redirect-chain` while retaining repetition details
- repeated redirect-response URLs producing `redirect-loop`
- Playwright `ERR_TOO_MANY_REDIRECTS` remaining `redirect-loop`

## Verification

- `npm run test:browser-redirect-diagnostics` - passed (`browser redirect diagnostics ok`)
- `npm run test:browser-artifact-session` - passed
- `npm run test:browser-diagnostic-providers` - passed (`browser diagnostic providers ok`)
- `npm run test:artifact-result-envelope` - passed (`artifact result envelope contract passed`)
- `npm run test:browser-session-public-dto` - passed (`browser session public dto ok`)
- `npm run test:public-api-contract` - passed (`public API contract ok`)
- `npm run build` - passed
- `git diff --check` - passed

Fixes #2186