### PR TITLE
Fix fuzz-suite runtime paths relative to input files

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -190,6 +190,11 @@ path `wp-codebox run-fuzz-suite --runner-mode=runtime-backed`. Targets that
 require the runtime command, browser, editor, or page-load executors return
 `status: "skipped"`, a case-level `skipReason`, and a warning diagnostic in
 permissive PHP mode rather than silently passing without exercising the target.
+For the Node CLI `--input-file` path, local `metadata.runtime_requirements`
+`wordpress_directory`, `extra_plugins`, and `component_contracts` paths resolve
+relative to the input file before WP Codebox materializes its temporary recipe.
+Absolute paths remain unchanged; `sourceSubpath` and `sourceSubdir` remain
+bounded relative plugin-internal paths.
 Public suite builders declare
 `metadata.requiredRunnerCapabilities`, and the PHP ability also infers required
 target/runtime-action capabilities from suite targets, so callers can choose

--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -347,7 +347,6 @@ function normalizeRuntimeRequirementExtraPlugins(value: unknown[], fallback: Wor
       source,
       sourceRoot: stringValue(plugin.sourceRoot ?? plugin.source_root),
       sourceSubpath: stringValue(plugin.sourceSubpath ?? plugin.source_subpath),
-      originalSource: stringValue(plugin.originalSource ?? plugin.original_source),
       slug: stringValue(plugin.slug),
       pluginFile: stringValue(plugin.pluginFile ?? plugin.plugin_file),
       activate: typeof plugin.activate === "boolean" ? plugin.activate : undefined,
@@ -422,13 +421,48 @@ async function readInput(options: Map<string, string | true>): Promise<Record<st
     throw new Error("Use either --input-file or --input-json, not both")
   }
   if (inputFile) {
-    const parsed = parseCommandJson(await readFile(resolve(inputFile), "utf8"), "--input-file")
-    return objectInput(parsed, "--input-file")
+    const resolvedInputFile = resolve(inputFile)
+    const parsed = objectInput(parseCommandJson(await readFile(resolvedInputFile, "utf8"), "--input-file"), "--input-file")
+    return resolveFuzzSuiteRuntimeRequirementPaths(parsed, dirname(resolvedInputFile))
   }
   if (inputJson) {
     return objectInput(parseCommandJson(inputJson, "--input-json"), "--input-json")
   }
   throw new Error("Missing required option: --input-file")
