### PR TITLE
feat: expose prepared plugin receipts

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
     "test:composer-package-overlay-autoload-layout": "tsx scripts/composer-package-overlay-autoload-layout-smoke.ts",
     "test:composer-installed-versions-loader-order": "tsx scripts/composer-installed-versions-loader-order-smoke.ts",
     "test:recipe-extra-plugin-composer-autoloaders": "tsx tests/recipe-extra-plugin-composer-autoloaders.test.ts",
+    "test:recipe-extra-plugin-local-zip": "tsx tests/recipe-extra-plugin-local-zip.test.ts",
     "test:runtime-preset-registry": "tsx tests/runtime-preset-registry.test.ts",
     "test:generic-ability-runtime-run": "tsx tests/generic-ability-runtime-run.test.ts",
     "test:provider-runtime-contracts": "tsx tests/provider-runtime-contracts.test.ts",

--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -6,7 +6,7 @@ import { serializeError } from "../output.js"
 import { finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeTerminalResultOutput } from "../recipe-evidence.js"
 import { recipeRunFailureStatus, serializeRecipeRunError } from "./recipe-run-output.js"
 import type { RecipeArtifactPointerTracker } from "./recipe-run-artifact-pointers.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeStepFailure } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOutput, RecipeRunPreparedExtraPlugin, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeStepFailure } from "./recipe-run-types.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 
 export interface RunResourceCleanupEvidence {
@@ -46,6 +46,7 @@ interface RecipeRunCommonOutputFields {
   runtime?: RuntimeInfo
   executions: RecipeExecutionResult[]
   componentContracts?: RecipeRunComponentContract[]
+  preparedExtraPlugins?: RecipeRunPreparedExtraPlugin[]
   stagedFiles?: RecipeRunStagedFile[]
   fixtureDatabases?: RecipeRunFixtureDatabase[]
   siteSeeds?: RecipeRunSiteSeed[]
@@ -107,6 +108,7 @@ export function recipeRunOutputWithResult<T extends RecipeRunOutput>(output: T):
 export function completedRecipeOutputFields(args: {
   executions: RecipeExecutionResult[]
   componentContracts?: RecipeRunComponentContract[]
+  preparedExtraPlugins?: RecipeRunPreparedExtraPlugin[]
   stagedFiles: RecipeRunStagedFile[]
   fixtureDatabases: RecipeRunFixtureDatabase[]
   siteSeeds: RecipeRunOutput["siteSeeds"]
@@ -125,6 +127,7 @@ export function completedRecipeOutputFields(args: {
   return {
     executions: args.executions,
     componentContracts: args.componentContracts,
+    preparedExtraPlugins: args.preparedExtraPlugins,
     stagedFiles: args.stagedFiles,
     fixtureDatabases: args.fixtureDatabases,
     siteSeeds: args.siteSeeds,

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -6,6 +6,7 @@ import type { RecipeValidationIssue, RecipeWorkflowPhase } from "../recipe-valid
 import type { RunOutput } from "../runtime-command-wrappers.js"
 import type { RecipeAdversarialCampaignOutput } from "../adversarial-recipe.js"
 import type { RuntimeServiceEvidence } from "../runtime-services.js"
+import type { RecipeSourceProvenance } from "../recipe-sources.js"
 
 export interface RecipeRunOptions {
   recipePath: string
@@ -59,6 +60,7 @@ export interface RecipeRunOutput {
   runtime?: RuntimeInfo
   executions: RecipeExecutionResult[]
   componentContracts?: RecipeRunComponentContract[]
+  preparedExtraPlugins?: RecipeRunPreparedExtraPlugin[]
   stagedFiles?: RecipeRunStagedFile[]
   fixtureDatabases?: RecipeRunFixtureDatabase[]
   siteSeeds?: RecipeRunSiteSeed[]
@@ -118,6 +120,19 @@ export interface RecipeRunComponentContract {
   loadAs: "plugin" | "mu-plugin" | string
   activate: boolean
   status: "prepared" | "mounted" | "activated" | "failed"
+  activationStatus: "not_requested" | "not_applicable" | "pending" | "activated" | "failed"
+  failures: Array<Record<string, unknown>>
+}
+
+export interface RecipeRunPreparedExtraPlugin {
+  schema: "wp-codebox/prepared-extra-plugin/v1"
+  slug: string
+  source: string
+  target: string
+  pluginFile: string
+  loadAs: "plugin" | "mu-plugin"
+  activate: boolean
+  provenance: RecipeSourceProvenance
   activationStatus: "not_requested" | "not_applicable" | "pending" | "activated" | "failed"
   failures: Array<Record<string, unknown>>
 }

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1662,7 +1662,7 @@ function componentContractResult(plugin: PreparedExtraPlugin, phases: RecipePhas
   }) as RecipeRunComponentContract
 }
 
-function preparedExtraPluginReceipts(plugins: PreparedExtraPlugin[], phases: RecipePhaseEvidence[], executions: RecipeExecutionResult[]): RecipeRunPreparedExtraPlugin[] {
+export function preparedExtraPluginReceipts(plugins: PreparedExtraPlugin[], phases: RecipePhaseEvidence[], executions: RecipeExecutionResult[]): RecipeRunPreparedExtraPlugin[] {
   return plugins.map((plugin) => {
     const failures = componentContractFailures(plugin, phases, executions)
     const activated = plugin.loadAs === "plugin" && plugin.activate !== false && activePluginPhaseIncludes(phases, plugin.pluginFile)

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -32,7 +32,7 @@ import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRunti
 import { provisionRuntimeServices, provisionRuntimeServicesForRecipe, runtimeServiceEvidenceFromError, type RuntimeServiceEvidence } from "../runtime-services.js"
 import { distributionStartupProbeFailure, executeRecipeCollectWorkloadResult, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeStepFailure, recipeWorkflowArgsEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
 import { recipeAdversarialCampaignFailure, runRecipeAdversarialCampaigns, writeRecipeAdversarialEvidence, type RecipeAdversarialCampaignOutput } from "../adversarial-recipe.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeEffectiveRecipeArtifact, RecipeExecutionResult, RecipeFuzzCaseCommandRef, RecipeFuzzCaseResult, RecipeFuzzCaseStatus, RecipeFuzzRunResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunProvenance, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeStepFailure, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeEffectiveRecipeArtifact, RecipeExecutionResult, RecipeFuzzCaseCommandRef, RecipeFuzzCaseResult, RecipeFuzzCaseStatus, RecipeFuzzRunResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunPreparedExtraPlugin, RecipeRunProbe, RecipeRunProvenance, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeStepFailure, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
@@ -447,7 +447,7 @@ export async function runRecipe(options: RecipeRunOptions, interruption?: Recipe
         browserEvidence,
         replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
         failure: recipeFailure,
-        output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, stepFailures, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), ...(adversarialCampaigns.length > 0 ? { adversarialCampaigns } : {}), provenance: recipeRunProvenance(recipe, recipePath), managedRuntimeServices: serviceEvidence },
+        output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), preparedExtraPlugins: preparedExtraPluginReceipts(extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, stepFailures, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), ...(adversarialCampaigns.length > 0 ? { adversarialCampaigns } : {}), provenance: recipeRunProvenance(recipe, recipePath), managedRuntimeServices: serviceEvidence },
       })
     }
 
@@ -466,7 +466,7 @@ export async function runRecipe(options: RecipeRunOptions, interruption?: Recipe
       phaseEvidence: phaseTracker.list(),
       browserEvidence,
       replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
-      output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, stepFailures, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), ...(adversarialCampaigns.length > 0 ? { adversarialCampaigns } : {}), provenance: recipeRunProvenance(recipe, recipePath), managedRuntimeServices: serviceEvidence },
+        output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), preparedExtraPlugins: preparedExtraPluginReceipts(extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, stepFailures, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), ...(adversarialCampaigns.length > 0 ? { adversarialCampaigns } : {}), provenance: recipeRunProvenance(recipe, recipePath), managedRuntimeServices: serviceEvidence },
     })
   } catch (error) {
     const failedServiceEvidence = runtimeServiceEvidenceFromError(error)
@@ -1660,6 +1660,15 @@ function componentContractResult(plugin: PreparedExtraPlugin, phases: RecipePhas
     activationStatus,
     failures,
   }) as RecipeRunComponentContract
