### PR TITLE
fix: route converted multisite previews through proxy

### DIFF
--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -14,6 +14,7 @@ export interface BrowserPreviewNetworkPolicy {
   allowHosts: Set<string>
   blockHosts: Set<string>
   routeHosts: Set<string>
+  routeOrigins: Set<string>
   firstPartyHosts: Set<string>
   recordExternal: boolean
   stats: Map<string, { requests: number; external: boolean; blocked: number; routed: number }>
@@ -115,7 +116,7 @@ export function browserPreviewTopology(args: string[], runtimeSpec: RuntimeCreat
   const routedHosts = [...new Set([...commaListArg(args, "route-host"), ...(declaredTopology?.routeHosts ?? [])])]
   const preview = browserPreviewRouting(args, runtimeSpec, localPreviewOrigin)
   applyCanonicalRoutedPreviewOrigin(preview, playgroundSiteSeedPrimaryUrl(runtimeSpec) ?? runtimeSpec?.preview?.siteUrl, routedHosts)
-  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
+  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview, browserPreviewInternalRouteOrigins(preview, upstreamRuntimeOrigin))
 
   return {
     preview,
@@ -151,6 +152,9 @@ export function browserPreviewNavigationScope(effectivePreviewOrigin: string, po
       }
       if (policy.routeHosts.has(normalizeBrowserPreviewHost(resolved.hostname))) {
         return { allowed: true, rawOrigin, effectiveOrigin, routeDecision: "routed-preview", reason: "declared-route-host" }
+      }
+      if (policy.routeOrigins.has(rawOrigin)) {
+        return { allowed: true, rawOrigin, effectiveOrigin, routeDecision: "routed-preview", reason: "internal-runtime-origin" }
       }
       return { allowed: false, rawOrigin, effectiveOrigin: rawOrigin, routeDecision: "external", reason: policy.allowHosts.has(normalizeBrowserPreviewHost(resolved.hostname)) ? "network-host-allowed-but-not-routed" : "host-not-routed-to-preview" }
     },
@@ -252,7 +256,7 @@ export function browserPreviewAuthCookieUrls(localPreviewOrigin: string, routedH
   return uniqueBrowserPreviewAuthCookieUrls(urls)
 }
 
-export function browserPreviewNetworkPolicy(args: string[], routeHosts: string[], preview: BrowserProbePreviewRouting): BrowserPreviewNetworkPolicy {
+export function browserPreviewNetworkPolicy(args: string[], routeHosts: string[], preview: BrowserProbePreviewRouting, routeOrigins: string[] = []): BrowserPreviewNetworkPolicy {
   const mode = browserPreviewNetworkPolicyMode(args)
   const allowHosts = new Set(commaListArg(args, "allow-host").map(normalizeBrowserPreviewHost).filter(Boolean))
   const blockHosts = new Set(commaListArg(args, "block-host").map(normalizeBrowserPreviewHost).filter(Boolean))
@@ -270,6 +274,7 @@ export function browserPreviewNetworkPolicy(args: string[], routeHosts: string[]
     allowHosts,
     blockHosts,
     routeHosts: routedHosts,
+    routeOrigins: new Set(routeOrigins),
     firstPartyHosts,
     recordExternal: strictBooleanArg(args, "record-external", false),
     stats: new Map(),
@@ -283,7 +288,7 @@ export function browserPreviewNetworkPolicyIsActive(policy: BrowserPreviewNetwor
 }
 
 export function browserPreviewNeedsContextRouting(policy: BrowserPreviewNetworkPolicy): boolean {
-  return policy.mode === "block" || policy.blockHosts.size > 0 || policy.routeHosts.size > 0 || policy.recordExternal
+  return policy.mode === "block" || policy.blockHosts.size > 0 || policy.routeHosts.size > 0 || policy.routeOrigins.size > 0 || policy.recordExternal
 }
 
 export function browserPreviewNetworkPolicySummary(policy: BrowserPreviewNetworkPolicy): BrowserProbeNetworkPolicySummary {
@@ -446,15 +451,25 @@ async function handleBrowserPreviewRoute(route: Route, policy: BrowserPreviewNet
     return
   }
 
-  if (policy.routeHosts.has(host)) {
+  const internalRuntimeRoute = policy.routeOrigins.has(requestUrl.origin)
+  if (internalRuntimeRoute || policy.routeHosts.has(host)) {
     stat.routed += 1
-    if (policy.preserveRoutedOrigin) {
+    if (internalRuntimeRoute && request.resourceType() === "document") {
+      const previewUrl = new URL(requestUrl.toString())
+      previewUrl.protocol = origin.protocol
+      previewUrl.hostname = origin.hostname
+      previewUrl.port = origin.port
+      setOperation("redirect-internal-runtime-document")
+      await route.fulfill({ status: 307, headers: { location: previewUrl.toString() }, body: "" })
+      return
+    }
+    if (!internalRuntimeRoute && policy.preserveRoutedOrigin) {
       setOperation("continue-preserved-routed-origin")
       await route.continue()
       return
     }
     setOperation("fulfill-routed-host")
-    await fulfillBrowserPreviewRoutedHost(route, requestUrl, policy, origin)
+    await fulfillBrowserPreviewRoutedHost(route, requestUrl, policy, origin, !internalRuntimeRoute)
     return
   }
 
@@ -469,8 +484,8 @@ async function handleBrowserPreviewRoute(route: Route, policy: BrowserPreviewNet
   await route.continue()
 }
 
-async function fulfillBrowserPreviewRoutedHost(route: Route, requestUrl: URL, policy: BrowserPreviewNetworkPolicy, localOrigin: URL): Promise<void> {
-  const response = await fetchBrowserPreviewRoutedHost(route, requestUrl, policy, localOrigin)
+async function fulfillBrowserPreviewRoutedHost(route: Route, requestUrl: URL, policy: BrowserPreviewNetworkPolicy, localOrigin: URL, preserveRequestedAuthority: boolean): Promise<void> {
+  const response = await fetchBrowserPreviewRoutedHost(route, requestUrl, policy, localOrigin, preserveRequestedAuthority)
   if (!response) {
     return
   }
@@ -543,7 +558,7 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, policy: BrowserPreviewNetworkPolicy, origin: URL): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
+async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, policy: BrowserPreviewNetworkPolicy, origin: URL, preserveRequestedAuthority: boolean): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
   let currentUrl = requestUrl
   for (let redirectCount = 0; redirectCount < 10; redirectCount++) {
     const routedUrl = new URL(currentUrl.toString())
@@ -562,10 +577,10 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, poli
           url: routedUrl.toString(),
           headers: {
             ...route.request().headers(),
-            host: currentUrl.host,
-            "x-forwarded-host": currentUrl.host,
-            "x-forwarded-port": currentUrl.port || (currentUrl.protocol === "https:" ? "443" : "80"),
-            "x-forwarded-proto": currentUrl.protocol.replace(":", ""),
+            host: preserveRequestedAuthority ? currentUrl.host : origin.host,
+            "x-forwarded-host": preserveRequestedAuthority ? currentUrl.host : origin.host,
+            "x-forwarded-port": preserveRequestedAuthority ? (currentUrl.port || (currentUrl.protocol === "https:" ? "443" : "80")) : (origin.port || (origin.protocol === "https:" ? "443" : "80")),
+            "x-forwarded-proto": (preserveRequestedAuthority ? currentUrl.protocol : origin.protocol).replace(":", ""),
           },
           maxRedirects: 0,
         })
@@ -605,7 +620,7 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, poli
       return response
     }
     const redirectedHost = normalizeBrowserPreviewHost(redirectedUrl.hostname)
-    if (!policy.routeHosts.has(redirectedHost)) {
+    if (!policy.routeOrigins.has(redirectedUrl.origin) && !policy.routeHosts.has(redirectedHost)) {
       const stat = browserPreviewNetworkPolicyHostStat(policy, redirectedHost)
       stat.requests += 1
       stat.external = true
@@ -624,6 +639,16 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, poli
   }
 
   throw new Error(`wordpress.browser-probe route-host exceeded redirect limit for ${requestUrl.href}`)
+}
+
+function browserPreviewInternalRouteOrigins(preview: BrowserProbePreviewRouting, upstreamRuntimeOrigin: string | undefined): string[] {
+  if (!upstreamRuntimeOrigin) {
+    return []
+  }
+
+  const upstream = new URL(upstreamRuntimeOrigin)
+  const previewOrigins = new Set([new URL(preview.localOrigin).origin, new URL(preview.effectiveOrigin).origin])
+  return [...new Set([upstream.origin, `${upstream.protocol}//${upstream.hostname}`])].filter((origin) => !previewOrigins.has(origin))
 }
 
 export function isBrowserPreviewRouteFetchRequestContextDisposedError(error: unknown): boolean {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -1,5 +1,6 @@
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
+import { Transform } from "node:stream"
 import type { PreviewLease } from "@automattic/wp-codebox-core"
 
 export interface PlaygroundServerRunResponse {
@@ -190,14 +191,26 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
       },
       (response) => {
         targetResponse = response
-        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, proxyResponseHeaders(response.headers, requestTarget, target))
+        const headers = proxyResponseHeaders(response.headers, requestTarget, target)
+        const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target)
+        if (bodyTransform) {
+          delete headers["content-length"]
+          delete headers["content-md5"]
+          delete headers.etag
+        }
+        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, headers)
         response.on("error", (error) => {
           outgoing.destroy(error)
           settle()
         })
         outgoing.on("finish", settle)
         outgoing.on("close", settle)
-        response.pipe(outgoing)
+        if (bodyTransform) {
+          bodyTransform.on("error", (error) => outgoing.destroy(error))
+          response.pipe(bodyTransform).pipe(outgoing)
+        } else {
+          response.pipe(outgoing)
+        }
       },
     )
 
@@ -220,6 +233,7 @@ interface PreviewProxyRequestTarget {
   path: string
   port: string
   protocol: "http:" | "https:"
+  rewriteTargetOrigin: boolean
 }
 
 function previewProxyRequestTarget(incoming: IncomingMessage, target: URL): PreviewProxyRequestTarget {
@@ -233,6 +247,7 @@ function previewProxyRequestTarget(incoming: IncomingMessage, target: URL): Prev
         path: `${url.pathname}${url.search}`,
         port: url.port || (url.protocol === "https:" ? "443" : "80"),
         protocol: url.protocol,
+        rewriteTargetOrigin: false,
       }
     }
   } catch {
@@ -240,7 +255,7 @@ function previewProxyRequestTarget(incoming: IncomingMessage, target: URL): Prev
   }
   const host = incoming.headers.host ?? "localhost"
   const authority = new URL(`http://${host}`)