+}
+
+// Runtime requirements become recipe inputs after the suite is read, so anchor
+// their local sources to the suite file rather than the temporary recipe.
+function resolveFuzzSuiteRuntimeRequirementPaths(input: Record<string, unknown>, inputDirectory: string): Record<string, unknown> {
+  const metadata = objectOption(input.metadata)
+  const requirements = objectOption(metadata?.runtime_requirements)
+  if (!metadata || !requirements) return input
+
+  const resolvePath = (value: unknown): unknown => typeof value === "string" && value.trim() && !/^https?:\/\//i.test(value) ? resolve(inputDirectory, value) : value
+  const resolvePluginPaths = (entries: unknown): unknown => Array.isArray(entries)
+    ? entries.map((entry) => {
+      const plugin = objectOption(entry)
+      if (!plugin) return entry
+      const resolved = { ...plugin }
+      for (const key of ["source", "path", "sourceRoot", "source_root"]) {
+        if (key in plugin) resolved[key] = resolvePath(plugin[key])
+      }
+      return resolved
+    })
+    : entries
+
+  return {
+    ...input,
+    metadata: {
+      ...metadata,
+      runtime_requirements: {
+        ...requirements,
+        wordpress_directory: resolvePath(requirements.wordpress_directory),
+        extra_plugins: resolvePluginPaths(requirements.extra_plugins),
+        component_contracts: resolvePluginPaths(requirements.component_contracts),
+      },
+    },
+  }
 }
 
 function workloadRecipeOptions(input: Record<string, unknown>, runtimeRequirements?: Record<string, unknown>): WordPressWorkloadRunRecipeOptions {

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -145,6 +145,59 @@ return static function ( array $input, array $args ): array {
   const typedWorkloads = JSON.parse(typedWorkloadsJson.replace(/^workloads-json=/, ""))
   assert.deepEqual(typedWorkloads[0].run, [{ type: "php", code: "return array('ok' => true);" }])
 
+  const nestedSuiteDirectory = join(directory, "repository", "tests", "fuzz")
+  const siblingPluginSource = join(directory, "repository", "plugins", "sibling-plugin")
+  await mkdir(nestedSuiteDirectory, { recursive: true })
+  await mkdir(siblingPluginSource, { recursive: true })
+  await writeFile(join(siblingPluginSource, "sibling-plugin.php"), "<?php\n/* Plugin Name: Sibling Plugin */\n", "utf8")
+  const nestedRuntimeFuzzInput = join(nestedSuiteDirectory, "suite.json")
+  await writeFile(nestedRuntimeFuzzInput, JSON.stringify({
+    schema: "wp-codebox/fuzz-suite/v1",
+    id: "portable-relative-runtime-requirements",
+    metadata: {
+      runtime_requirements: {
+        extra_plugins: [{ slug: "sibling-plugin", source: "../../plugins/sibling-plugin", originalSource: "../../plugins/sibling-plugin", loadAs: "plugin", activate: true }],
+        component_contracts: [{ slug: "sibling-plugin", path: "../../plugins/sibling-plugin", original_source: "../../plugins/sibling-plugin", loadAs: "plugin", activate: true }],
+      },
+    },
+    cases: [{
+      id: "portable-relative-plugin",
+      target: { kind: "runtime", id: "wordpress.rest-route-inventory", entrypoint: "wordpress.rest-route-inventory" },
+      input: { args: [] },
+    }],
+  }), "utf8")
+  const nestedRuntimeFuzzOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["run-fuzz-suite", "--input-file", nestedRuntimeFuzzInput, "--format=json", "--dry-run"]), 0)
+  })
+  const nestedRuntimeFuzzJson = JSON.parse(nestedRuntimeFuzzOutput)
+  const nestedRuntimePlan = nestedRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan
+  assert.deepEqual(nestedRuntimePlan.extra_plugins.map((plugin: { source: string; slug: string; activate: boolean }) => ({ source: plugin.source, slug: plugin.slug, activate: plugin.activate })), [{ source: siblingPluginSource, slug: "sibling-plugin", activate: true }])
+  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.extra_plugins[0].originalSource, "../../plugins/sibling-plugin")
+  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.component_contracts[0].original_source, "../../plugins/sibling-plugin")
+  const nestedRuntimeExecutionOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["run-fuzz-suite", "--input-file", nestedRuntimeFuzzInput, "--format=json", "--runner-mode=runtime-backed"]), 0)
+  })
+  const nestedRuntimeExecution = JSON.parse(nestedRuntimeExecutionOutput)
+  assert.equal(nestedRuntimeExecution.status, "passed")
+  assert.equal(nestedRuntimeExecution.cases[0].status, "passed")
+
+  const componentOnlyFuzzInput = join(nestedSuiteDirectory, "component-suite.json")
+  await writeFile(componentOnlyFuzzInput, JSON.stringify({
+    schema: "wp-codebox/fuzz-suite/v1",
+    id: "portable-relative-component-contract",
+    metadata: { runtime_requirements: { component_contracts: [{ slug: "sibling-plugin", path: "../../plugins/sibling-plugin", loadAs: "plugin", activate: true }] } },
+    cases: [{
+      id: "portable-relative-component",
+      target: { kind: "runtime", id: "wordpress.rest-route-inventory", entrypoint: "wordpress.rest-route-inventory" },
+      input: { args: [] },
+    }],
+  }), "utf8")
+  const componentOnlyFuzzOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["run-fuzz-suite", "--input-file", componentOnlyFuzzInput, "--format=json", "--dry-run"]), 0)
+  })
+  const componentOnlyPlan = JSON.parse(componentOnlyFuzzOutput).cases[0].metadata.execution.result.json.plan
+  assert.deepEqual(componentOnlyPlan.extra_plugins.map((plugin: { source: string; slug: string; activate: boolean }) => ({ source: plugin.source, slug: plugin.slug, activate: plugin.activate })), [{ source: siblingPluginSource, slug: "sibling-plugin", activate: true }])
+
   const runtimeCommandFuzzInput = join(directory, "runtime-command-fuzz.json")
   await writeFile(runtimeCommandFuzzInput, JSON.stringify({
     schema: "wp-codebox/fuzz-suite/v1",


### PR DESCRIPTION
## Summary

- resolve local `metadata.runtime_requirements` paths relative to `--input-file` before temporary recipe creation
- preserve `originalSource` and `original_source` provenance metadata
- cover dry-run and real runtime-backed execution for a nested portable suite
- document the public path contract

## Verification

```text
npm run build
npx tsx tests/public-fuzz-workload-cli.test.ts
npm run test:recipe-extra-plugin-local-zip
npm run test:recipe-source-packages
npm run test:recipe-runtime-setup-staged-materialization
npm run test:public-api-contract
git diff --check
```

Fixes #2279.

AI assistance: OpenAI gpt-5.6-sol via OpenCode reviewed the implementation, strengthened runtime-backed coverage, and ran verification. Chris Huber remains responsible for every line.