### PR TITLE
fix: preserve executable CLI in release ZIP

### DIFF
--- a/scripts/lib/assemble-wordpress-plugin-zip.ts
+++ b/scripts/lib/assemble-wordpress-plugin-zip.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises"
+import { chmod, cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
@@ -36,6 +36,7 @@ export async function assembleWordpressPluginZip(repoRoot: string): Promise<stri
 			await cp(join(pluginSource, "assets"), join(stagingPlugin, "assets"), { recursive: true })
 		}
 		await cp(cliPackageRoot, join(stagingPlugin, "vendor", "wp-codebox-cli"), { recursive: true })
+		await chmod(join(stagingPlugin, "vendor", "wp-codebox-cli", "packages", "cli", "dist", "index.js"), 0o755)
 		await rm(outputZip, { force: true })
 		await execFileAsync("zip", ["-qr", outputZip, "wp-codebox"], { cwd: stagingRoot })
 		return outputZip

--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -39,6 +39,9 @@ try {
     await mkdir(targetRoot, { recursive: true })
     await cp(join(sourceRoot, "package.json"), join(targetRoot, "package.json"))
     await cp(join(sourceRoot, "dist"), join(targetRoot, "dist"), { recursive: true })
+    if (packageName === "cli") {
+      await chmod(join(targetRoot, "dist", "index.js"), 0o755)
+    }
   }
 
   await execFileAsync("npm", ["ci", "--omit=dev", "--omit=optional", "--ignore-scripts", "--no-fund", "--no-audit"], {

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -106,6 +106,7 @@ try {
     }
 
     const cliEntrypoint = join(root, "packages", "cli", "dist", "index.js")
+    assert.equal((await lstat(cliEntrypoint)).mode & 0o777, 0o755, `${cliEntrypoint} must be executable after extraction`)
     const { stdout: version } = await execFileAsync(process.execPath, [cliEntrypoint, "--version"])
     assert.match(version, /^\d+\.\d+\.\d+\s*$/)
     await execFileAsync(process.execPath, [cliEntrypoint, "commands"])


### PR DESCRIPTION
## Summary
- establish CLI entrypoint mode `0755` while staging the release package
- reassert executable mode at the final WordPress ZIP assembly boundary
- verify the mode after extracting the official plugin ZIP

## Testing
- `npm run build`
- extracted `packages/wordpress-plugin/dist/wp-codebox.zip` reports `-rwxr-xr-x` for `vendor/wp-codebox-cli/packages/cli/dist/index.js`
- the new release-coverage assertion passes before the suite reaches packaged CLI execution
- `git diff --check`

The full release coverage suite later fails on the independent missing Sharp native runtime defect tracked in #2209.

Closes #2205