### PR TITLE
Fix cross-target release package coverage

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -75,6 +75,7 @@
     ],
     "test": [
       "npm run smoke -- --group package",
+      "npm run test:release-target",
       "npm run test:release-package-coverage",
       "npm run release:package"
     ]

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "test:release-package-coverage": "tsx tests/release-package-coverage.test.ts",
+    "test:release-target": "tsx --test tests/release-target.test.ts",
     "test:sharp-release-runtime": "tsx --test tests/sharp-release-runtime.test.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wp-codebox:source": "node bin/wp-codebox-source.mjs",

--- a/scripts/lib/release-target.ts
+++ b/scripts/lib/release-target.ts
@@ -1,0 +1,9 @@
+export function normalizeReleasePlatform(platformName: NodeJS.Platform): string {
+  if (platformName === "darwin") return "macos"
+  if (platformName === "win32") return "windows"
+  return platformName
+}
+
+export function releaseTargetMatchesHost(target: string, hostPlatform: NodeJS.Platform, hostArch: string): boolean {
+  return target === `${normalizeReleasePlatform(hostPlatform)}-${hostArch}`
+}

--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -8,13 +8,14 @@ import { promisify } from "node:util"
 
 import { assembleWordpressPluginZip } from "./lib/assemble-wordpress-plugin-zip.ts"
 import { materializeSharpReleaseRuntime, sharpRuntimePackageNames } from "./lib/materialize-sharp-release-runtime.ts"
+import { normalizeReleasePlatform } from "./lib/release-target.ts"
 
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
 const releaseRoot = resolve(repoRoot, "dist", "release")
 const stagingReleaseRoot = await mkdtemp(join(tmpdir(), "wp-codebox-release-"))
 const packageRoot = join(stagingReleaseRoot, "wp-codebox-cli")
-const platformName = process.env.WP_CODEBOX_RELEASE_PLATFORM ?? normalizePlatform(platform())
+const platformName = process.env.WP_CODEBOX_RELEASE_PLATFORM ?? normalizeReleasePlatform(platform())
 const archName = process.env.WP_CODEBOX_RELEASE_ARCH ?? normalizeArch(arch())
 sharpRuntimePackageNames(platformName, archName)
 const nodeRuntimeVersion = process.env.WP_CODEBOX_NODE_RUNTIME_VERSION ?? "24.16.0"
@@ -179,7 +180,7 @@ async function bundleNodeRuntime(root: string, platformName: string, archName: s
     } finally {
       await rm(tempRoot, recursiveRmOptions)
     }
-  } else if (platformName === normalizePlatform(platform()) && archName === normalizeArch(arch())) {
+  } else if (platformName === normalizeReleasePlatform(platform()) && archName === normalizeArch(arch())) {
     await cp(process.execPath, join(runtimeRoot, "bin", "node"))
     await chmod(join(runtimeRoot, "bin", "node"), 0o755)
   } else {
@@ -196,16 +197,6 @@ function nodeRuntimePackageName(platformName: string, archName: string): string 
   }
 
   return null
