### PR TITLE
fix: run packaged CLI through Node

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -981,6 +981,20 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			if ( is_wp_error( $node ) ) {
 				return $node;
 			}
+
+			$entrypoint = dirname( dirname( $bin ) ) . DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . 'cli' . DIRECTORY_SEPARATOR . 'dist' . DIRECTORY_SEPARATOR . 'index.js';
+			if ( ! is_file( $entrypoint ) ) {
+				return new WP_Error(
+					'wp_codebox_bin_missing',
+					'The bundled WP Codebox JavaScript entrypoint is missing.',
+					array(
+						'status' => 500,
+						'path'   => $entrypoint,
+					)
+				);
+			}
+
+			return escapeshellarg( $node ) . ' ' . escapeshellarg( $entrypoint );
 		}
 
 		return escapeshellarg( $bin );

--- a/scripts/php-agent-runtime-execution-smoke.php
+++ b/scripts/php-agent-runtime-execution-smoke.php
@@ -2,7 +2,17 @@
 
 declare(strict_types=1);
 
+$plugin_root = sys_get_temp_dir() . '/wp-codebox-nonexecutable-cli-' . bin2hex( random_bytes( 4 ) );
+$wrapper     = $plugin_root . '/vendor/wp-codebox-cli/bin/wp-codebox';
+$entrypoint  = $plugin_root . '/vendor/wp-codebox-cli/packages/cli/dist/index.js';
+mkdir( dirname( $wrapper ), 0777, true );
+mkdir( dirname( $entrypoint ), 0777, true );
+file_put_contents( $wrapper, "#!/usr/bin/env bash\n" );
+file_put_contents( $entrypoint, "#!/usr/bin/env node\n" );
+chmod( $wrapper, 0644 );
+
 define( 'ABSPATH', __DIR__ );
+define( 'WP_CODEBOX_PLUGIN_PATH', $plugin_root . '/' );
 
 final class WP_Error {
 	private string $code;
@@ -150,5 +160,28 @@ foreach ( $cases as $name => $case ) {
 	smoke_assert( is_array( $result ) && ! is_wp_error( $result ), $name . ' returns result envelope' );
 	$case['assert']( $result );
 }
+
+$runner = new WP_Codebox_Agent_Sandbox_Runner(
+	array(
+		'command_resolver' => static fn( string $command ): string => 'node' === $command ? '/usr/bin/node' : '',
+	)
+);
+$method = new ReflectionMethod( $runner, 'command_prefix' );
+$prefix = $method->invoke( $runner, $wrapper );
+smoke_assert( ! is_wp_error( $prefix ), 'non-executable bundled wrapper resolves to a command prefix' );
+smoke_assert(
+	escapeshellarg( '/usr/bin/node' ) . ' ' . escapeshellarg( $entrypoint ) === $prefix,
+	'non-executable bundled wrapper runs its JavaScript entrypoint through Node'
+);
+
+unlink( $wrapper );
+unlink( $entrypoint );
+rmdir( dirname( $wrapper ) );
+rmdir( dirname( $entrypoint ) );
+rmdir( dirname( dirname( $entrypoint ) ) );
+rmdir( dirname( dirname( dirname( $entrypoint ) ) ) );
+rmdir( dirname( dirname( dirname( dirname( $entrypoint ) ) ) ) );
+rmdir( dirname( dirname( dirname( $wrapper ) ) ) );
+rmdir( $plugin_root );
 
 echo "agent runtime execution smoke passed\n";


### PR DESCRIPTION
## Summary

- invoke the WordPress plugin's bundled CLI JavaScript entrypoint through Codebox's validated Node resolver
- avoid depending on executable mode surviving WordPress plugin ZIP extraction
- cover the installed-plugin shape with a deliberately non-executable bundled wrapper

## Root cause

`WP_Codebox_Agent_Sandbox_Runner::command_prefix()` already resolved Node for the bundled wrapper, but discarded that result and executed the wrapper path directly. WordPress Studio extracted the packaged wrapper with mode `0644`, causing every public agent task to exit `126` before sandbox creation.

Standalone CLI behavior and explicitly configured JavaScript paths are unchanged.

## Verification

- `php scripts/php-agent-runtime-execution-smoke.php`
- `npm run test:release-package-coverage`
- PHP syntax checks
- `git diff --check`

## AI assistance

OpenCode using `openai/gpt-5.6-sol` reproduced the public Codebox task failure, traced the command construction and package extraction boundary, implemented the repair and regression fixture, and ran verification. Chris Huber reviewed and owns the submitted changes.

Closes #2191.
