### PR TITLE
fix(playground): bridge managed database environment

### DIFF
--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -176,7 +176,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           ...(spec.environment.extensions?.length ? { phpExtension: spec.environment.extensions.map((extension) => extension.manifest) } : {}),
           ...playgroundBundledExtensionOptions(spec),
           phpIniEntries: pluginRuntimePhpIniEntries(spec),
-          phpEnv: connectorSecretEnvironment(spec),
+          phpEnv: runtimePhpEnvironment(spec),
           "site-url": playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl,
           blueprint: playgroundCliBlueprint(spec),
         })
@@ -491,10 +491,13 @@ require_once ABSPATH . 'wp-settings.php';
 `
 }
 
-function connectorSecretEnvironment(spec: RuntimeCreateSpec): Record<string, string> | undefined {
+function runtimePhpEnvironment(spec: RuntimeCreateSpec): Record<string, string> | undefined {
   if (spec.environment.databaseSetup !== "external") return undefined
-  const resolved = resolveRuntimeSecretEnvTargets(spec.secretEnv ?? {}, spec.secretEnvTargets)
-  return Object.keys(resolved).length > 0 ? resolved : undefined
+  const environment = {
+    ...(spec.runtimeEnv ?? {}),
+    ...resolveRuntimeSecretEnvTargets(spec.secretEnv ?? {}, spec.secretEnvTargets),
+  }
+  return Object.keys(environment).length > 0 ? environment : undefined
 }
 
 function distributionBootstrapPhp(spec: RuntimeCreateSpec): string {

--- a/tests/disposable-mysql-mysqli.integration.test.ts
+++ b/tests/disposable-mysql-mysqli.integration.test.ts
@@ -46,11 +46,12 @@ if (!await dockerAvailable()) {
     assert.equal(result.executions.at(-1)?.stdout.trim(), "1")
 
     const mariaDbRecipePath = join(directory, "mariadb-recipe.json")
-    const mariaDbCode = "if (!function_exists('mysqli_init')) { throw new RuntimeException('mysqli is unavailable'); } $db = mysqli_init(); if (!mysqli_real_connect($db, getenv('DB_HOST'), 'root', '', 'runtime', (int) getenv('DB_PORT'))) { throw new RuntimeException(mysqli_connect_error()); } mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT); mysqli_query($db, 'CREATE TABLE parent (id INT NOT NULL, KEY (id)) ENGINE=InnoDB'); mysqli_query($db, 'CREATE TABLE child (parent_id INT NOT NULL, FOREIGN KEY (parent_id) REFERENCES parent(id)) ENGINE=InnoDB'); mysqli_query($db, \"CREATE TABLE settings (payload LONGTEXT NOT NULL DEFAULT '{}') ENGINE=InnoDB\"); $result = mysqli_query($db, 'SELECT 1 AS connected'); echo mysqli_fetch_assoc($result)['connected'];"
+    const mariaDbCode = "if (!function_exists('mysqli_init')) { throw new RuntimeException('mysqli is unavailable'); } mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT); $connect = static function (string $port): mysqli { $db = mysqli_init(); if (!mysqli_real_connect($db, getenv('DB_HOST'), getenv('DB_USER'), getenv('DB_PASSWORD'), getenv('DB_NAME'), (int) $port)) { throw new RuntimeException(mysqli_connect_error()); } return $db; }; $db = $connect((string) getenv('DB_PORT')); $compatibility = $connect((string) getenv('TC_MYSQL_PORT')); mysqli_query($db, 'CREATE TABLE mariadb_bridge (id INT PRIMARY KEY, value VARCHAR(32) NOT NULL) ENGINE=InnoDB'); mysqli_query($db, \"INSERT INTO mariadb_bridge (id, value) VALUES (1, 'reachable')\"); $row = mysqli_fetch_assoc(mysqli_query($compatibility, 'SELECT value FROM mariadb_bridge WHERE id = 1')); if (($row['value'] ?? null) !== 'reachable') { throw new RuntimeException('MariaDB read failed'); } mysqli_query($db, 'DROP TABLE mariadb_bridge'); echo getenv('DB_PORT') . ':' . getenv('TC_MYSQL_PORT');"
     await writeFile(mariaDbRecipePath, JSON.stringify({
       schema: "wp-codebox/workspace-recipe/v1",
+      runtime: { php: "8.4" },
       inputs: {
-        services: [{ id: "mariadb", kind: "mysql", configuration: { engine: "mariadb", rootAuthentication: "empty-password" }, outputs: { host: "DB_HOST", port: "DB_PORT" } }],
+        services: [{ id: "mariadb", kind: "mysql", configuration: { engine: "mariadb", rootAuthentication: "empty-password" }, outputs: { host: "DB_HOST", port: ["DB_PORT", "TC_MYSQL_PORT"], username: "DB_USER", password: "DB_PASSWORD", database: "DB_NAME" } }],
       },
       workflow: { steps: [{ command: "wordpress.run-php", args: [`code=${mariaDbCode}`] }] },
     }))
@@ -65,7 +66,9 @@ if (!await dockerAvailable()) {
       dryRun: false,
     })
     assert.equal(mariaDbResult.success, true, JSON.stringify(mariaDbResult))
-    assert.equal(mariaDbResult.executions.at(-1)?.stdout.trim(), "1")
+    const [canonicalPort, compatibilityPort] = (mariaDbResult.executions.at(-1)?.stdout.trim() ?? "").split(":")
+    assert.match(canonicalPort, /^\d+$/)
+    assert.equal(compatibilityPort, canonicalPort)
 
     const harness = join(directory, "phpunit-harness")
     const plugin = join(directory, "bounded-phpunit-fixture")

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -89,7 +89,14 @@ try {
   assert.equal(calls[0].workers, 1)
   assert.equal(calls[0].wordpressInstallMode, "do-not-attempt-installing")
   assert.equal(calls[0].skipSqliteSetup, true)
-  assert.equal(calls[0].phpEnv?.DB_PASSWORD, "secret")
+  assert.deepEqual(calls[0].phpEnv, {
+    TC_MYSQL_PORT: "33060",
+    DB_HOST: "127.0.0.1",
+    DB_PORT: "33061",
+    DB_USER: "runtime",
+    DB_NAME: "runtime",
+    DB_PASSWORD: "secret",
+  })
   assert.equal(shouldUseProgrammaticPlaygroundRunner(spec), false)
   assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
   assert.deepEqual(calls[0].phpExtension, ["/tmp/sodium/manifest.json"])
@@ -125,7 +132,13 @@ try {
   const passwordlessExternalServer = await startPlaygroundCliServer({ ...spec, secretEnv: {}, secretEnvTargets: {} }, [], { cliModule })
   assert.equal((await passwordlessExternalServer.playground.run({ code: "<?php echo getenv('DB_PASSWORD');" })).text, "", "connector secrets do not leak across runtime instances")
   await passwordlessExternalServer[Symbol.asyncDispose]()
-  assert.equal(calls[0]?.phpEnv, undefined)
+  assert.deepEqual(calls[0]?.phpEnv, {
+    TC_MYSQL_PORT: "33060",
+    DB_HOST: "127.0.0.1",
+    DB_PORT: "33061",
+    DB_USER: "runtime",
+    DB_NAME: "runtime",
+  })
   assert.equal(calls[0]?.["mount-before-install"]?.some((mount) => mount.vfsPath === "/internal/wp-codebox"), true, "passwordless external databases retain isolated request workers")
   assert.equal(calls[0]?.["mount-before-install"]?.some((mount) => /^\/wordpress\/wp-codebox-execute-[a-f0-9]{24}\.php$/.test(mount.vfsPath)), true)
 


### PR DESCRIPTION
Closes #2225

## Summary
- initialize the PHP.wasm CLI worker with all resolved managed database bindings, including canonical and compatibility port aliases
- retain connector-secret target resolution while making endpoint bindings available during runtime bootstrap
- extend the Docker MariaDB integration to boot PHP 8.4, connect through `mysqli` using canonical bindings, read data through `TC_MYSQL_PORT`, and drop the test table

## Verification
- `npm run build`
- `npm run test:runtime-services`
- `npm exec -- tsx tests/playground-cli-runner-bootstrap-ini.test.ts`
- `npm run test:disposable-mysql-mysqli-e2e` (skipped: Docker daemon unavailable in this environment)
- `npx eslint packages/runtime-playground/src/playground-cli-runner.ts tests/disposable-mysql-mysqli.integration.test.ts` (not runnable: repository has no ESLint configuration)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to inspect the PHP.wasm/managed MariaDB runtime path, implement the generic environment bridge, and add focused integration coverage. Chris Huber remains responsible for every line.