### PR TITLE
fix: preserve PHPUnit MySQL output aliases

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -164,7 +164,28 @@ function phpunitRuntimeServices(databaseType: WordPressPhpunitRecipeOptions["dat
     return [...services, { id: "wordpress-database", kind: "mysql", outputs: canonicalOutputs }]
   }
 
-  return services.map((service, index) => index === mysqlIndex ? { ...service, outputs: { ...service.outputs, ...canonicalOutputs } } : service)
+  return services.map((service, index) => index === mysqlIndex ? { ...service, outputs: mergeCanonicalMysqlOutputs(service.outputs, canonicalOutputs) } : service)
+}
+
+function mergeCanonicalMysqlOutputs(outputs: WorkspaceRecipeRuntimeService["outputs"], canonicalOutputs: Record<string, string>): WorkspaceRecipeRuntimeService["outputs"] {
+  const canonicalTargets = new Map(Object.entries(canonicalOutputs).map(([output, target]) => [target, output]))
+  for (const [output, value] of Object.entries(outputs)) {
+    for (const target of outputTargets(value)) {
+      const canonicalOutput = canonicalTargets.get(target)
+      if (canonicalOutput && canonicalOutput !== output) {
+        throw new Error(`MySQL service output ${output} conflicts with canonical ${canonicalOutput} binding ${target}`)
+      }
+    }
+  }
+
+  return Object.fromEntries(Object.entries(canonicalOutputs).map(([output, target]) => {
+    const targets = [...new Set([target, ...outputTargets(outputs[output])])]
+    return [output, targets.length === 1 ? targets[0]! : targets]
+  }).concat(Object.entries(outputs).filter(([output]) => !(output in canonicalOutputs))))
+}
+
+function outputTargets(value: string | string[] | undefined): string[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value]
 }
 
 function normalizeRecipeSteps(steps: readonly WorkspaceRecipeStep[], label: string): WorkspaceRecipeStep[] {

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -49,6 +49,20 @@ assert.deepEqual(buildWordPressPhpunitRecipe({ pluginSlug: "example", services: 
 const mysqlPhpunitRecipe = buildWordPressPhpunitRecipe({ pluginSlug: "example", databaseType: "mysql" })
 assert.deepEqual(mysqlPhpunitRecipe.inputs?.services, [{ id: "wordpress-database", kind: "mysql", outputs: { host: "DB_HOST", port: "DB_PORT", username: "DB_USER", password: "DB_PASSWORD", database: "DB_NAME" } }])
 assert.ok(mysqlPhpunitRecipe.workflow.steps[0].args?.includes("database-type=mysql"))
+const mysqlWithExplicitPortAliases = buildWordPressPhpunitRecipe({
+  pluginSlug: "example",
+  databaseType: "mysql",
+  services: [{ id: "mysql", kind: "mysql", outputs: { port: ["DB_PORT", "TC_MYSQL_PORT"] } }],
+})
+assert.deepEqual(mysqlWithExplicitPortAliases.inputs?.services, [{
+  id: "mysql",
+  kind: "mysql",
+  outputs: { host: "DB_HOST", port: ["DB_PORT", "TC_MYSQL_PORT"], username: "DB_USER", password: "DB_PASSWORD", database: "DB_NAME" },
+}], "canonical MySQL outputs retain explicit aliases")
+assert.throws(
+  () => buildWordPressPhpunitRecipe({ pluginSlug: "example", databaseType: "mysql", services: [{ id: "mysql", kind: "mysql", outputs: { host: "DB_PORT" } }] }),
+  /MySQL service output host conflicts with canonical port binding DB_PORT/,
+)
 const sqlitePhpunitRecipe = buildWordPressPhpunitRecipe({ pluginSlug: "example" })
 assert.equal(sqlitePhpunitRecipe.inputs?.services, undefined)
 assert.equal(sqlitePhpunitRecipe.workflow.steps[0].args?.some((arg) => arg.startsWith("database-type=")), false)


### PR DESCRIPTION
## Summary
- merge canonical PHPUnit MySQL bindings with explicit output aliases
- reject ambiguous canonical MySQL environment bindings
- cover DB_PORT plus TC_MYSQL_PORT regression

Fixes #2224.

## Verification
- `npm run build`
- `npm run test:runtime-services`
- `node ./node_modules/typescript/bin/tsc -p packages/runtime-core --noEmit`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent.