### PR TITLE
Apply browser close timeout semantics consistently

### DIFF
--- a/packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts
+++ b/packages/runtime-playground/src/browser-multi-actor-scenario-runner.ts
@@ -6,7 +6,7 @@ import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js
 import { attachBrowserCaptureListeners, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeReplayability } from "./browser-probe.js"
-import { browserPreviewReadinessError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
+import { browserPreviewCleanupErrorIsFatal, browserPreviewReadinessError, browserPreviewTopology, closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { browserCommandResult } from "./browser-result-sanitization.js"
 import { installWordPressAdminAuthCookies } from "./browser-probe-support.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
@@ -76,7 +76,7 @@ export async function runBrowserMultiActorScenarioCommand(input: {
     if (error instanceof BrowserMultiActorScenarioError) result = error.result
   } finally {
     const routeErrors = await closeBrowserAndDrainPreviewRoutes(browser, routeTracker)
-    failure ??= routeErrors[0]
+    failure = selectBrowserMultiActorScenarioFailure(failure, routeErrors)
   }
 
   const replay = result?.replay ?? { schema: "wp-codebox/browser-multi-actor-replay/v1", seed: scenario.seed, scenario, schedule: [] }
@@ -95,6 +95,10 @@ export async function runBrowserMultiActorScenarioCommand(input: {
   const artifact = { artifactType: "scenario" as const, requestedUrl: target, url: target, preview: topology.preview, ...topology.origins, files: { summary: "files/browser/multi-actor-scenario-summary.json", steps: "files/browser/multi-actor-events.json", network: "files/browser/multi-actor-network.json", requestCoverage: "files/browser/multi-actor-request-coverage.json", waterfall: "files/browser/multi-actor-waterfall.json", ...(traces.length > 0 ? { traces } : {}) }, summary: { actions: scenario.actions.length, steps: scenario.actions.length, consoleMessages: Object.values(evidence).reduce((total, actor) => total + actor.console.length, 0), errors: Object.values(evidence).reduce((total, actor) => total + actor.errors.length, 0), finalUrl: target, htmlSnapshot: false, networkEvents: network.length, replayability: browserProbeReplayability(captures), screenshot: captures.has("screenshot"), viewport: null, environment: Object.values(evidence)[0]?.environment, multiActor: { seed: scenario.seed, finalState: result?.finalState ?? "failed", actors: Object.keys(evidence), replay: "files/browser/multi-actor-replay.json" } } } satisfies BrowserArtifact
   if (failure) throw new BrowserCommandArtifactError(`wordpress.browser-scenario failed: ${failure.message}`, artifact)
   return browserCommandResult(artifact, { command: "wordpress.browser-scenario", files: artifact.files, summary: artifact.summary, scenario: summary })
+}
+
+export function selectBrowserMultiActorScenarioFailure(failure: Error | undefined, routeErrors: Error[]): Error | undefined {
+  return failure ?? routeErrors.find(browserPreviewCleanupErrorIsFatal)
 }
 
 export async function navigateBrowserMultiActorPages(

--- a/tests/browser-multi-actor-scenario.test.ts
+++ b/tests/browser-multi-actor-scenario.test.ts
@@ -6,7 +6,8 @@ import { join } from "node:path"
 import { BROWSER_MULTI_ACTOR_SCENARIO_SCHEMA, type BrowserMultiActorScenario } from "../packages/runtime-core/src/browser-multi-actor-scenario-contracts.js"
 import type { RuntimeCreateSpec } from "../packages/runtime-core/src/runtime-contracts.js"
 import { BrowserMultiActorScenarioError, runBrowserMultiActorScenario, type BrowserMultiActorClient } from "../packages/runtime-playground/src/browser-multi-actor-scenario.js"
-import { navigateBrowserMultiActorPages, runBrowserMultiActorScenarioCommand } from "../packages/runtime-playground/src/browser-multi-actor-scenario-runner.js"
+import { navigateBrowserMultiActorPages, runBrowserMultiActorScenarioCommand, selectBrowserMultiActorScenarioFailure } from "../packages/runtime-playground/src/browser-multi-actor-scenario-runner.js"
+import { closeBrowserAndDrainPreviewRoutes, createBrowserPreviewRouteTracker } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
 const navigationStarted: string[] = []
@@ -30,6 +31,15 @@ await assert.rejects(
   ], "https://example.test/editor"),
   /Actor reviewer failed to navigate to https:\/\/example\.test\/editor: net::ERR_FAILED/,
 )
+
+const closeTimeoutErrors = await closeBrowserAndDrainPreviewRoutes({ close: () => new Promise<void>(() => {}) }, createBrowserPreviewRouteTracker(), 10)
+assert.equal(selectBrowserMultiActorScenarioFailure(undefined, closeTimeoutErrors), undefined)
+
+const closeFailureErrors = await closeBrowserAndDrainPreviewRoutes({ close: async () => { throw new Error("browser close failed") } }, createBrowserPreviewRouteTracker())
+assert.strictEqual(selectBrowserMultiActorScenarioFailure(undefined, closeFailureErrors), closeFailureErrors[0])
+
+const probeFailure = new Error("editor validation failed")
+assert.strictEqual(selectBrowserMultiActorScenarioFailure(probeFailure, closeTimeoutErrors), probeFailure)
 
 const closed: string[] = []
 const actions: string[] = []

--- a/tests/browser-preview-routing.test.ts
+++ b/tests/browser-preview-routing.test.ts
@@ -141,16 +141,13 @@ test("shared browser cleanup bounds a close operation that never settles", async
   assert.equal(browserPreviewCleanupErrorIsFatal(lifecycleErrors[0]!), false)
 })
 
-test("close timeout preserves a committed probe outcome while genuine cleanup and probe failures remain fatal", async () => {
+test("close timeout is diagnostic-only while genuine cleanup remains fatal", async () => {
   const tracker = createBrowserPreviewRouteTracker()
   const timeoutErrors = await closeBrowserAndDrainPreviewRoutes({ close: () => new Promise<void>(() => {}) }, tracker, 10)
-  const committedProbeError = timeoutErrors.find(browserPreviewCleanupErrorIsFatal)
-  assert.equal(committedProbeError, undefined)
+  assert.equal(timeoutErrors.find(browserPreviewCleanupErrorIsFatal), undefined)
 
   const closeErrors = await closeBrowserAndDrainPreviewRoutes({ close: async () => { throw new Error("browser close failed") } }, createBrowserPreviewRouteTracker())
   assert.equal(browserPreviewCleanupErrorIsFatal(closeErrors[0]!), true)
-  const probeFailure = new Error("editor validation failed")
-  assert.equal(probeFailure ?? timeoutErrors.find(browserPreviewCleanupErrorIsFatal), probeFailure)
 })
 
 test("the complete route callback contains continue and policy abort failures", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2195 and #2194. Apply the merged browser-close timeout severity contract to the remaining multi-actor scenario caller and replace classifier-only assertions with result-selection coverage.

## What changed

- Use `browserPreviewCleanupErrorIsFatal` in `runBrowserMultiActorScenarioCommand`.
- Preserve a pre-existing scenario failure when cleanup only reports `operation=browser-close-timeout`.
- Keep genuine browser-close and route-drain failures fatal.
- Cover timeout, genuine cleanup failure, and pre-existing probe failure at the owning result-selection boundary.

## Verification

- `npm run build`
- `npm run test:browser-preview-routing`
- `npm run test:browser-runner-template`
- `npm run test:editor-validate-blocks`
- `npm run test:editor-actions`
- `PLAYWRIGHT_BROWSERS_PATH=/Users/chubes/Library/Caches/ms-playwright npm run test:browser-scenarios`

All passed locally. Homeboy run `agent-task-cc813887-7b0d-416a-a406-d80be00b9053` recorded the first five deterministic gates; the browser scenario passed after explicitly exposing the existing Playwright cache to the isolated gate environment.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode and Homeboy inspected the shared cleanup callers, implemented the consistency repair and regression coverage, and ran the verification commands. Chris Huber reviewed the patch and remains responsible for every line.