### PR TITLE
fix(artifacts): preserve partial browser evidence

### DIFF
--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -80,6 +80,7 @@ export interface ArtifactBundleBuilderSource {
   previewInfo(createdAt: string, previewHoldSeconds: number | undefined, commands: ExecutionResult[]): Promise<ArtifactPreview | undefined>
   browserReviewSummary(): ArtifactReviewBrowserSummary | undefined
   browserArtifacts(): BrowserArtifact[]
+  additionalArtifactDiagnostics?(): unknown[]
   captureMountedFiles(filesDirectory: string, redactor: ArtifactRedactor): Promise<CapturedMountFiles>
   captureMountDiffs(filesDirectory: string, redactor: ArtifactRedactor): Promise<MountDiffsResult>
   redactBrowserArtifacts(redactor: ArtifactRedactor): Promise<void>
@@ -172,6 +173,7 @@ export class ArtifactBundleBuilder {
     })
     const previewSessionEvidenceRelativePath = relative(source.artifactRoot, previewSessionEvidencePath)
     const diagnostics = buildArtifactDiagnostics(source.observations)
+    diagnostics.diagnostics.push(...buildArtifactDiagnostics(source.additionalArtifactDiagnostics?.() ?? []).diagnostics)
     diagnostics.diagnostics.push(...mountDiffDiagnostics)
     diagnostics.summary.total = diagnostics.diagnostics.length
     diagnostics.summary.error = diagnostics.diagnostics.filter((diagnostic) => diagnostic.severity === "error").length

--- a/packages/runtime-playground/src/runtime-artifact-helpers.ts
+++ b/packages/runtime-playground/src/runtime-artifact-helpers.ts
@@ -1,3 +1,4 @@
+import { access } from "node:fs/promises"
 import { join } from "node:path"
 import { artifactManifestFile } from "@automattic/wp-codebox-core"
 import { normalizeJsonValue } from "@automattic/wp-codebox-core/internals"