-}
-
-function normalizePlatform(value: NodeJS.Platform): string {
-  if (value === "darwin") {
-    return "macos"
-  }
-  if (value === "win32") {
-    return "windows"
-  }
-  return value
 }
 
 function normalizeArch(value: string): string {

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -7,6 +7,8 @@ import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
+import { releaseTargetMatchesHost } from "../scripts/lib/release-target.ts"
+
 const execFileAsync = promisify(execFile)
 const repositoryRoot = resolve(import.meta.dirname, "..")
 const pluginRoot = "packages/wordpress-plugin"
@@ -50,6 +52,10 @@ const cliArtifact = cliArtifacts[0] as { path: string, platform: string }
 assert.match(cliArtifact.path, /^dist\/wp-codebox-cli-[^/]+\.tar\.gz$/)
 assert.match(cliArtifact.platform, /^[a-z0-9]+-[a-z0-9]+$/)
 assert.equal(cliArtifact.path, `dist/wp-codebox-cli-${cliArtifact.platform}.tar.gz`)
+const canExecuteReleaseTarget = releaseTargetMatchesHost(cliArtifact.platform, process.platform, process.arch)
+if (!canExecuteReleaseTarget) {
+  console.log(`Skipping packaged CLI execution because release target ${cliArtifact.platform} does not match host ${process.platform}-${process.arch}.`)
+}
 
 const { stdout: tracked } = await execFileAsync("git", ["ls-files", "-z", "--", `${pluginRoot}/**`], { cwd: repositoryRoot })
 const mappedFiles = tracked
@@ -112,9 +118,12 @@ try {
       ["sharp-libvips-linux-x64", "sharp-linux-x64"],
       "release package must contain only the Sharp native runtime for its declared target",
     )
-    const { stdout: version } = await execFileAsync(process.execPath, [cliEntrypoint, "--version"])
-    assert.match(version, /^\d+\.\d+\.\d+\s*$/)
-    await execFileAsync(process.execPath, [cliEntrypoint, "commands"])
+    let version = ""
+    if (canExecuteReleaseTarget) {
+      ({ stdout: version } = await execFileAsync(process.execPath, [cliEntrypoint, "--version"]))
+      assert.match(version, /^\d+\.\d+\.\d+\s*$/)
+      await execFileAsync(process.execPath, [cliEntrypoint, "commands"])
+    }
     const descriptorModule = await import(pathToFileURL(join(root, "packages", "runtime-core", "dist", "runtime-contract-manifest.js")).href) as { runtimeDescriptor(): { capabilities: string[]; packageCapabilities: string[]; runtimeServices: { nativeMariaDb: { status: string } }; contractManifest: { capabilities: { runtimeServices: { packageCapabilities: string[] } } } } }
     const descriptor = descriptorModule.runtimeDescriptor()
     assert.equal(descriptor.capabilities.includes("runtime-service:mysql:native:mariadb"), false, "package support must not claim unknown host readiness")
@@ -122,11 +131,13 @@ try {
     assert.equal(descriptor.runtimeServices.nativeMariaDb.status, "unknown")
     assert.deepEqual(descriptor.contractManifest.capabilities.runtimeServices.packageCapabilities, ["runtime-service:mysql:native:mariadb"])
 
-    const wrapper = join(root, "bin", "wp-codebox")
-    const { stdout: wrapperVersion } = await execFileAsync(wrapper, ["--version"], {
-      env: { ...process.env, WP_CODEBOX_NODE_BIN: "" },
-    })
-    assert.equal(wrapperVersion, version, "wrapper must fall back to host Node when bundled Node is incompatible")
+    if (canExecuteReleaseTarget) {
+      const wrapper = join(root, "bin", "wp-codebox")
+      const { stdout: wrapperVersion } = await execFileAsync(wrapper, ["--version"], {
+        env: { ...process.env, WP_CODEBOX_NODE_BIN: "" },
+      })
+      assert.equal(wrapperVersion, version, "wrapper must fall back to host Node when bundled Node is incompatible")
+    }
 
     await assertPackagedReadonlyMaterialization(root)
   }

--- a/tests/release-target.test.ts
+++ b/tests/release-target.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { normalizeReleasePlatform, releaseTargetMatchesHost } from "../scripts/lib/release-target.ts"
+
+test("normalizes Node platform names to release target names", () => {
+  assert.equal(normalizeReleasePlatform("darwin"), "macos")
+  assert.equal(normalizeReleasePlatform("win32"), "windows")
+  assert.equal(normalizeReleasePlatform("linux"), "linux")
+})
+
+test("executes release packages only on a compatible host target", () => {
+  assert.equal(releaseTargetMatchesHost("linux-x64", "linux", "x64"), true)
+  assert.equal(releaseTargetMatchesHost("linux-x64", "darwin", "arm64"), false)
+  assert.equal(releaseTargetMatchesHost("macos-arm64", "darwin", "arm64"), true)
+  assert.equal(releaseTargetMatchesHost("windows-x64", "win32", "x64"), true)
+})


### PR DESCRIPTION
## Summary

- separate cross-target package structure validation from target-native process execution
- keep packaged CLI execution mandatory when the release target matches the host
- centralize and test Node-to-release platform normalization
- include the focused compatibility test in Homeboy release gates

Fixes #2250.

## Verification

- `npm run test:release-target`
- `npm run test:sharp-release-runtime`
- `npm run build`
- `npm run smoke -- --group package` (Docker-backed mysqli E2E skipped because Docker is unavailable)
- `npm run test:release-package-coverage`
- `npm run release:package`
- `git diff --check`

On macOS ARM64, release package coverage now validates the Linux x64 package and reports:

```text
Skipping packaged CLI execution because release target linux-x64 does not match host darwin-arm64.
release package coverage passed
```

Linux x64 remains responsible for the packaged `--version`, `commands`, and wrapper execution assertions because its host and target match.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to reproduce and diagnose the release-gate failure, implement the compatibility boundary and tests, and run verification. Chris Huber reviewed and remains responsible for every line.
