### PR TITLE
Deduplicate release package gate

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -76,8 +76,7 @@
     "test": [
       "npm run smoke -- --group package",
       "npm run test:release-target",
-      "npm run test:release-package-coverage",
-      "npm run release:package"
+      "npm run test:release-package-coverage"
     ]
   }
 }

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -21,6 +21,11 @@ assert.deepEqual(homeboy.release?.package_coverage, [{
   source_roots: [pluginRoot],
   archive_root: "wp-codebox",
 }])
+assert.deepEqual(homeboy.scripts?.test, [
+  "npm run smoke -- --group package",
+  "npm run test:release-target",
+  "npm run test:release-package-coverage",
+])
 
 await execFileAsync("npm", ["run", "build"], { cwd: repositoryRoot, maxBuffer: 1024 * 1024 * 10 })
 const staleDistPath = resolve(repositoryRoot, "packages/runtime-playground/dist/mount-materialization.js")


### PR DESCRIPTION
## Summary

- remove the second full `release:package` invocation from the Homeboy test gate
- keep release-package coverage as the single preflight distribution proof
- assert the expensive test command graph so duplicate packaging is not reintroduced

Closes #2259.

## Verification

- `npm run test:release-package-coverage`
- deterministic `homeboy.json` command-graph assertion
- `git diff --check`

The package-coverage run completed in 13m57s; this change removes one duplicate full packaging pass from every release.

## AI assistance

GPT-5.6 Sol and GPT-5.6 Terra via OpenCode were used to trace the release command graph, implement the configuration fix and regression assertion, and run verification. Chris Huber reviewed and is responsible for every line.