-  return { upstreamHost: target.host, visibleHost: authority.host, path: rawUrl, port: authority.port || "80", protocol: "http:" }
+  return { upstreamHost: target.host, visibleHost: authority.host, path: rawUrl, port: authority.port || "80", protocol: "http:", rewriteTargetOrigin: true }
 }
 
 function createPreviewProxyQueue(): (task: () => Promise<void>) => Promise<void> {
@@ -308,6 +323,9 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: Previe
   delete forwarded["x-forwarded-host"]
   delete forwarded["x-forwarded-port"]
   delete forwarded["x-forwarded-proto"]
+  if (requestTarget.rewriteTargetOrigin) {
+    forwarded["accept-encoding"] = "identity"
+  }
 
   return {
     ...forwarded,
@@ -339,6 +357,92 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: Previ
   }
 
   return forwarded
+}
+
+function previewProxyResponseBodyTransform(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, target: URL): Transform | undefined {
+  if (!requestTarget.rewriteTargetOrigin || requestTarget.visibleHost === target.host || !previewProxyTextResponse(headers)) {
+    return undefined
+  }
+
+  const contentEncoding = headerValue(headers["content-encoding"])
+  if (contentEncoding && contentEncoding.toLowerCase() !== "identity") {
+    return undefined
+  }
+
+  return originRewriteTransform(
+    [target.origin, `${target.protocol}//${target.hostname}`],
+    `${requestTarget.protocol}//${requestTarget.visibleHost}`,
+  )
+}
+
+function previewProxyTextResponse(headers: IncomingHttpHeaders): boolean {
+  const contentType = headerValue(headers["content-type"])
+  return !!contentType && (/^text\//i.test(contentType) || /\b(?:html|css|javascript|json|xml|svg)\b/i.test(contentType))
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function originRewriteTransform(internalOrigins: string[], visibleOrigin: string): Transform {
+  const searches = [...new Set(internalOrigins)]
+    .filter((origin) => origin !== visibleOrigin)
+    .map((origin) => Buffer.from(origin))
+    .sort((left, right) => right.length - left.length)
+  const replacement = Buffer.from(visibleOrigin)
+  const overlap = Math.max(...searches.map((search) => search.length), 1)
+  let pending = Buffer.alloc(0)
+
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      pending = Buffer.concat([pending, chunk])
+      let match = nextOriginMatch(pending, searches)
+      while (match) {
+        this.push(pending.subarray(0, match.index))
+        this.push(replacement)
+        pending = pending.subarray(match.index + match.search.length)
+        match = nextOriginMatch(pending, searches)
+      }
+
+      const safeLength = Math.max(0, pending.length - overlap)
+      if (safeLength > 0) {
+        this.push(pending.subarray(0, safeLength))
+        pending = pending.subarray(safeLength)
+      }
+      callback()
+    },
+    flush(callback) {
+      let match = nextOriginMatch(pending, searches, true)
+      while (match) {
+        this.push(pending.subarray(0, match.index))
+        this.push(replacement)
+        pending = pending.subarray(match.index + match.search.length)
+        match = nextOriginMatch(pending, searches, true)
+      }
+      this.push(pending)
+      callback()
+    },
+  })
+}
+
+function nextOriginMatch(buffer: Buffer, searches: Buffer[], allowTerminal = false): { index: number; search: Buffer } | undefined {
+  let match: { index: number; search: Buffer } | undefined
+  for (const search of searches) {
+    let index = buffer.indexOf(search)
+    while (index !== -1) {
+      const end = index + search.length
+      const boundary = end < buffer.length ? String.fromCharCode(buffer[end]!) : undefined
+      const completeOrigin = boundary ? /[\/?#\s'"<>)\]},;\\]/.test(boundary) : allowTerminal
+      if (completeOrigin) {
+        if (!match || index < match.index || (index === match.index && search.length > match.search.length)) {
+          match = { index, search }
+        }
+        break
+      }
+      index = buffer.indexOf(search, index + 1)
+    }
+  }
+  return match
 }
 
 function writeProxyError(outgoing: ServerResponse, error: Error): void {

--- a/tests/browser-canonical-preview-origin.test.ts
+++ b/tests/browser-canonical-preview-origin.test.ts
@@ -33,6 +33,28 @@ const upstream = createServer((request, response) => {
       response.end()
       return
     }
+    if (request.url === "/community/generated.js") {
+      response.writeHead(200, { "content-type": "application/javascript" })
+      response.end("window.generatedAssetLoaded = true")
+      return
+    }
+    if (request.url === "/community/wp-login.php") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+      response.end("<!doctype html><title>Community login</title><main>Login loaded</main>")
+      return
+    }
+    if (request.url === "/community/") {
+      const body = `<!doctype html><script src="${upstreamUrl}/community/generated.js"></script><a id="login" href="${upstreamUrl}/community/wp-login.php">Log in</a><a id="hostname-only" href="http://127.0.0.1/community/">Community</a><a id="unrelated-port" href="http://127.0.0.1:9999/">Unrelated</a>`
+      response.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": String(Buffer.byteLength(body)),
+        etag: "internal-authority-body",
+      })
+      const splitOrigin = Buffer.from(upstreamUrl)
+      response.write(Buffer.concat([Buffer.from("<!doctype html><script src=\""), splitOrigin.subarray(0, splitOrigin.length - 2)]))
+      response.end(`${splitOrigin.subarray(splitOrigin.length - 2).toString()}/community/generated.js\"></script><a id=\"login\" href=\"${upstreamUrl}/community/wp-login.php\">Log in</a><a id=\"hostname-only\" href=\"http://127.0.0.1/community/\">Community</a><a id=\"unrelated-port\" href=\"http://127.0.0.1:9999/\">Unrelated</a>`)
+      return
+    }
 
     response.writeHead(200, {
       "content-type": "text/html; charset=utf-8",
@@ -65,6 +87,20 @@ try {
   const proxyOrigin = new URL(proxy.serverUrl)
   const upstreamOrigin = new URL(upstreamUrl)
   assert(requests.some((request) => request.url === "/direct-preview/" && request.host === upstreamOrigin.host && request.forwardedHost === proxyOrigin.host && request.forwardedPort === proxyOrigin.port && request.forwardedProto === "http"))
+
+  const pathContext = await browser.newContext()
+  const pathPage = await pathContext.newPage()
+  await pathPage.goto(`${proxy.serverUrl}/community/`, { waitUntil: "load" })
+  assert.equal(await pathPage.evaluate(() => (window as typeof window & { generatedAssetLoaded?: boolean }).generatedAssetLoaded), true)
+  assert.equal(await pathPage.locator("script").getAttribute("src"), `${proxy.serverUrl}/community/generated.js`)
+  assert.equal(await pathPage.locator("#login").getAttribute("href"), `${proxy.serverUrl}/community/wp-login.php`)
+  assert.equal(await pathPage.locator("#hostname-only").getAttribute("href"), `${proxy.serverUrl}/community/`)
+  assert.equal(await pathPage.locator("#unrelated-port").getAttribute("href"), "http://127.0.0.1:9999/")
+  await Promise.all([pathPage.waitForURL(`${proxy.serverUrl}/community/wp-login.php`), pathPage.click("#login")])
+  assert.equal(await pathPage.locator("main").textContent(), "Login loaded")
+  assert(requests.some((request) => request.url === "/community/generated.js" && request.host === upstreamOrigin.host && request.forwardedHost === proxyOrigin.host))
+  assert(requests.some((request) => request.url === "/community/wp-login.php" && request.host === upstreamOrigin.host && request.forwardedHost === proxyOrigin.host))
+  await pathContext.close()
 
   const context = await browser.newContext({
     ...topology.contextOptions(),

--- a/tests/playground-mapped-domain-multisite.integration.test.ts
+++ b/tests/playground-mapped-domain-multisite.integration.test.ts
@@ -152,8 +152,8 @@ async function verifyConvertedPathMultisitePreview(): Promise<void> {
         steps: [
           { command: "wordpress.wp-cli", args: ["command=wp core multisite-convert --title=\"Path Network\" --base=\"/\""] },
           { command: "wordpress.run-php", args: ["code=$network = get_network(); $site_id = wp_insert_site( array( 'domain' => $network->domain, 'path' => '/community/', 'network_id' => $network->id, 'title' => 'Community' ) ); if ( is_wp_error( $site_id ) ) { throw new RuntimeException( $site_id->get_error_message() ); } update_blog_option( $site_id, 'home', 'http://' . $network->domain . '/community/' ); update_blog_option( $site_id, 'siteurl', 'http://' . $network->domain . '/community/' ); update_blog_option( $site_id, 'blogname', 'Community' );"] },
-          { command: "wordpress.browser-probe", args: ["url=/community/", "wait-for=load", "script=return { pathname: location.pathname };", "capture=network"] },
-          { command: "wordpress.browser-probe", args: ["url=/community/wp-login.php", "wait-for=load", "script=return { pathname: location.pathname };", "capture=network"] },
+          { command: "wordpress.browser-probe", args: ["url=/community/", "wait-for=load", "script=const generated = [...document.querySelectorAll('[src],[href]')].map((element) => element.src || element.href).filter((url) => url.startsWith('http://127.0.0.1')); const fetched = await fetch('/community/wp-login.php'); return { pathname: location.pathname, generatedOrigins: [...new Set(generated.map((url) => new URL(url).origin))], fetchUrl: fetched.url };", "capture=network"] },
+          { command: "wordpress.browser-actions", args: ["steps-json=[{\"kind\":\"navigate\",\"url\":\"http://127.0.0.1/community/wp-login.php\",\"waitFor\":\"load\"},{\"kind\":\"evaluate\",\"expression\":\"location.pathname\",\"assert\":\"/community/wp-login.php\"}]", "capture=steps,network"] },
         ],
       },
     })}\n`)
@@ -174,13 +174,24 @@ async function verifyConvertedPathMultisitePreview(): Promise<void> {
 
     assert.equal(output.success, true, JSON.stringify(output))
     const probes = output.executions?.filter((execution) => execution.command === "wordpress.browser-probe") ?? []
-    assert.equal(probes.length, 2)
+    assert.equal(probes.length, 1)
     const community = JSON.parse(probes[0]!.stdout)
-    const login = JSON.parse(probes[1]!.stdout)
     assert.equal(new URL(community.finalUrl).pathname, "/community/")
-    assert.deepEqual(community.summary.scriptResult, { pathname: "/community/" })
+    assert.equal(community.summary.scriptResult.pathname, "/community/")
+    assert(community.summary.scriptResult.generatedOrigins.length > 0)
+    const generatedOrigins = [...new Set(community.summary.scriptResult.generatedOrigins.map((origin: string) => new URL(origin).origin))]
+    assert(generatedOrigins.includes(new URL(community.finalUrl).origin))
+    assert(generatedOrigins.every((origin) => origin === "http://127.0.0.1" || origin === new URL(community.finalUrl).origin))
+    assert.equal(community.summary.scriptResult.fetchUrl, `${new URL(community.finalUrl).origin}/community/wp-login.php`)
+    const actions = output.executions?.filter((execution) => execution.command === "wordpress.browser-actions") ?? []
+    assert.equal(actions.length, 1)
+    const login = JSON.parse(actions[0]!.stdout)
     assert.equal(new URL(login.finalUrl).pathname, "/community/wp-login.php")
-    assert.deepEqual(login.summary.scriptResult, { pathname: "/community/wp-login.php" })
+    assert.equal(new URL(login.finalUrl).origin, new URL(community.finalUrl).origin)
+    assert.deepEqual(login.steps.map((step: { kind: string; status: string }) => ({ kind: step.kind, status: step.status })), [
+      { kind: "navigate", status: "ok" },
+      { kind: "evaluate", status: "ok" },
+    ])
   } finally {
     await rm(pathRoot, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- Rewrite generated internal Playground origins in textual preview responses to the reviewer-visible preview authority.
- Route runtime-origin aliases through the existing browser routing primitive, canonicalizing internal document navigation to the preview URL while transparently serving internal subresources.
- Preserve absolute-form mapped-domain routing and forwarded authority semantics from #2182.

## Root cause
The preview proxy fixed redirect handling and forwarded the visible authority for origin-form requests, but converted path-based multisite retained the internal Playground authority in network/site state. WordPress could therefore emit the internal origin in HTML, scripts, assets, and navigation. Some hostname-only URLs were also assembled client-side, beyond response-body rewriting. Because the existing `route-host` primitive is hostname-based, it could not safely declare a second `127.0.0.1` port without also matching the preview listener.

## Owning layer
This belongs in the generic Playground preview boundary. The proxy now rewrites only textual origin-form responses and leaves absolute-form requests unchanged. Browser topology registers the known upstream runtime authorities as authority-specific aliases in the existing routing primitive; no multisite, consumer, or Extra Chill behavior is introduced.

## Behavior
Before:
- `/community/` could render through the preview URL while generated assets and links targeted the internal Playground authority.
- Normal internal links were rejected as `host-not-routed-to-preview` or timed out during the first browser journey step.

After:
- Literal internal origins in HTML/JSON/JS/CSS/XML/SVG text responses are streamed to the visible preview origin, including matches split across response chunks.
- Internal-origin subresources are fetched through the preview listener.
- Internal document navigation receives a temporary redirect to the equivalent preview URL, so the browser-visible authority remains canonical.
- Unrelated localhost ports are not rewritten.
- Declared mapped domains retain absolute-form authority and reviewer-visible forwarded authority behavior.

## Regression coverage
- The deterministic proxy/browser contract verifies generated scripts and links use the preview authority, generated assets load, login navigation succeeds, split-chunk origin rewriting works, and unrelated ports remain unchanged.
- The real Playground integration converts WordPress to path-based multisite, creates `/community/`, verifies generated resource origins and a same-site fetch, then runs a two-step `wordpress.browser-actions` journey from the hostname-only login URL. Navigation lands on the preview authority and the evaluate step completes.
- The existing mapped-domain scenario still verifies alpha/beta domain identity, cross-domain redirect behavior, subresources, REST requests, and blog selection.

## Verification
- `npm run build` passed.
- `npm run test:browser-preview-routing` passed: 14/14.
- `npm run test:browser-canonical-preview-origin` passed.
- `npm run test:playground-mapped-domain-multisite-integration` passed with a real WordPress Playground runtime.
- `npm run test:browser-callback-materialization-contracts` passed.
- `npm run test:generic-primitives` passed.
- `npm run test:browser-actions-environment` passed: 9/9.
- `npm run test:site-seed-multisite` passed.
- `git diff --check` passed.

Fixes #2178