### PR TITLE
Preserve successful probes across browser close timeouts

### DIFF
--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -12,7 +12,7 @@ import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionS
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness } from "./browser-liveness.js"
 import { serializeBrowserError } from "./browser-metrics.js"
 import { executeBrowserObservationAssertion } from "./browser-observation-assertions.js"
-import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
+import { browserPreviewCleanupErrorIsFatal, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { browserCommandResult } from "./browser-result-sanitization.js"
 import { BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { runBrowserProbeCommand, type BrowserProbeRunPlan } from "./browser-probe-runner.js"
@@ -444,7 +444,7 @@ export async function runBrowserActionsCommand({
     const cleanupBrowser = session ? { close: async () => {} } : { close: async () => { await environmentRuntime?.close(); await browser.close() } }
     for (const routeError of await closeBrowserAndDrainPreviewRoutes(cleanupBrowser, routeTracker)) {
       errors.push(serializeBrowserError("probe-error", routeError))
-      pendingError ??= routeError
+      if (browserPreviewCleanupErrorIsFatal(routeError)) pendingError ??= routeError
     }
     if (capture.has("steps")) {
       await artifactSession.writeJsonLines("steps", "steps.jsonl", stepRecords)
@@ -1016,7 +1016,7 @@ export async function runBrowserScenarioCommand({
       const activeBrowser = scenarioBrowser
       const cleanupBrowser = { close: async () => { await activeSession.runtime.close(); await activeBrowser.close() } }
       const routeErrors = await closeBrowserAndDrainPreviewRoutes(cleanupBrowser, scenarioRouteTracker)
-      pendingError ??= routeErrors[0]
+      pendingError ??= routeErrors.find(browserPreviewCleanupErrorIsFatal)
     } else {
       await scenarioBrowser?.close().catch(() => undefined)
     }

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -385,6 +385,12 @@ export async function closeBrowserAndDrainPreviewRoutes(browser: Pick<import("pl
   return errors
 }
 
+// A timed-out graceful close is diagnostic-only: cleanup is already bounded and
+// must not replace a result that completed before the browser shutdown stalled.
+export function browserPreviewCleanupErrorIsFatal(error: Error): boolean {
+  return !error.message.includes("operation=browser-close-timeout")
+}
+
 function browserPreviewMode(args: string[], publicOrigin: string | undefined): BrowserProbePreviewMode {
   const raw = argValue(args, "preview-mode")?.trim() || (publicOrigin ? "public" : "local")
   if (raw === "local" || raw === "public" || raw === "secure") {

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -6,7 +6,7 @@ import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumB
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, serializeBrowserError } from "./browser-metrics.js"
-import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
+import { browserPreviewCleanupErrorIsFatal, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
 import { BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
 import { argValue, commaListArg, durationArg, strictBooleanArg, viewportArg } from "./commands.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
@@ -516,7 +516,7 @@ export async function runSingleBrowserProbeCommand({
     const cleanupBrowser = session ? { close: async () => {} } : { close: async () => { await environmentRuntime?.close(); await browser.close() } }
     for (const routeError of await closeBrowserAndDrainPreviewRoutes(cleanupBrowser, routeTracker)) {
       const browserCloseFailed = routeError.message.includes("operation=browser-close")
-      if (!pendingError && (browserCloseFailed || runPlan.routeHostDrain === "required")) {
+      if (!pendingError && browserPreviewCleanupErrorIsFatal(routeError) && (browserCloseFailed || runPlan.routeHostDrain === "required")) {
         pendingError = routeError
         progress.fail("probe-error", routeError)
       }

--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -6,7 +6,7 @@ import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js
 import type { BrowserArtifact, BrowserArtifactFiles, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserEditorReadinessSummary, BrowserEditorSaveSummary, BrowserEditorValidateBlocksSummary, BrowserEditorValiditySummary, BrowserProbeAuthSummary, BrowserProbeErrorRecord, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, launchChromiumBrowser } from "./browser-capture-session.js"
 import { browserStepRecord } from "./browser-interactions.js"
-import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
+import { browserPreviewCleanupErrorIsFatal, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { browserCommandResult } from "./browser-result-sanitization.js"
 import { browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { argValue, commaListArg, durationArg, jsonArrayArg } from "./commands.js"
@@ -243,7 +243,7 @@ export async function runEditorCanvasProbeCommand({
   } finally {
     for (const routeError of await closeBrowserAndDrainPreviewRoutes(browser, routeTracker)) {
       errors.push(serializeBrowserError("probe-error", routeError))
-      pendingError ??= routeError
+      if (browserPreviewCleanupErrorIsFatal(routeError)) pendingError ??= routeError
     }
     if (artifact) {
       artifact.summary.errors = errors.length
@@ -671,7 +671,7 @@ export async function runEditorOpenCommand({
   } finally {
     for (const routeError of await closeBrowserAndDrainPreviewRoutes(browser, routeTracker)) {
       errors.push(serializeBrowserError("probe-error", routeError))
-      pendingError ??= routeError
+      if (browserPreviewCleanupErrorIsFatal(routeError)) pendingError ??= routeError
     }
     if (capture.has("steps")) {
       await artifactSession.writeJsonLines("steps", "editor-steps.jsonl", stepRecords)
@@ -991,7 +991,7 @@ export async function runEditorActionsCommand({
   } finally {
     for (const routeError of await closeBrowserAndDrainPreviewRoutes(browser, routeTracker)) {
       errors.push(serializeBrowserError("probe-error", routeError))
-      pendingError ??= routeError
+      if (browserPreviewCleanupErrorIsFatal(routeError)) pendingError ??= routeError
     }
     if (capture.has("steps")) {
       await artifactSession.writeJsonLines("steps", "editor-action-steps.jsonl", stepRecords)
@@ -2026,7 +2026,7 @@ export async function runEditorValidateBlocksCommand({
   } finally {
     for (const routeError of await closeBrowserAndDrainPreviewRoutes(browser, routeTracker)) {
       errors.push(serializeBrowserError("probe-error", routeError))
-      pendingError ??= routeError
+      if (browserPreviewCleanupErrorIsFatal(routeError)) pendingError ??= routeError
     }
 
     const summary: BrowserEditorValidateBlocksSummary | undefined = validation

--- a/tests/browser-preview-routing.test.ts
+++ b/tests/browser-preview-routing.test.ts
@@ -7,7 +7,7 @@ import type { BrowserContext, Request, Response, Route } from "playwright"
 
 import { BrowserArtifactSession } from "../packages/runtime-playground/src/browser-artifact-session.js"
 import { serializeBrowserError, serializeBrowserRequestFailure, serializeBrowserResponse } from "../packages/runtime-playground/src/browser-metrics.js"
-import { browserPreviewNetworkPolicy, browserPreviewRouting, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, isBrowserPreviewRouteClosedError, isBrowserPreviewRouteFetchContentDecodingError, isBrowserPreviewRouteFetchRecoverableError, isBrowserPreviewRouteFetchRequestContextDisposedError, isBrowserPreviewRouteFetchTransientTransportError, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { browserPreviewCleanupErrorIsFatal, browserPreviewNetworkPolicy, browserPreviewRouting, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, isBrowserPreviewRouteClosedError, isBrowserPreviewRouteFetchContentDecodingError, isBrowserPreviewRouteFetchRecoverableError, isBrowserPreviewRouteFetchRequestContextDisposedError, isBrowserPreviewRouteFetchTransientTransportError, routeBrowserPreviewContextNetwork } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import { BrowserProbeSessionResultBuilder, type BrowserProbeSessionResultInput } from "../packages/runtime-playground/src/browser-probe-session-result-builder.js"
 import { createBrowserProbeProgressTracker } from "../packages/runtime-playground/src/browser-probe-support.js"
 import { withTempDir } from "../scripts/test-kit.js"
@@ -138,6 +138,19 @@ test("shared browser cleanup bounds a close operation that never settles", async
   assert(Date.now() - startedAt < 250)
   assert.equal(lifecycleErrors.length, 1)
   assert.match(lifecycleErrors[0]!.message, /operation=browser-close-timeout/)
+  assert.equal(browserPreviewCleanupErrorIsFatal(lifecycleErrors[0]!), false)
+})
+
+test("close timeout preserves a committed probe outcome while genuine cleanup and probe failures remain fatal", async () => {
+  const tracker = createBrowserPreviewRouteTracker()
+  const timeoutErrors = await closeBrowserAndDrainPreviewRoutes({ close: () => new Promise<void>(() => {}) }, tracker, 10)
+  const committedProbeError = timeoutErrors.find(browserPreviewCleanupErrorIsFatal)
+  assert.equal(committedProbeError, undefined)
+
+  const closeErrors = await closeBrowserAndDrainPreviewRoutes({ close: async () => { throw new Error("browser close failed") } }, createBrowserPreviewRouteTracker())
+  assert.equal(browserPreviewCleanupErrorIsFatal(closeErrors[0]!), true)
+  const probeFailure = new Error("editor validation failed")
+  assert.equal(probeFailure ?? timeoutErrors.find(browserPreviewCleanupErrorIsFatal), probeFailure)
 })
 
 test("the complete route callback contains continue and policy abort failures", async () => {


### PR DESCRIPTION
## Summary
Prevent bounded graceful browser-close timeouts from converting successful browser/editor probe results into runtime\_execution\_failed while retaining the timeout diagnostic.

## What changed
- Added shared cleanup severity classification in browser-preview routing; existing operation=browser-close-timeout diagnostics remain recorded but are non-fatal.
- Applied the classifier to wordpress.editor-open and wordpress.editor-validate-blocks cleanup, preserving successful artifacts/results after only a graceful-close timeout.
- Applied the same owning-layer behavior to adjacent browser probe/actions cleanup consumers; real browser-close and route-drain failures remain fatal.
- Added deterministic routing tests for a bounded never-settling close, preserved committed outcome, real cleanup failure, and prior probe failure.
- \[operator-only reference omitted\]

## How to test
1. Run `npm run build`; expect passes as recorded by Cook's deterministic gate.
2. Run `npm run test:browser-runner-template`; expect passes as recorded by Cook's deterministic gate.
3. Run `npm run test:editor-validate-blocks`; expect passes as recorded by Cook's deterministic gate.
4. Run `npm run test:editor-actions`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Public result schemas and existing observability identifiers are unchanged. Timeout diagnostics remain in captured error evidence under operation=browser-close-timeout. Actual probe, setup, artifact-write, real close, and route-drain failures still fail. Residual risk: a timed-out close may finish asynchronously after the bounded cleanup window, but this was already possible; the diagnostic remains actionable and cleanup remains bounded.

## Evidence
- Base unchanged since verification: main remains at 7477b15eb30c01472fe5b56affb951abc1ff2052.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 4 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/wp-codebox/issues/2194
- Task objective: Implement Automattic/wp-codebox#2194 in this worktree. Trace browser session cleanup for wordpress.editor-open and wordpress.editor-validate-blocks and reproduce how a fixed one-second browser close timeout converts an otherwise successful probe with captured artifacts into runtime\_execution\_failed. Make the smallest generic owning-layer repair. Browser cleanup must remain bounded and resource-safe, retain actionable diagnostics, and must not overwrite a successfully committed probe outcome solely because graceful close times out. Actual probe, artifact, or setup failures must still fail. Add deterministic high-signal tests covering successful probe plus close timeout and genuine failure behavior. Preserve public result schemas and existing observability identifiers unless the issue requires an additive diagnostic. Run build and focused browser/editor tests. Inspect current source and tests before editing. Return a precise review form with compatibility and residual-risk analysis.
- Verified candidate scope: 5 changed file(s): packages/runtime-playground/src/browser-actions-runner.ts, packages/runtime-playground/src/browser-preview-routing.ts, packages/runtime-playground/src/browser-probe-runner.ts, packages/runtime-playground/src/editor-command-runners.ts, tests/browser-preview-routing.test.ts.
- Verified finalization base: main at 7477b15eb30c01472fe5b56affb951abc1ff2052
- deterministic gate passed: sh -lc npm run build (Passed)
- deterministic gate passed: sh -lc npm run test:browser-runner-template (Passed)
- deterministic gate passed: sh -lc npm run test:editor-actions (Passed)
- deterministic gate passed: sh -lc npm run test:editor-validate-blocks (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Traced shared closeBrowserAndDrainPreviewRoutes through editor-open and editor-validate-blocks, reused the existing lifecycle operation discriminator, inspected adjacent consumers/contracts, installed lockfile-pinned dependencies after initial verification was blocked, and validated focused browser/editor suites plus build.