@@ -55,6 +56,7 @@ export async function collectPlaygroundArtifacts({
   spec: RuntimeCreateSpec
   themeChecks: ThemeCheckArtifact[]
 }, artifactSpec: ArtifactSpec = {}): Promise<ArtifactBundle> {
+  const { probes, missing } = await availableBrowserArtifacts(artifactRoot, browserProbes)
   return new ArtifactBundleBuilder({
     artifactRoot,
     runtimeId,
@@ -67,14 +69,15 @@ export async function collectPlaygroundArtifacts({
     events,
     info,
     previewInfo,
-    browserReviewSummary: () => browserArtifactReviewSummary(browserProbes),
-    browserArtifacts: () => browserProbes,
+    browserReviewSummary: () => browserArtifactReviewSummary(probes),
+    browserArtifacts: () => probes,
+    additionalArtifactDiagnostics: () => missing,
     captureMountedFiles: (filesDirectory, redactor) => captureMountedFiles(filesDirectory, mounts, redactor),
     captureMountDiffs: (filesDirectory, redactor) => captureMountDiffs(artifactRoot, filesDirectory, mounts, redactor),
-    redactBrowserArtifacts: (redactor) => redactBrowserArtifacts(artifactRoot, browserProbes, redactor),
+    redactBrowserArtifacts: (redactor) => redactBrowserArtifacts(artifactRoot, probes, redactor),
     redactPluginCheckArtifacts: (redactor) => redactPluginCheckArtifacts(artifactRoot, pluginChecks, redactor),
     redactThemeCheckArtifacts: (redactor) => redactThemeCheckArtifacts(artifactRoot, themeChecks, redactor),
-    browserManifestFiles: () => browserArtifactManifestFiles(artifactRoot, browserProbes),
+    browserManifestFiles: () => browserArtifactManifestFiles(artifactRoot, probes),
     pluginCheckArtifactPaths: () => pluginChecks.map((check) => check.files.normalized),
     themeCheckArtifactPaths: () => themeChecks.map((check) => check.files.normalized),
     observationManifestFiles: () => observationManifestFiles(artifactRoot, observations),
@@ -84,6 +87,50 @@ export async function collectPlaygroundArtifacts({
     formatCommandsLog: (artifactCommands) => formatCommandsLog(artifactCommands),
     recordArtifactsCollected,
   }).build(artifactSpec)
+}
+
+async function availableBrowserArtifacts(artifactRoot: string, probes: BrowserArtifact[]): Promise<{ probes: BrowserArtifact[]; missing: unknown[] }> {
+  const available: BrowserArtifact[] = []
+  const missing: unknown[] = []
+  for (const probe of probes) {
+    const files = { ...probe.files }
+    const fileRecord = files as Record<string, unknown>
+    for (const [key, value] of Object.entries(probe.files)) {
+      const paths = Array.isArray(value) ? value : typeof value === "string" ? [value] : []
+      const existing: string[] = []
+      for (const path of paths) {
+        try {
+          await access(join(artifactRoot, path))
+          existing.push(path)
+        } catch (error) {
+          if (!isMissingFileError(error)) throw error
+          missing.push({
+            type: "artifact-missing",
+            severity: "warning",
+            code: "browser-capture-not-materialized",
+            message: `Optional browser capture was not materialized: ${path}`,
+            source: "browser-artifact-collection",
+            path,
+            details: { browserArtifactType: probe.artifactType, field: key },
+          })
+        }
+      }
+      if (Array.isArray(value)) {
+        if (existing.length > 0) fileRecord[key] = existing
+        else delete fileRecord[key]
+      } else if (existing.length > 0) {
+        fileRecord[key] = existing[0]
+      } else {
+        delete fileRecord[key]
+      }
+    }
+    available.push({ ...probe, files, summary: { ...probe.summary, screenshot: Boolean(files.screenshot) } } as BrowserArtifact)
+  }
+  return { probes: available, missing }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && (error as { code?: unknown }).code === "ENOENT")
 }
 
 export function formatRuntimeLog(events: LifecycleEvent[]): string {

--- a/tests/runtime-command-artifact-bounds.test.ts
+++ b/tests/runtime-command-artifact-bounds.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { Buffer } from "node:buffer"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -209,6 +209,37 @@ try {
   assert(Buffer.byteLength(await readFile(join(artifactRoot, "logs", "commands.log"), "utf8")) <= COMMAND_ARTIFACT_STRING_MAX_BYTES + 1024)
 } finally {
   await rm(artifactRoot, { recursive: true, force: true })
+}
+
+const partialBrowserArtifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-partial-browser-artifact-"))
+try {
+  await mkdir(join(partialBrowserArtifactRoot, "files/browser"), { recursive: true })
+  await writeFile(join(partialBrowserArtifactRoot, "files/browser/summary.json"), "{}\n")
+  const partialBrowserBundle = await collectPlaygroundArtifacts({
+    artifactRoot: partialBrowserArtifactRoot,
+    browserProbes: [{
+      artifactType: "actions",
+      requestedUrl: "http://127.0.0.1:9400/",
+      url: "http://127.0.0.1:9400/",
+      preview: { requestedMode: "local", mode: "local", requestedOrigin: "http://127.0.0.1:9400", localOrigin: "http://127.0.0.1:9400", effectiveOrigin: "http://127.0.0.1:9400", secureContext: false, capabilities: [], fallbacks: [] },
+      files: { summary: "files/browser/summary.json", screenshot: "files/browser/screenshot.png" },
+      summary: { actions: 1, steps: 1, consoleMessages: 0, errors: 1, networkEvents: 0, screenshot: true, finalUrl: "http://127.0.0.1:9400/", viewport: null, replayability: "partial" },
+    }],
+    commands: [], createdAt: "2026-07-21T19:59:00.000Z", events: [],
+    info: async () => ({ id: "partial-browser", backend: "playground", status: "ready", environment: { version: "latest" } }),
+    mounts: [], observations: [{ type: "adversarial-finding", data: { diagnostics: [{ severity: "error", message: "navigation blocked" }] } }], pluginChecks: [],
+    previewInfo: async () => undefined, recordArtifactsCollected: () => {}, runtimeId: "partial-browser", snapshots: [], spec: { environment: { blueprint: {} } }, themeChecks: [],
+  })
+  const diagnostics = JSON.parse(await readFile(join(partialBrowserArtifactRoot, "files/diagnostics.json"), "utf8"))
+  assert.equal(diagnostics.diagnostics.some((diagnostic: { message?: string }) => diagnostic.message === "navigation blocked"), true)
+  assert.equal(diagnostics.diagnostics.some((diagnostic: { code?: string }) => diagnostic.code === "browser-capture-not-materialized"), true)
+  const review = JSON.parse(await readFile(partialBrowserBundle.reviewPath, "utf8"))
+  assert.equal(review.browser.probes[0].screenshot, undefined)
+  const manifest = JSON.parse(await readFile(partialBrowserBundle.manifestPath, "utf8"))
+  assert.equal(manifest.files.some((file: { path?: string }) => file.path === "files/browser/screenshot.png"), false)
+  assert.equal(manifest.files.some((file: { path?: string }) => file.path === "files/browser/summary.json"), true)
+} finally {
+  await rm(partialBrowserArtifactRoot, { recursive: true, force: true })
 }
 
 const collectionCause = Object.assign(new RangeError("Invalid string length"), {


### PR DESCRIPTION
## Summary
- validate browser artifact references before redaction, review generation, and manifest collection
- omit captures that were requested but never materialized instead of throwing raw `ENOENT`
- retain original campaign/runtime diagnostics and add a bounded `browser-capture-not-materialized` warning
- verify partial browser results never claim or synthesize a missing screenshot

## Verification
- `npm run build`
- `npm run test:runtime-command-artifact-bounds`
- `npm run test:browser-artifact-session`
- `npm run test:recipe-declared-artifacts`

Fixes #2282

## AI Assistance
AI-assisted investigation, implementation, regression-test correction, and verification using OpenAI GPT-5.6 Sol through Homeboy/OpenCode. The final diff and focused gate results were reviewed before publication.