### PR TITLE
Add deterministic WordPress filesystem overlays to prepared browser runtimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "test:browser-visual-compare-url-capture": "npm run build && tsx tests/browser-visual-compare-url-capture.test.ts",
     "test:browser-session-public-dto": "tsx tests/browser-session-public-dto.test.ts",
     "test:browser-playground-session-run": "tsx tests/browser-playground-session-run.test.ts",
+    "test:browser-prepared-runtime-filesystem-overlays": "tsx tests/browser-prepared-runtime-filesystem-overlays.test.ts",
     "test:browser-contained-site-status": "tsx tests/browser-contained-site-status.test.ts",
     "test:host-recipe-builder": "tsx tests/host-recipe-builder.test.ts",
     "test:runtime-recipe-resolver": "tsx tests/runtime-recipe-resolver.test.ts",

--- a/packages/runtime-core/src/runtime-neutral-contracts.ts
+++ b/packages/runtime-core/src/runtime-neutral-contracts.ts
@@ -23,11 +23,25 @@ export interface RuntimeWordPressFilesystemIntent {
   metadata?: Record<string, unknown>
 }
 
+/**
+ * Bytes materialized into a WordPress runtime before caller-provided Blueprint
+ * steps execute. Backends must reject targets outside the WordPress root.
+ */
+export interface RuntimeWordPressFilesystemOverlay {
+  target: string
+  content?: string
+  contentBase64?: string
+  overwrite: boolean
+  purpose?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface RuntimeWordPressSetupPlanIntent {
   schema: "wp-codebox/wordpress-runtime-setup-plan/v1"
   backend?: BackendNeutralRuntimeBackendKind
   components?: RuntimeWordPressComponentIntent[]
   filesystem?: RuntimeWordPressFilesystemIntent[]
+  filesystemOverlays?: RuntimeWordPressFilesystemOverlay[]
   metadata?: Record<string, unknown>
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -493,6 +493,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'plugins'      => $dependencies( $profile['plugins'] ?? array(), 'plugin' ),
 				'mu_plugins'   => $dependencies( $profile['mu_plugins'] ?? array(), 'mu_plugin' ),
 				'themes'       => $dependencies( $profile['themes'] ?? array(), 'theme' ),
+				'filesystem_overlays' => self::object_list( $profile['filesystem_overlays'] ?? array() ),
 				'overlays'     => $dependencies( $profile['overlays'] ?? $profile['runtime_overlays'] ?? array(), 'overlay' ),
 				'runtime_overlays'     => self::object_list( $profile['runtime_overlays'] ?? array() ),
 				'runtime_state_mounts' => self::object_list( $profile['runtime_state_mounts'] ?? array() ),
@@ -532,7 +533,7 @@ final class WP_Codebox_Browser_Task_Builder {
 		$profile_plugins = self::merge_lists( self::object_list( $profile['plugins'] ?? array() ), self::object_list( $profile['provider_plugins'] ?? array() ) );
 		$runtime_plugins = is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array();
 		$runtime['plugins'] = empty( $runtime['resolved_profile'] ) ? self::merge_lists( $profile_plugins, $runtime_plugins ) : self::merge_lists( $runtime_plugins, $profile_plugins );
-		foreach ( array( 'components', 'mu_plugins', 'themes', 'bootstrap', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts' ) as $field ) {
+		foreach ( array( 'components', 'mu_plugins', 'themes', 'bootstrap', 'filesystem_overlays', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts' ) as $field ) {
 			$profile_items = self::object_list( $profile[ $field ] ?? array() );
 			if ( ! empty( $profile_items ) ) {
 				$runtime_items = is_array( $runtime[ $field ] ?? null ) ? $runtime[ $field ] : array();

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
@@ -36,7 +36,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 			is_array( $materialization_profile['provider_plugins'] ?? null ) ? $materialization_profile['provider_plugins'] : array(),
 			is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array()
 		);
-		foreach ( array( 'components', 'mu_plugins', 'themes', 'bootstrap', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts' ) as $field ) {
+		foreach ( array( 'components', 'mu_plugins', 'themes', 'bootstrap', 'filesystem_overlays', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts' ) as $field ) {
 			$items = is_array( $materialization_profile[ $field ] ?? null ) ? $materialization_profile[ $field ] : array();
 			if ( ! empty( $items ) ) {
 				$runtime[ $field ] = self::merge_lists( $items, is_array( $runtime[ $field ] ?? null ) ? $runtime[ $field ] : array() );
@@ -397,7 +397,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 	/** @param array<string,mixed> $profile Resolved runtime profile. @return array<string,mixed> */
 	private static function readiness( array $profile ): array {
 		$missing = array();
-		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'overlays' ) as $field ) {
+		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'filesystem_overlays', 'overlays' ) as $field ) {
 			foreach ( is_array( $profile[ $field ] ?? null ) ? $profile[ $field ] : array() as $entry ) {
 				if ( ! is_array( $entry ) ) {
 					continue;
@@ -474,7 +474,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 
 	/** @param array<string,mixed> $base Base profile. @param array<string,mixed> $extra Extra profile. @return array<string,mixed> */
 	private static function merge_profile( array $base, array $extra ): array {
-		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'overlays', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts', 'provider_plugins', 'extra_plugins', 'component_contracts', 'bootstrap', 'diagnostics' ) as $field ) {
+		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'filesystem_overlays', 'overlays', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts', 'provider_plugins', 'extra_plugins', 'component_contracts', 'bootstrap', 'diagnostics' ) as $field ) {
 			$base[ $field ] = self::merge_lists( is_array( $base[ $field ] ?? null ) ? $base[ $field ] : array(), is_array( $extra[ $field ] ?? null ) ? $extra[ $field ] : array() );
 		}
 		$base['capabilities'] = self::merge_string_lists( $base['capabilities'] ?? array(), $extra['capabilities'] ?? array() );

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php
@@ -235,7 +235,7 @@ final class WP_Codebox_Runtime_Recipe_Resolver {
 
 	/** @param array<string,mixed> $base Base runtime. @param array<string,mixed> $extra Extra runtime. @return array<string,mixed> */
 	private static function merge_runtime( array $base, array $extra ): array {
-		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'bootstrap' ) as $field ) {
+		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'bootstrap', 'filesystem_overlays' ) as $field ) {
 			$base[ $field ] = self::merge_lists( is_array( $base[ $field ] ?? null ) ? $base[ $field ] : array(), is_array( $extra[ $field ] ?? null ) ? $extra[ $field ] : array() );
 		}
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php
@@ -71,15 +71,12 @@ private static function browser_blueprint_with_post_runtime( array $blueprint, a
 
 /** @param array<string,mixed> $blueprint Blueprint override. @param array<string,mixed> $runtime Runtime dependency specs. @return array<string,mixed> */
 private static function browser_blueprint_with_runtime( array $blueprint, array $runtime, array $playground = array() ): array {
-	$steps = is_array( $blueprint['steps'] ?? null ) ? $blueprint['steps'] : array();
-	if ( ! self::browser_blueprint_has_login_step( $steps ) ) {
-		array_unshift(
-			$steps,
-			array(
-				'step'     => 'login',
-				'username' => 'admin',
-				'password' => 'password',
-			)
+	$caller_steps  = is_array( $blueprint['steps'] ?? null ) ? $blueprint['steps'] : array();
+	$runtime_steps = array();
+	foreach ( $runtime['filesystem_overlays'] ?? array() as $overlay ) {
+		$runtime_steps[] = array(
+			'step' => 'runPHP',
+			'code' => self::browser_wordpress_filesystem_overlay_write_php( $overlay ),
 		);
 	}
 
@@ -87,9 +84,9 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 		if ( ! empty( $plugin['local_package'] ) ) {
 			$write_step = self::browser_local_package_write_step( $plugin, 'plugin' );
 			if ( ! empty( $write_step ) ) {
-				$steps[] = $write_step;
+				$runtime_steps[] = $write_step;
 			}
-			$steps[] = array(
+			$runtime_steps[] = array(
 				'step' => 'runPHP',
 				'code' => self::browser_plugin_install_php( $plugin, (string) ( $write_step['path'] ?? '' ) ),
 			);
@@ -116,7 +113,7 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 			$options['targetFolderName'] = (string) $plugin['targetFolderName'];
 		}
 
-		$steps[] = array(
+		$runtime_steps[] = array(
 			'step'       => 'installPlugin',
 			'pluginData' => $plugin_data,
 			'options'    => $options,
@@ -126,9 +123,9 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 	foreach ( $runtime['mu_plugins'] as $mu_plugin ) {
 		$write_step = ! empty( $mu_plugin['local_package'] ) ? self::browser_local_package_write_step( $mu_plugin, 'mu-plugin' ) : array();
 		if ( ! empty( $write_step ) ) {
-			$steps[] = $write_step;
+			$runtime_steps[] = $write_step;
 		}
-		$steps[] = array(
+		$runtime_steps[] = array(
 			'step' => 'runPHP',
 			'code' => self::browser_mu_plugin_install_php( $mu_plugin, (string) ( $write_step['path'] ?? '' ) ),
 		);
@@ -139,14 +136,14 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 			if ( ! empty( $theme['local_package'] ) ) {
 				$write_step = self::browser_local_package_write_step( $theme, 'theme' );
 				if ( ! empty( $write_step ) ) {
-					$steps[] = $write_step;
+					$runtime_steps[] = $write_step;
 				}
-				$steps[] = array(
+				$runtime_steps[] = array(
 					'step' => 'runPHP',
 					'code' => self::browser_theme_package_install_php( $theme, (string) ( $write_step['path'] ?? '' ) ),
 				);
 			} else {
-				$steps[] = array(
+				$runtime_steps[] = array(
 					'step'      => 'installTheme',
 					'themeData' => array(
 						'resource' => 'url',
@@ -160,7 +157,7 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 		}
 
 		if ( ! empty( $theme['files'] ) ) {
-			$steps[] = array(
+			$runtime_steps[] = array(
 				'step' => 'runPHP',
 				'code' => self::browser_theme_files_install_php( $theme ),
 			);
@@ -168,11 +165,21 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 	}
 
 	foreach ( $runtime['bootstrap'] as $operation ) {
-		$steps[] = array(
+		$runtime_steps[] = array(
 			'step' => 'runPHP',
 			'code' => self::browser_bootstrap_operation_php( $operation ),
 		);
 	}
+
+	$steps = $runtime_steps;
+	if ( ! self::browser_blueprint_has_login_step( $caller_steps ) ) {
+		$steps[] = array(
+			'step'     => 'login',
+			'username' => 'admin',
+			'password' => 'password',
+		);
+	}
+	$steps = array_merge( $steps, $caller_steps );
 
 	$blueprint['steps'] = $steps;
 	if ( ! isset( $blueprint['preferredVersions'] ) ) {
@@ -186,6 +193,25 @@ private static function browser_blueprint_with_runtime( array $blueprint, array 
 	}
 
 	return $blueprint;
+}
+
+/** @param array<string,mixed> $overlay Normalized filesystem overlay. */
+private static function browser_wordpress_filesystem_overlay_write_php( array $overlay ): string {
+	return '<?php
+$target = ' . var_export( (string) $overlay['target'], true ) . ';
+$content = ' . var_export( (string) $overlay['content'], true ) . ';
+$overwrite = ' . ( ! empty( $overlay['overwrite'] ) ? 'true' : 'false' ) . ';
+if ( file_exists( $target ) && ! $overwrite ) {
+throw new RuntimeException( "Browser filesystem overlay target already exists: " . $target );
+}
+$directory = dirname( $target );
+if ( ! is_dir( $directory ) && ! mkdir( $directory, 0777, true ) && ! is_dir( $directory ) ) {
+throw new RuntimeException( "Could not create browser filesystem overlay directory: " . $directory );
+}
+if ( false === file_put_contents( $target, $content ) ) {
+throw new RuntimeException( "Could not materialize browser filesystem overlay: " . $target );
+}
+';
 }
 
 /** @param array<string,mixed> $package Runtime package spec. @return array<string,mixed> */
@@ -596,6 +622,7 @@ private static function browser_runtime_readiness_metadata( array $runtime ): ar
 		'mu_plugins' => array_map( static fn( array $mu_plugin ): array => array( 'slug' => $mu_plugin['slug'] ?? '', 'file' => $mu_plugin['file'] ?? '', 'readiness' => $mu_plugin['readiness'] ?? 'compiled' ), $runtime['mu_plugins'] ?? array() ),
 		'themes'    => array_map( static fn( array $theme ): array => array( 'slug' => $theme['slug'] ?? '', 'activate' => (bool) ( $theme['activate'] ?? true ), 'readiness' => $theme['readiness'] ?? 'compiled' ), $runtime['themes'] ?? array() ),
 		'bootstrap' => array_map( static fn( array $operation ): array => array( 'operation' => $operation['operation'] ?? '', 'readiness' => $operation['readiness'] ?? 'compiled' ), $runtime['bootstrap'] ?? array() ),
+		'filesystem_overlays' => array_map( static fn( array $overlay ): array => array( 'target' => $overlay['target'] ?? '', 'overwrite' => $overlay['overwrite'] ?? false, 'source_digest' => $overlay['source_digest'] ?? array(), 'materialized_digest' => $overlay['materialized_digest'] ?? array(), 'provenance' => $overlay['provenance'] ?? array(), 'readiness' => $overlay['readiness'] ?? 'compiled' ), $runtime['filesystem_overlays'] ?? array() ),
 	);
 }
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -8,6 +8,73 @@
 defined( 'ABSPATH' ) || exit;
 
 trait WP_Codebox_Abilities_Browser_Runtime {
+/** @param array<int,mixed> $overlays WordPress filesystem overlay specs. @return array<int,array<string,mixed>>|WP_Error */
+private static function normalize_browser_wordpress_filesystem_overlays( array $overlays ): array|WP_Error {
+	$normalized = array();
+	$targets    = array();
+	foreach ( $overlays as $index => $overlay ) {
+		if ( ! is_array( $overlay ) ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_invalid', 'Each browser filesystem overlay must be an object.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		$target = trim( (string) ( $overlay['target'] ?? '' ) );
+		if ( ! self::browser_wordpress_filesystem_overlay_target_is_safe( $target ) ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_target_invalid', 'Browser filesystem overlay targets must be safe files under /wordpress.', array( 'status' => 400, 'index' => $index, 'target' => $target ) );
+		}
+		if ( isset( $targets[ $target ] ) ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_target_collision', 'Browser filesystem overlay targets must be unique.', array( 'status' => 400, 'index' => $index, 'target' => $target, 'conflicts_with' => $targets[ $target ] ) );
+		}
+		$targets[ $target ] = $index;
+
+		$has_content = array_key_exists( 'content', $overlay );
+		$has_base64  = array_key_exists( 'content_base64', $overlay );
+		if ( $has_content === $has_base64 ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_content_invalid', 'Browser filesystem overlays require exactly one of content or content_base64.', array( 'status' => 400, 'index' => $index ) );
+		}
+		if ( $has_content && ! is_string( $overlay['content'] ) ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_content_invalid', 'Browser filesystem overlay content must be a string.', array( 'status' => 400, 'index' => $index ) );
+		}
+		if ( ! array_key_exists( 'overwrite', $overlay ) || ! is_bool( $overlay['overwrite'] ) ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_overwrite_invalid', 'Browser filesystem overlays require an explicit boolean overwrite policy.', array( 'status' => 400, 'index' => $index ) );
+		}
+		$content = $has_content ? $overlay['content'] : base64_decode( (string) $overlay['content_base64'], true );
+		if ( ! is_string( $content ) ) {
+			return new WP_Error( 'wp_codebox_browser_filesystem_overlay_base64_invalid', 'Browser filesystem overlay content_base64 must be valid base64.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		$source_digest = hash( 'sha256', $content );
+		$materialized_digest = hash( 'sha256', 'wp-codebox/browser-wordpress-filesystem-overlay/v1' . "\n" . $target . "\n" . $content );
+		$normalized[] = array_filter( array(
+			'target' => $target,
+			'content' => $content,
+			'overwrite' => $overlay['overwrite'],
+			'source_digest' => array( 'algorithm' => 'sha256', 'value' => $source_digest ),
+			'materialized_digest' => array( 'algorithm' => 'sha256', 'value' => $materialized_digest ),
+			'provenance' => array_filter( array(
+				'schema' => 'wp-codebox/browser-wordpress-filesystem-overlay-provenance/v1',
+				'source' => 'runtime.filesystem_overlays[' . $index . ']',
+				'purpose' => trim( (string) ( $overlay['purpose'] ?? '' ) ),
+				'metadata' => is_array( $overlay['metadata'] ?? null ) ? $overlay['metadata'] : array(),
+			) ),
+			'readiness' => 'compiled',
+		), static fn( mixed $value ): bool => null !== $value && '' !== $value && array() !== $value );
+	}
+
+	return $normalized;
+}
+
+private static function browser_wordpress_filesystem_overlay_target_is_safe( string $target ): bool {
+	if ( '' === $target || ! str_starts_with( $target, '/wordpress/' ) || str_contains( $target, "\0" ) || str_contains( $target, '\\' ) || str_contains( $target, '//' ) || str_ends_with( $target, '/' ) ) {
+		return false;
+	}
+	foreach ( explode( '/', substr( $target, 1 ) ) as $segment ) {
+		if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+			return false;
+		}
+	}
+	return true;
+}
+
 /** @param array<int,mixed> $mu_plugins Mu-plugin dependency specs. @return array<int,array<string,mixed>>|WP_Error */
 private static function normalize_browser_mu_plugins( array $mu_plugins ): array|WP_Error {
 	$normalized = array();
@@ -376,6 +443,10 @@ private static function browser_runtime_dependencies( array $input, array $brows
 	if ( is_wp_error( $bootstrap ) ) {
 		return $bootstrap;
 	}
+	$filesystem_overlays = self::normalize_browser_wordpress_filesystem_overlays( is_array( $runtime['filesystem_overlays'] ?? null ) ? $runtime['filesystem_overlays'] : array() );
+	if ( is_wp_error( $filesystem_overlays ) ) {
+		return $filesystem_overlays;
+	}
 
 	$declared_components = is_array( $runtime['components'] ?? null ) ? $runtime['components'] : array();
 	$component_plugins   = self::browser_component_plugins( $input, array_merge( $browser_plugins, $runtime_plugins ), $declared_components );
@@ -384,7 +455,7 @@ private static function browser_runtime_dependencies( array $input, array $brows
 	}
 
 	$plugins = self::dedupe_browser_plugins( array_merge( $browser_plugins, $runtime_plugins, $component_plugins ) );
-	$prepared = self::browser_prepared_runtime_contract( $runtime, $plugins, $mu_plugins, $themes, $bootstrap, $input );
+	$prepared = self::browser_prepared_runtime_contract( $runtime, $plugins, $mu_plugins, $themes, $bootstrap, $filesystem_overlays, $input );
 	if ( is_wp_error( $prepared ) ) {
 		return $prepared;
 	}
@@ -396,6 +467,7 @@ private static function browser_runtime_dependencies( array $input, array $brows
 		'mu_plugins'             => $mu_plugins,
 		'themes'                 => $themes,
 		'bootstrap'              => $bootstrap,
+		'filesystem_overlays'    => $filesystem_overlays,
 		'prepared_runtime'       => $prepared,
 		'component_plugins'      => count( $component_plugins ),
 		'browser_plugins'        => count( $browser_plugins ),
@@ -404,12 +476,13 @@ private static function browser_runtime_dependencies( array $input, array $brows
 			'mu_plugins' => count( $mu_plugins ),
 			'themes'     => count( $themes ),
 			'bootstrap'  => count( $bootstrap ),
+			'filesystem_overlays' => count( $filesystem_overlays ),
 		),
 	);
 }
 
 /** @return array<string,mixed>|WP_Error */
-private static function browser_prepared_runtime_contract( array $runtime, array $plugins, array $mu_plugins, array $themes, array $bootstrap, array $input ): array|WP_Error {
+private static function browser_prepared_runtime_contract( array $runtime, array $plugins, array $mu_plugins, array $themes, array $bootstrap, array $filesystem_overlays, array $input ): array|WP_Error {
 	$prepared = is_array( $runtime['prepared'] ?? null ) ? $runtime['prepared'] : ( is_array( $runtime['prepared_runtime'] ?? null ) ? $runtime['prepared_runtime'] : array() );
 	$enabled  = array_key_exists( 'enabled', $prepared ) ? (bool) $prepared['enabled'] : ! empty( $prepared );
 	if ( ! $enabled ) {
@@ -424,6 +497,7 @@ private static function browser_prepared_runtime_contract( array $runtime, array
 		'mu_plugins' => self::browser_prepared_runtime_hashable_dependencies( $mu_plugins ),
 		'themes'     => self::browser_prepared_runtime_hashable_dependencies( $themes ),
 		'bootstrap'  => $bootstrap,
+		'filesystem_overlays' => $filesystem_overlays,
 		'blueprint'  => is_array( $input['blueprint'] ?? null ) ? $input['blueprint'] : array(),
 		'site_blueprint_artifact' => is_array( $input['site_blueprint_artifact'] ?? null ) ? $input['site_blueprint_artifact'] : array(),
 		'playground' => array(

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -1154,6 +1154,22 @@ private static function browser_runtime_input_schema(): array {
 			'mu_plugins' => array( 'type' => 'array' ),
 			'themes'     => array( 'type' => 'array' ),
 			'bootstrap'  => array( 'type' => 'array' ),
+			'filesystem_overlays' => array(
+				'type' => 'array',
+				'description' => 'WordPress-root filesystem bytes materialized before caller Blueprint steps and runtime readiness.',
+				'items' => array(
+					'type' => 'object',
+					'properties' => array(
+						'target' => array( 'type' => 'string' ),
+						'content' => array( 'type' => 'string' ),
+						'content_base64' => array( 'type' => 'string' ),
+						'overwrite' => array( 'type' => 'boolean' ),
+						'purpose' => array( 'type' => 'string' ),
+						'metadata' => array( 'type' => 'object' ),
+					),
+					'required' => array( 'target', 'overwrite' ),
+				),
+			),
 			'prepared'   => array(
 				'type'        => 'object',
 				'description' => 'Optional prepared browser runtime cache contract. When enabled, WP Codebox keys the compiled browser-ready blueprint by a source digest and reuses matching cached artifacts on repeated known-site opens.',

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -46,6 +46,7 @@ export const smokeGroups = {
       npmScript("test:host-recipe-builder"),
       npmScript("test:browser-runner-template"),
       npmScript("test:browser-runtime-file-ops"),
+      npmScript("test:browser-prepared-runtime-filesystem-overlays"),
       npmScript("test:browser-provider-bridge-inheritance"),
       npmScript("test:browser-preview-routing"),
       npmScript("test:browser-routed-command-security"),

--- a/tests/browser-prepared-runtime-filesystem-overlays.test.ts
+++ b/tests/browser-prepared-runtime-filesystem-overlays.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict"
+
+import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
+
+const result = await runPhpJson<any>(`
+define('ABSPATH', ${phpStringLiteral(repoRoot)});
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
+function apply_filters( $hook, $value, ...$args ) { return $value; }
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-path-policy.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php`)};
+class WP_Codebox_Filesystem_Overlay_Test_Abilities {
+	use WP_Codebox_Abilities_Browser_Runtime;
+	use WP_Codebox_Abilities_Browser_Blueprint;
+	public static function safe_key( $value ) { return sanitize_key( (string) $value ); }
+	public static function stable_json( $value ) { return json_encode( $value, JSON_UNESCAPED_SLASHES ); }
+}
+$normalize = new ReflectionMethod( WP_Codebox_Filesystem_Overlay_Test_Abilities::class, 'normalize_browser_wordpress_filesystem_overlays' );
+$prepared = new ReflectionMethod( WP_Codebox_Filesystem_Overlay_Test_Abilities::class, 'browser_prepared_runtime_contract' );
+$blueprint = new ReflectionMethod( WP_Codebox_Filesystem_Overlay_Test_Abilities::class, 'browser_blueprint_with_runtime' );
+$readiness = new ReflectionMethod( WP_Codebox_Filesystem_Overlay_Test_Abilities::class, 'browser_runtime_readiness_metadata' );
+$input = array(
+	'runtime' => array(
+		'prepared' => array( 'enabled' => true, 'cache_key' => 'overlay-fixture' ),
+		'filesystem_overlays' => array(
+			array( 'target' => '/wordpress/wp-content/mu-plugins/fixture-overlay.php', 'content' => "<?php\nfunction fixture_overlay_loaded() { return true; }\n", 'overwrite' => false, 'purpose' => 'fixture mu plugin' ),
+		),
+	),
+	'blueprint' => array( 'steps' => array( array( 'step' => 'runPHP', 'code' => '<?php /* caller step */' ) ) ),
+);
+$overlays = $normalize->invoke( null, $input['runtime']['filesystem_overlays'] );
+$first_prepared = $prepared->invoke( null, $input['runtime'], array(), array(), array(), array(), $overlays, $input );
+$second_prepared = $prepared->invoke( null, $input['runtime'], array(), array(), array(), array(), $overlays, $input );
+$changed = $input;
+$changed['runtime']['filesystem_overlays'][0]['content'] .= "// changed\n";
+$changed_overlays = $normalize->invoke( null, $changed['runtime']['filesystem_overlays'] );
+$changed_prepared = $prepared->invoke( null, $changed['runtime'], array(), array(), array(), array(), $changed_overlays, $changed );
+$runtime = array(
+	'plugins' => array(),
+	'mu_plugins' => array(
+		array(
+			'slug' => 'packaged-fixture',
+			'file' => 'packaged-fixture.php',
+			'path' => '/wordpress/wp-content/mu-plugins/packaged-fixture.php',
+			'url' => 'data:application/zip;base64,' . base64_encode( 'PKfixture' ),
+			'sha256' => hash( 'sha256', 'PKfixture' ),
+			'targetFolderName' => 'packaged-fixture',
+			'entry' => 'packaged-fixture/packaged-fixture.php',
+			'local_package' => true,
+		),
+	),
+	'themes' => array(),
+	'bootstrap' => array(),
+	'filesystem_overlays' => $overlays,
+);
+$compiled = $blueprint->invoke( null, $input['blueprint'], $runtime, array() );
+$traversal = $normalize->invoke( null, array( array( 'target' => '/wordpress/../escape.php', 'content' => '<?php', 'overwrite' => false ) ) );
+$collision = $normalize->invoke( null, array( array( 'target' => '/wordpress/wp-content/mu-plugins/a.php', 'content' => '<?php', 'overwrite' => false ), array( 'target' => '/wordpress/wp-content/mu-plugins/a.php', 'content' => '<?php', 'overwrite' => false ) ) );
+$undeclared_overwrite = $normalize->invoke( null, array( array( 'target' => '/wordpress/wp-content/mu-plugins/undeclared.php', 'content' => '<?php' ) ) );
+echo json_encode( array(
+	'overlays' => $overlays,
+	'first_hash' => $first_prepared['input_hash'],
+	'second_hash' => $second_prepared['input_hash'],
+	'changed_hash' => $changed_prepared['input_hash'],
+	'compiled' => $compiled,
+	'readiness' => $readiness->invoke( null, $runtime ),
+	'traversal' => is_wp_error( $traversal ) ? $traversal->code : '',
+	'collision' => is_wp_error( $collision ) ? $collision->code : '',
+	'undeclared_overwrite' => is_wp_error( $undeclared_overwrite ) ? $undeclared_overwrite->code : '',
+), JSON_UNESCAPED_SLASHES);
+`)
+
+const overlay = result.overlays[0]
+assert.equal(overlay.target, "/wordpress/wp-content/mu-plugins/fixture-overlay.php")
+assert.equal(overlay.provenance.source, "runtime.filesystem_overlays[0]")
+assert.match(overlay.source_digest.value, /^[a-f0-9]{64}$/)
+assert.match(overlay.materialized_digest.value, /^[a-f0-9]{64}$/)
+const overlayIndex = result.compiled.steps.findIndex((step: { code?: string }) => /fixture-overlay\.php/.test(step.code ?? ""))
+const packageIndex = result.compiled.steps.findIndex((step: { code?: string }) => /packaged-fixture/.test(step.code ?? ""))
+const callerIndex = result.compiled.steps.findIndex((step: { code?: string }) => /caller step/.test(step.code ?? ""))
+assert.equal(result.compiled.steps[0].step, "runPHP")
+assert.ok(overlayIndex > -1 && overlayIndex < callerIndex, "filesystem overlays are materialized before any caller Blueprint step")
+assert.ok(packageIndex > overlayIndex && packageIndex < callerIndex, "packaged MU plugins are materialized before caller Blueprint steps")
+assert.equal(result.compiled.steps.some((step: { step?: string }) => step.step === "installPlugin"), false, "runtime MU plugins must not emit an installPlugin download")
+assert.deepEqual(result.readiness.filesystem_overlays, [{
+  target: "/wordpress/wp-content/mu-plugins/fixture-overlay.php",
+  overwrite: false,
+  source_digest: overlay.source_digest,
+  materialized_digest: overlay.materialized_digest,
+  provenance: overlay.provenance,
+  readiness: "compiled",
+}])
+assert.equal(result.first_hash, result.second_hash, "stable overlay bytes and target reuse prepared runtime identity")
+assert.notEqual(result.first_hash, result.changed_hash, "changed overlay bytes invalidate prepared runtime identity")
+assert.equal(result.traversal, "wp_codebox_browser_filesystem_overlay_target_invalid")
+assert.equal(result.collision, "wp_codebox_browser_filesystem_overlay_target_collision")
+assert.equal(result.undeclared_overwrite, "wp_codebox_browser_filesystem_overlay_overwrite_invalid")
+
+console.log("browser prepared runtime filesystem overlays ok")

--- a/tests/runtime-profile-resolver.test.ts
+++ b/tests/runtime-profile-resolver.test.ts
@@ -4,12 +4,13 @@ import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
 const result = await runPhpJson<{
   default_error: { code: string; data: { errors: Array<{ code: string; profile: string }> } }
   input: {
-    runtime: { components: Array<{ slug: string }>; plugins: Array<{ slug: string }>; resolved_profile: { schema: string; summary: { profiles: number }; capabilities: string[]; profiles: Array<{ id: string; aliases?: string[]; internal?: { provides?: string[] } }> } }
+    runtime: { components: Array<{ slug: string }>; plugins: Array<{ slug: string }>; filesystem_overlays: Array<{ target: string }>; resolved_profile: { schema: string; summary: { profiles: number }; capabilities: string[]; profiles: Array<{ id: string; aliases?: string[]; internal?: { provides?: string[] } }> } }
     runtime_profile: {
       schema: string
       capabilities: string[]
       provider_plugins?: Array<{ slug: string }>
       runtime_overlays: Array<{ id: string }>
+      filesystem_overlays: Array<{ target: string }>
       readiness: { status: string; checks: Record<string, boolean> }
       diagnostics: Array<{ code: string; status: string; severity: string; evidence: Record<string, unknown> }>
       provenance: { owner: string; resolver: string }
@@ -70,6 +71,7 @@ $input = WP_Codebox_Browser_Task_Builder::local_browser_task_input( array(
 		'components' => array( 'workspace-overlay' ),
 		'capabilities' => array( 'provider.openai' ),
 		'runtime_overlays' => array( array( 'id' => 'codex-runtime-overlay' ) ),
+		'filesystem_overlays' => array( array( 'target' => '/wordpress/wp-content/mu-plugins/profile.php', 'content' => '<?php', 'overwrite' => false ) ),
 	),
 ) );
 
@@ -103,6 +105,8 @@ assert.deepEqual(result.input.runtime_profile.capabilities, [
 assert.deepEqual(result.input.runtime.plugins.map((plugin) => plugin.slug), ["ai-provider-for-openai"])
 assert.equal(result.input.runtime_profile.provider_plugins, undefined)
 assert.deepEqual(result.input.runtime_profile.runtime_overlays.map((overlay) => overlay.id), ["codex-runtime-overlay"])
+assert.deepEqual(result.input.runtime_profile.filesystem_overlays.map((overlay) => overlay.target), ["/wordpress/wp-content/mu-plugins/profile.php"])
+assert.deepEqual(result.input.runtime.filesystem_overlays.map((overlay) => overlay.target), ["/wordpress/wp-content/mu-plugins/profile.php"])
 assert.equal(result.input.runtime_profile.readiness.status, "ready")
 assert.equal(result.input.runtime_profile.readiness.checks.dependencies, true)
 assert.equal(result.input.runtime_profile.diagnostics[0].code, "runtime_profile.resolved")

--- a/tests/runtime-recipe-resolver.test.ts
+++ b/tests/runtime-recipe-resolver.test.ts
@@ -3,7 +3,7 @@ import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
 
 const result = await runPhpJson<{
   resolved: {
-    runtime: { components: string[]; plugins: Array<{ slug: string }>; resolved_recipe: { schema: string; summary: { packages: number } } }
+    runtime: { components: string[]; plugins: Array<{ slug: string }>; filesystem_overlays: Array<{ target: string }>; resolved_recipe: { schema: string; summary: { packages: number } } }
     inherit: { connectors: string[] }
     provider_plugin_paths: string[]
     secret_env: string[]
@@ -49,6 +49,7 @@ function apply_filters( $hook, $value, ...$args ) {
 				array( 'slug' => 'sample-runtime-tools', 'url' => 'https://example.test/sample-runtime-tools.zip', 'activate' => true ),
 			),
 			'bootstrap' => array( array( 'operation' => 'set_option', 'args' => array( 'name' => 'sample_runtime', 'value' => 'sandbox' ) ) ),
+			'filesystem_overlays' => array( array( 'target' => '/wordpress/wp-content/mu-plugins/sample-runtime.php', 'content' => '<?php', 'overwrite' => false ) ),
 		),
 	);
 	$value['provider-connector'] = array(
@@ -93,6 +94,7 @@ echo json_encode( array( 'resolved' => $resolved, 'local_task' => $local_task ),
 
 assert.deepEqual(result.resolved.runtime.components, ["agents-api", "sample-runtime", "sample-runtime-tools"])
 assert.deepEqual(result.resolved.runtime.plugins.map((plugin: { slug: string }) => plugin.slug), ["caller-plugin", "agents-api", "sample-runtime", "sample-runtime-tools"])
+assert.deepEqual(result.resolved.runtime.filesystem_overlays.map((overlay) => overlay.target), ["/wordpress/wp-content/mu-plugins/sample-runtime.php"])
 assert.deepEqual(result.resolved.inherit.connectors, ["existing", "primary-ai"])
 assert.deepEqual(result.resolved.provider_plugin_paths, ["/opt/provider-plugin"])
 assert.deepEqual(result.resolved.secret_env, ["PROVIDER_TOKEN"])


### PR DESCRIPTION
## Summary

- add deterministic WordPress filesystem overlays to prepared browser runtimes
- materialize Codebox-owned overlays and packaged MU plugins before caller Blueprint steps
- include overlay bytes and targets in runtime identity, provenance, readiness, and profile propagation
- reject traversal, ambiguous collisions, invalid content encoding, and implicit overwrite behavior

## Compatibility

The new overlay field is optional. No-overlay payload shapes remain compatible. Declared runtime plugins, MU plugins, themes, and bootstrap operations now precede caller steps instead of following them; reviewers should confirm no consumer intentionally relies on the inverted ordering.

## Verification

- `npm run build`
- `npm run test:browser-prepared-runtime-filesystem-overlays`
- `npm run test:runtime-profile-resolver`
- `npm run test:runtime-recipe-resolver`
- `npm run test:browser-task-builder`
- PHP lint for touched implementation files
- `git diff --check`

`npm run check` reaches the new overlay smoke successfully, then stops at an existing unrelated `command-registry-smoke` invariant for `wordpress.collect-workload-result`.

Closes #2200.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents traced, implemented, reviewed, and verified the runtime overlay contract. Chris Huber remains responsible for every line.