+}
+
+function preparedExtraPluginReceipts(plugins: PreparedExtraPlugin[], phases: RecipePhaseEvidence[], executions: RecipeExecutionResult[]): RecipeRunPreparedExtraPlugin[] {
+  return plugins.map((plugin) => {
+    const failures = componentContractFailures(plugin, phases, executions)
+    const activated = plugin.loadAs === "plugin" && plugin.activate !== false && activePluginPhaseIncludes(phases, plugin.pluginFile)
+    const activationStatus = plugin.loadAs === "mu-plugin" ? "not_applicable" : plugin.activate === false ? "not_requested" : activated ? "activated" : failures.some((failure) => failure.phase === "activate_plugins") ? "failed" : "pending"
+    return { schema: "wp-codebox/prepared-extra-plugin/v1", slug: plugin.slug, source: plugin.source, target: plugin.target, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs, activate: plugin.activate, provenance: plugin.provenance, activationStatus, failures }
+  })
 }
 
 function componentContractPreparationFailure(contract: Record<string, unknown>, plugin: WorkspaceRecipeExtraPlugin, error: unknown): RecipeRunComponentContract {

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -7,8 +7,8 @@ import type { MountSpec, WorkspaceRecipe, WorkspaceRecipeDependencyOverlay, Work
 import { executeManagedHostCommand, resolvePluginEntrypointContract } from "@automattic/wp-codebox-core"
 import { collectPreparedSourceCleanupPaths, DEFAULT_PREPARED_SOURCE_EXCLUDE_NAMES, localPreparedSourceProvenance, prepareLocalSourceStageSync, SANDBOX_WORKSPACE_ROOT, type PreparedSourceProvenance } from "@automattic/wp-codebox-core/internals"
 import { registerRuntimeOverlayDescriptor, runtimeOverlayDescriptor } from "./runtime-overlay-registry.js"
-import { evaluateSourcePolicy, sourcePolicySnapshot, type SourcePolicyIssue } from "./source-policy.js"
-import { prepareZipSource } from "./zip-source.js"
+import { evaluateSourcePolicy, evaluateZipSourcePolicy, sourcePolicySnapshot, type SourcePolicyIssue } from "./source-policy.js"
+import { prepareLocalZipSource, prepareZipSource } from "./zip-source.js"
 
 export { ALLOW_NETWORK_DOWNLOADS_ENV, ALLOWED_DOWNLOAD_HOSTS_ENV, allowedDownloadHosts, isSha256, maxDownloadBytes, maxExtractedBytes, maxExtractedFiles, MAX_DOWNLOAD_BYTES_ENV, MAX_EXTRACTED_BYTES_ENV, MAX_EXTRACTED_FILES_ENV, REQUIRE_SOURCE_SHA256_ENV, sourceSha256Required } from "./source-policy.js"
 
@@ -1436,8 +1436,24 @@ async function assertPreparedPluginFileExists(sourceDirectory: string, pluginFil
 async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, slug: string, expectedSha256?: string): Promise<PreparedExternalSource> {
   const source = recipeSource(sourceRef, expectedSha256)
   if (source.type === "local") {
+    const localPath = resolve(recipeDirectory, sourceRef)
+    if (sourceRef.toLowerCase().endsWith(".zip")) {
+      const [policyIssue] = evaluateZipSourcePolicy(source, expectedSha256)
+      if (policyIssue) {
+        throw new Error(policyIssue.message)
+      }
+      const preparedZip = await prepareLocalZipSource(localPath, slug, source.expectedSha256)
+      return {
+        source: await extractedPluginSourceDirectory(preparedZip.extractDirectory, slug),
+        cleanupPaths: [preparedZip.root],
+        provenance: {
+          ...recipeSourceProvenance(source, recipeDirectory),
+          digest: { sha256: preparedZip.digest, ...(source.expectedSha256 ? { expected: source.expectedSha256, verified: true } : {}) },
+        },
+      }
+    }
     return {
-      source: resolve(recipeDirectory, sourceRef),
+      source: localPath,
       cleanupPaths: [],
       provenance: recipeSourceProvenance(source, recipeDirectory),
     }
@@ -1581,7 +1597,7 @@ export function recipeSource(sourceRef: string, expectedSha256?: string): Parsed
   try {
     url = new URL(sourceRef)
   } catch {
-    return { type: "local", resolvedUrl: sourceRef, host: "" }
+    return { type: "local", resolvedUrl: sourceRef, host: "", ...(expectedSha256 ? { expectedSha256: expectedSha256.toLowerCase() } : {}) }
   }
 
   if (url.protocol !== "https:") {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from "node:fs"
-import { readFile, stat } from "node:fs/promises"
+import { lstat, readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { BROWSER_PROBE_CHROMIUM_PROFILE_IDS, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, RUNTIME_PHP_WASM_BUNDLED_EXTENSIONS, assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, browserEnvironment, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateRuntimePolicy, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { commandValidationDescriptorFor, effectivePolicyCommandsFor, type CommandArgValidationDescriptor } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPluginSource, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { loadConfiguredRuntimeOverlayDescriptors, registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandIds, listCliRuntimeBackendKinds } from "./runtime-backends.js"
+import { evaluateZipSourcePolicy } from "./source-policy.js"
 
 export interface RecipeValidationIssue {
   code: string
@@ -652,6 +653,7 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
       addIssue("invalid-source-subdir", `${path}.${plugin.sourceSubdir !== undefined ? "sourceSubdir" : "sourceSubpath"}`, error instanceof Error ? error.message : String(error))
       continue
     }
+    const localZipSource = source.type === "local" && sourceRef.toLowerCase().endsWith(".zip")
     const pluginSource = source.type === "local" ? resolve(recipeDirectory, sourceRef) : undefined
     const sourceRootPath = resolve(recipeDirectory, sourceRoot)
     const pluginMountedSource = source.type === "local" ? resolve(sourceRootPath, sourceSubpath) : undefined
@@ -664,18 +666,22 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
     }
     const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
 
-    validateRecipeSource(source, `${path}.source`, addIssue, plugin.sha256)
+    validateRecipeSource(source, `${path}.source`, addIssue, plugin.sha256, localZipSource)
     if (pluginSource) {
-      await validateExistingDirectory(pluginSource, `${path}.source`, addIssue)
+      if (localZipSource) {
+        await validateExistingRegularFile(pluginSource, `${path}.source`, addIssue)
+      } else {
+        await validateExistingDirectory(pluginSource, `${path}.source`, addIssue)
+      }
     }
-    if (sourceRoot !== sourceRef) {
+    if (sourceRoot !== sourceRef && !localZipSource) {
       await validateExistingDirectory(resolve(recipeDirectory, sourceRoot), `${path}.sourceRoot`, addIssue)
     }
     if (pluginMountedSource && !pluginMountedSource.startsWith(`${sourceRootPath}/`) && pluginMountedSource !== sourceRootPath) {
       addIssue("invalid-source-subdir", `${path}.${plugin.sourceSubdir !== undefined ? "sourceSubdir" : "sourceSubpath"}`, "Plugin source subdirectory must stay inside the source root.")
       continue
     }
-    if (sourceSubpath && pluginMountedSource) {
+    if (sourceSubpath && pluginMountedSource && !localZipSource) {
       await validateExistingDirectory(pluginMountedSource, `${path}.${plugin.sourceSubdir !== undefined ? "sourceSubdir" : "sourceSubpath"}`, addIssue)
     }
 
@@ -684,7 +690,7 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
       continue
     }
 
-    if (pluginMountedSource) {
+    if (pluginMountedSource && !localZipSource) {
       await validateExistingFile(join(pluginMountedSource, pluginFile.slice(slug.length + 1)), `${path}.pluginFile`, addIssue)
     }
   }
@@ -1942,6 +1948,17 @@ async function validateExistingFile(path: string, issuePath: string, addIssue: (
   }
 }
 
+async function validateExistingRegularFile(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+  try {
+    const result = await lstat(path)
+    if (result.isSymbolicLink() || !result.isFile()) {
+      addIssue("not-file", issuePath, `Expected regular file: ${path}`)
+    }
+  } catch {
+    addIssue("missing-path", issuePath, `File does not exist: ${path}`)
+  }
+}
+
 async function validateExistingFileOrDirectory(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
   try {
     const result = await stat(path)
@@ -1975,8 +1992,9 @@ function validateAbsoluteSandboxPath(path: string, issuePath: string, addIssue: 
   }
 }
 
-function validateRecipeSource(source: ReturnType<typeof recipeSource>, issuePath: string, addIssue: (code: string, path: string, message: string) => void, expectedSha256?: string): void {
-  for (const issue of evaluateRecipeSourcePolicy(source, expectedSha256)) {
+function validateRecipeSource(source: ReturnType<typeof recipeSource>, issuePath: string, addIssue: (code: string, path: string, message: string) => void, expectedSha256?: string, localZipSource = false): void {
+  const issues = localZipSource ? evaluateZipSourcePolicy(source, expectedSha256) : evaluateRecipeSourcePolicy(source, expectedSha256)
+  for (const issue of issues) {
     addIssue(issue.code, issuePath, issue.message)
   }
 }

--- a/packages/cli/src/source-policy.ts
+++ b/packages/cli/src/source-policy.ts
@@ -69,6 +69,28 @@ export function evaluateSourcePolicy(source: ExternalSourcePolicyInput, expected
   return issues
 }
 
+/** Policy shared by downloaded archives and local archive inputs. */
+export function evaluateZipSourcePolicy(source: ExternalSourcePolicyInput, expectedSha256?: string): SourcePolicyIssue[] {
+  if (source.type !== "local") {
+    return evaluateSourcePolicy(source, expectedSha256)
+  }
+
+  const issues: SourcePolicyIssue[] = []
+  if (expectedSha256 !== undefined && !isSha256(expectedSha256)) {
+    issues.push({
+      code: "invalid-source-sha256",
+      message: "Local ZIP recipe source sha256 must be a 64-character hex digest.",
+    })
+  }
+  if (sourceSha256Required() && !expectedSha256) {
+    issues.push({
+      code: "missing-source-sha256",
+      message: `Local ZIP recipe sources require sha256 when ${REQUIRE_SOURCE_SHA256_ENV}=1.`,
+    })
+  }
+  return issues
+}
+
 export function sourceSha256Required(): boolean {
   return process.env[REQUIRE_SOURCE_SHA256_ENV] === "1"
 }

--- a/packages/cli/src/zip-source.ts
+++ b/packages/cli/src/zip-source.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { mkdir, mkdtemp, readdir, stat, writeFile } from "node:fs/promises"
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { executeManagedHostCommand } from "@automattic/wp-codebox-core"
@@ -32,6 +32,32 @@ export async function prepareZipSource<TSource extends ZipSourceReference>(sourc
   await assertExtractedSourceBounds(extractDirectory)
 
   return { root, zipPath, extractDirectory, digest }
+}
+
+export async function prepareLocalZipSource(sourcePath: string, slug: string, expectedSha256?: string): Promise<PreparedZipSource> {
+  const root = await mkdtemp(join(tmpdir(), `wp-codebox-source-${slug}-`))
+  const zipPath = join(root, "source.zip")
+  const extractDirectory = join(root, "extracted")
+  try {
+    const source = await lstat(sourcePath)
+    if (source.isSymbolicLink() || !source.isFile()) {
+      throw new Error(`Local ZIP recipe source must be a regular file: ${sourcePath}`)
+    }
+    const buffer = await readFile(sourcePath)
+    const digest = createHash("sha256").update(buffer).digest("hex")
+    if (expectedSha256 && digest !== expectedSha256.toLowerCase()) {
+      throw new Error(`Recipe source sha256 mismatch for ${sourcePath}: expected ${expectedSha256.toLowerCase()}, got ${digest}`)
+    }
+    await writeFile(zipPath, buffer)
+    await mkdir(extractDirectory, { recursive: true })
+    await assertSafeZipEntries(zipPath)
+    await executeManagedHostCommand({ command: "unzip", args: ["-q", zipPath, "-d", extractDirectory], cwd: root, allowedCwdRoots: [root], label: "extract recipe source zip" })
+    await assertExtractedSourceBounds(extractDirectory)
+    return { root, zipPath, extractDirectory, digest }
+  } catch (error) {
+    await rm(root, { recursive: true, force: true })
+    throw error
+  }
 }
 
 async function downloadZipSource<TSource extends ZipSourceReference>(source: TSource, targetPath: string, redirectSource: RedirectSourceResolver<TSource>): Promise<string> {

--- a/tests/prepared-extra-plugin-receipts.test.ts
+++ b/tests/prepared-extra-plugin-receipts.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import { preparedExtraPluginReceipts } from "../packages/cli/src/commands/recipe-run.js"
+
+const plugin = {
+  source: "/tmp/plugin",
+  slug: "example-plugin",
+  target: "/wordpress/wp-content/plugins/example-plugin",
+  pluginFile: "example-plugin/example.php",
+  activate: true,
+  loadAs: "plugin" as const,
+  cleanupPaths: [],
+  provenance: { kind: "https_zip" as const, original: "https://example.test/plugin.zip", resolvedUrl: "https://example.test/plugin.zip", digest: { sha256: "a".repeat(64), verified: true } },
+}
+
+const receipts = preparedExtraPluginReceipts([plugin], [{ schema: "wp-codebox/recipe-phase-evidence/v1", name: "activate_plugins", status: "completed", startedAt: "2026-01-01T00:00:00Z", endedAt: "2026-01-01T00:00:01Z", durationMs: 1, data: { activePlugins: [plugin.pluginFile] } }], [])
+assert.deepEqual(receipts, [{ schema: "wp-codebox/prepared-extra-plugin/v1", slug: plugin.slug, source: plugin.source, target: plugin.target, pluginFile: plugin.pluginFile, loadAs: "plugin", activate: true, provenance: plugin.provenance, activationStatus: "activated", failures: [] }])
+console.log("prepared extra plugin receipts ok")

--- a/tests/recipe-extra-plugin-local-zip.test.ts
+++ b/tests/recipe-extra-plugin-local-zip.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
+import { mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+import { cleanupRecipePreparedSources, prepareRecipeExtraPlugins } from "../packages/cli/src/recipe-sources.js"
+import type { WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+const execFileAsync = promisify(execFile)
+
+async function zip(directory: string, archive: string, entries: string[]): Promise<void> {
+  await execFileAsync("zip", ["-q", archive, ...entries], { cwd: directory })
+}
+
+function recipe(source: string, slug: string, sha256?: string): WorkspaceRecipe {
+  return {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: { extra_plugins: [{ source, slug, pluginFile: `${slug}/${slug}.php`, ...(sha256 ? { sha256 } : {}) }] },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  }
+}
+
+await withTempDir("wp-codebox-local-zip-plugin-", async (recipeDirectory) => {
+  await mkdir(join(recipeDirectory, "nested-plugin"))
+  await writeFile(join(recipeDirectory, "nested-plugin", "nested-plugin.php"), "<?php\n/* Plugin Name: Nested */\n")
+  await zip(recipeDirectory, "nested.zip", ["nested-plugin/nested-plugin.php"])
+  const digest = createHash("sha256").update(await readFile(join(recipeDirectory, "nested.zip"))).digest("hex")
+  const nestedRecipe = recipe("nested.zip", "nested-plugin", digest)
+
+  assert.deepEqual(await validateWorkspaceRecipeSemantics(nestedRecipe, join(recipeDirectory, "recipe.json")), [])
+  const [nested] = await prepareRecipeExtraPlugins(nestedRecipe, recipeDirectory)
+  assert.equal((await stat(join(nested.source, "nested-plugin.php"))).isFile(), true)
+  assert.deepEqual(nested.provenance.digest, { sha256: digest, expected: digest, verified: true })
+  assert.equal(nested.provenance.kind, "local")
+  assert.equal(nested.cleanupPaths.length, 1)
+  await cleanupRecipePreparedSources([], [nested])
+
+  await writeFile(join(recipeDirectory, "flat-plugin.php"), "<?php\n/* Plugin Name: Flat */\n")
+  await zip(recipeDirectory, "flat.zip", ["flat-plugin.php"])
+  const flatRecipe = recipe("flat.zip", "flat-plugin")
+  assert.deepEqual(await validateWorkspaceRecipeSemantics(flatRecipe, join(recipeDirectory, "flat.json")), [])
+  const [flat] = await prepareRecipeExtraPlugins(flatRecipe, recipeDirectory)
+  assert.equal((await stat(join(flat.source, "flat-plugin.php"))).isFile(), true)
+  await cleanupRecipePreparedSources([], [flat])
+
+  await assert.rejects(() => prepareRecipeExtraPlugins(recipe("nested.zip", "nested-plugin", "0".repeat(64)), recipeDirectory), /sha256 mismatch/)
+})
+
+await withTempDir("wp-codebox-local-zip-rejections-", async (recipeDirectory) => {
+  await writeFile(join(recipeDirectory, "outside.php"), "<?php\n")
+  await mkdir(join(recipeDirectory, "inside"))
+  await execFileAsync("zip", ["-q", "unsafe.zip", "../outside.php"], { cwd: join(recipeDirectory, "inside") })
+  await assert.rejects(() => prepareRecipeExtraPlugins(recipe("inside/unsafe.zip", "unsafe"), recipeDirectory), /unsafe path/)
+
+  await writeFile(join(recipeDirectory, "large-plugin.php"), Buffer.alloc(2048, "x"))
+  await zip(recipeDirectory, "large.zip", ["large-plugin.php"])
+  const previousLimit = process.env.WP_CODEBOX_MAX_EXTRACTED_BYTES
+  process.env.WP_CODEBOX_MAX_EXTRACTED_BYTES = "1024"
+  try {
+    await assert.rejects(() => prepareRecipeExtraPlugins(recipe("large.zip", "large-plugin"), recipeDirectory), /extraction exceeds 1024 bytes/)
+  } finally {
+    if (previousLimit === undefined) delete process.env.WP_CODEBOX_MAX_EXTRACTED_BYTES
+    else process.env.WP_CODEBOX_MAX_EXTRACTED_BYTES = previousLimit
+  }
+
+  await mkdir(join(recipeDirectory, "directory.zip"))
+  const issues = await validateWorkspaceRecipeSemantics(recipe("directory.zip", "directory"), join(recipeDirectory, "directory.json"))
+  assert.ok(issues.some((issue) => issue.code === "not-file"))
+  await assert.rejects(() => prepareRecipeExtraPlugins(recipe("directory.zip", "directory"), recipeDirectory), /regular file/)
+
+  await symlink(join(recipeDirectory, "large.zip"), join(recipeDirectory, "symlink.zip"))
+  await assert.rejects(() => prepareRecipeExtraPlugins(recipe("symlink.zip", "symlink"), recipeDirectory), /regular file/)
+})
+
+await withTempDir("wp-codebox-local-zip-policy-", async (recipeDirectory) => {
+  await writeFile(join(recipeDirectory, "plugin.php"), "<?php\n")
+  await zip(recipeDirectory, "plugin.zip", ["plugin.php"])
+  const previousRequirement = process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256
+  process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256 = "1"
+  try {
+    const issues = await validateWorkspaceRecipeSemantics(recipe("plugin.zip", "plugin"), join(recipeDirectory, "recipe.json"))
+    assert.ok(issues.some((issue) => issue.code === "missing-source-sha256"))
+    await assert.rejects(() => prepareRecipeExtraPlugins(recipe("plugin.zip", "plugin"), recipeDirectory), /require sha256/)
+  } finally {
+    if (previousRequirement === undefined) delete process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256
+    else process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256 = previousRequirement
+  }
+})
+
+console.log("recipe extra plugin local ZIP sources ok")


### PR DESCRIPTION
## Summary
Expose generic prepared extra-plugin source provenance and activation outcomes in recipe-run output.

## Verification
- 
> wp-codebox-workspace@0.19.0 build
> node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs
- 
> wp-codebox-workspace@0.19.0 test:runtime-sources-materialization
> tsx tests/runtime-sources-materialization.test.ts

runtime sources materialization ok

AI assistance: gpt-5.6-terra via OpenCode was used to implement and verify this generic recipe evidence contract. Chris Huber remains responsible for every line.