### PR TITLE
fix: normalize empty sandbox tool policies

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { normalizeSandboxToolPolicySnapshot, type SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
+import { normalizeSandboxToolPolicySnapshot, sandboxToolPolicyFromAllowedTools, type SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
 import type { TaskInput } from "./task-input.js"
 import { isPlainObject, stringList, stripUndefined } from "./object-utils.js"
@@ -814,12 +814,7 @@ function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: TaskInput): Sand
   if (Object.keys(policy).length > 0) {
     return normalizeSandboxToolPolicySnapshot(policy)
   }
-  return normalizeSandboxToolPolicySnapshot({
-    schema: "wp-codebox/sandbox-tool-policy/v1",
-    version: 1,
-    tools: [{ id: "deny-all", runtime_tool_id: "deny-all", execution_location: "parent", transport_visibility: "hidden", allowed: false, runtime: { environment: "control_plane", capability_scope: "control_plane" } }],
-    metadata: { source: "contained-runtime.agent-task-run.default-deny" },
-  })
+  return sandboxToolPolicyFromAllowedTools([], { source: "contained-runtime.agent-task-run.default-deny" })
 }
 
 function slugFromPath(source: string): string {

--- a/packages/runtime-core/src/sandbox-tool-policy.ts
+++ b/packages/runtime-core/src/sandbox-tool-policy.ts
@@ -140,8 +140,8 @@ export function validateSandboxToolPolicySnapshot(input: unknown): SandboxToolPo
   if (input.version !== SANDBOX_TOOL_POLICY_VERSION) {
     issues.push({ code: "invalid-policy", field: "version", message: `sandbox_tool_policy.version must be ${SANDBOX_TOOL_POLICY_VERSION}.` })
   }
-  if (!Array.isArray(input.tools) || input.tools.length === 0) {
-    issues.push({ code: "invalid-policy", field: "tools", message: "sandbox_tool_policy.tools must be a non-empty array." })
+  if (!Array.isArray(input.tools)) {
+    issues.push({ code: "invalid-policy", field: "tools", message: "sandbox_tool_policy.tools must be an array." })
   }
 
   const seen = new Set<string>()

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
@@ -40,16 +40,15 @@ final class WP_Codebox_Agent_Task {
 			}
 		}
 
-		if ( ! empty( $task_input['allowed_tools'] ) ) {
-			$normalizer = new WP_Codebox_Sandbox_Tool_Policy_Normalizer();
-			$policy     = $normalizer->normalize_for_task_input( $task_input );
-			if ( is_wp_error( $policy ) ) {
-				return $policy;
-			}
-			$task_input['sandbox_tool_policy'] = $policy;
-			if ( empty( $task_input['tool_bridge'] ) ) {
-				$task_input['tool_bridge'] = $normalizer->tool_bridge_from_policy( $task_input['allowed_tools'], $policy, $task_input );
-			}
+		$normalizer = new WP_Codebox_Sandbox_Tool_Policy_Normalizer();
+		$policy     = $normalizer->normalize_for_task_input( $task_input );
+		if ( is_wp_error( $policy ) ) {
+			return $policy;
+		}
+		$task_input['sandbox_tool_policy'] = $policy;
+
+		if ( ! empty( $task_input['allowed_tools'] ) && empty( $task_input['tool_bridge'] ) ) {
+			$task_input['tool_bridge'] = $normalizer->tool_bridge_from_policy( $task_input['allowed_tools'], $policy, $task_input );
 		}
 
 		return $task_input;

--- a/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
@@ -187,10 +187,6 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 			}
 		}
 
-		if ( empty( $policy_tools ) ) {
-			return array();
-		}
-
 		$policy = array(
 			'schema'  => self::SCHEMA,
 			'version' => self::VERSION,
@@ -229,8 +225,8 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 		if ( self::VERSION !== (int) ( $policy['version'] ?? 0 ) ) {
 			$issues[] = array( 'field' => 'version', 'message' => 'sandbox_tool_policy.version must be ' . self::VERSION . '.' );
 		}
-		if ( empty( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
-			$issues[] = array( 'field' => 'tools', 'message' => 'sandbox_tool_policy.tools must be a non-empty array.' );
+		if ( ! isset( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
+			$issues[] = array( 'field' => 'tools', 'message' => 'sandbox_tool_policy.tools must be an array.' );
 			return $issues;
 		}
 

--- a/scripts/php-tool-policy-normalization-smoke.php
+++ b/scripts/php-tool-policy-normalization-smoke.php
@@ -49,6 +49,21 @@ function assert_not_error( mixed $actual, string $label ): void {
 	}
 }
 
+$goal_only_task_input = WP_Codebox_Agent_Task::normalize_input( array( 'goal' => 'Review the site' ) );
+assert_not_error( $goal_only_task_input, 'goal-only task normalizes' );
+assert_same( 'wp-codebox/sandbox-tool-policy/v1', $goal_only_task_input['sandbox_tool_policy']['schema'], 'goal-only policy schema' );
+assert_same( array(), $goal_only_task_input['sandbox_tool_policy']['tools'], 'goal-only policy denies all tools' );
+assert_same( '{"schema":"wp-codebox/sandbox-tool-policy/v1","version":1,"tools":[]}', json_encode( $goal_only_task_input['sandbox_tool_policy'], JSON_UNESCAPED_SLASHES ), 'goal-only policy serializes as an object' );
+
+$malformed_policy = WP_Codebox_Agent_Task::normalize_input(
+	array(
+		'goal'                => 'Review the site',
+		'sandbox_tool_policy' => array( 'schema' => 'wp-codebox/sandbox-tool-policy/v1', 'version' => 1, 'tools' => 'none' ),
+	)
+);
+assert_same( true, is_wp_error( $malformed_policy ), 'malformed no-tools policy is rejected' );
+assert_same( 'wp_codebox_sandbox_tool_policy_invalid', $malformed_policy->get_error_code(), 'malformed no-tools policy error code' );
+
 $task_input = WP_Codebox_Agent_Task::normalize_input(
 	array(
 		'goal'          => 'Create a page',

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -607,6 +607,8 @@ try {
   assert.equal(genericRecipe.inputs?.runtimeEnv?.PROFILE_ENV, "1")
   assert.equal(genericRecipe.runtime?.overlays?.some((overlay) => overlay.slug === "profile-overlay"), true)
   const genericSandboxStepArgs = genericRecipe.workflow.steps.find((step) => step.command === "wp-codebox.agent-sandbox-run")?.args ?? []
+  const genericSandboxPolicyArg = genericSandboxStepArgs.find((arg) => arg.startsWith("sandbox-tool-policy-json=")) ?? "sandbox-tool-policy-json={}"
+  assert.deepEqual(JSON.parse(genericSandboxPolicyArg.slice("sandbox-tool-policy-json=".length)).tools, [])
   const genericRuntimeComponentsArg = genericSandboxStepArgs.find((arg) => arg.startsWith("runtime-component-contracts-json=")) ?? "runtime-component-contracts-json=[]"
   const genericRuntimeComponents = JSON.parse(genericRuntimeComponentsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "wordpress-plugin"), true)

--- a/tests/host-recipe-builder.test.ts
+++ b/tests/host-recipe-builder.test.ts
@@ -78,7 +78,7 @@ $result = $builder->build(
 		'secret_env_names' => static function () use ( &$legacy_adapter_calls ): array { $legacy_adapter_calls[] = 'secret_env_names'; return array(); },
 		'component_plugins' => static fn( array $paths ): array => array( array( 'source' => '/components/demo-plugin', 'slug' => 'demo-plugin', 'activate' => true, 'loadAs' => 'plugin' ) ),
 		'runtime_task' => static fn( array $input ): array => array(),
-		'task_input' => static fn( array $input ): array => array( 'goal' => $input['goal'], 'sandbox_tool_policy' => array( 'commands' => array() ) ),
+		'task_input' => static fn( array $input ): array => array( 'goal' => $input['goal'], 'sandbox_tool_policy' => array( 'schema' => 'wp-codebox/sandbox-tool-policy/v1', 'version' => 1, 'tools' => array() ) ),
 		'json_encode' => static fn( mixed $value ): string => json_encode( $value, JSON_UNESCAPED_SLASHES ),
 		'task_timeout_seconds' => static fn( array $input ): int => 0,
 		'recipe_mounts' => static fn( array $input ): array => array(),
@@ -108,7 +108,7 @@ $preset_result = $builder->build(
 		'secret_env_names' => static fn(): array => array(),
 		'component_plugins' => static fn(): array => array(),
 		'runtime_task' => static fn(): array => array(),
-		'task_input' => static fn( array $input ): array => array( 'goal' => $input['goal'], 'sandbox_tool_policy' => array( 'commands' => array() ) ),
+		'task_input' => static fn( array $input ): array => array( 'goal' => $input['goal'], 'sandbox_tool_policy' => array( 'schema' => 'wp-codebox/sandbox-tool-policy/v1', 'version' => 1, 'tools' => array() ) ),
 		'json_encode' => static fn( mixed $value ): string => json_encode( $value, JSON_UNESCAPED_SLASHES ),
 		'task_timeout_seconds' => static fn( array $input ): int => 0,
 		'recipe_mounts' => static fn(): array => array(),
@@ -167,6 +167,12 @@ assert.ok(result.recipe.workflow.steps[0].args.includes("mode=planned-mode"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("provider=planned-provider"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("model=planned-model"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("provider-plugin-slugs=planned-provider"))
+const sandboxToolPolicyArg = result.recipe.workflow.steps[0].args.find((arg) => arg.startsWith("sandbox-tool-policy-json=")) ?? ""
+assert.deepEqual(JSON.parse(sandboxToolPolicyArg.slice("sandbox-tool-policy-json=".length)), {
+  schema: "wp-codebox/sandbox-tool-policy/v1",
+  version: 1,
+  tools: [],
+})
 const runtimeComponentContractsArg = result.recipe.workflow.steps[0].args.find((arg) => arg.startsWith("runtime-component-contracts-json=")) ?? "runtime-component-contracts-json=[]"
 const runtimeComponentContracts = JSON.parse(runtimeComponentContractsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
 assert.deepEqual(runtimeComponentContracts.map((component) => component.slug), ["demo-plugin"])

--- a/tests/runtime-tool-policy.test.ts
+++ b/tests/runtime-tool-policy.test.ts
@@ -67,6 +67,14 @@ const invalidLocationPolicy = structuredClone(policy)
 invalidLocationPolicy.tools[0].execution_location = "external"
 assert.throws(() => assertSandboxToolPolicySnapshot(invalidLocationPolicy), /must be sandbox or parent/)
 
+const noToolsPolicy = sandboxToolPolicyFromAllowedTools([])
+assert.doesNotThrow(() => assertSandboxToolPolicySnapshot(noToolsPolicy))
+assert.deepEqual(sandboxAllowedRuntimeToolIds(noToolsPolicy), [])
+assert.throws(
+  () => assertSandboxToolPolicySnapshot({ schema: "wp-codebox/sandbox-tool-policy/v1", version: 1, tools: "none" }),
+  /tools must be an array/,
+)
+
 const canonicalPolicy = sandboxToolPolicyFromAllowedTools(["workspace.read", "workspace.search", "workspace.write", "workspace.edit"], { source: "test" })
 assert.equal(canonicalPolicy.schema, "wp-codebox/sandbox-tool-policy/v1")
 assert.deepEqual(canonicalPolicy.tools.map((tool) => tool.id), ["workspace.read", "workspace.search", "workspace.write", "workspace.edit"])


### PR DESCRIPTION
## Summary

- normalize goal-only PHP task inputs to a canonical versioned no-tools policy object instead of a PHP empty array
- accept `tools: []` as the explicit deny-all boundary in PHP and Node while preserving validation for malformed policy shapes and tool entries
- use the same empty policy representation in reusable Node recipe construction instead of a synthetic `deny-all` tool

## Root Cause

PHP task normalization only resolved a sandbox tool policy when `allowed_tools` was non-empty. Goal-only requests therefore retained `sandbox_tool_policy` as `array()`, which `wp_json_encode()` serialized as JSON `[]`. The host recipe builder forwarded that value as `sandbox-tool-policy-json=[]`, but the canonical Node validator correctly required the top-level policy to be an object.

## Canonical Empty Policy

The canonical no-tools representation is a versioned policy object with `tools: []`:

```json
{"schema":"wp-codebox/sandbox-tool-policy/v1","version":1,"tools":[]}
```

An empty allowlist is an explicit deny-all boundary, so an empty `tools` array is valid and does not require inventing a fake tool. The existing Node `sandboxToolPolicyFromAllowedTools([])` factory already produced this shape; this change makes PHP normalization and both validators agree with it.

## Contract Effects

- PHP now resolves and validates a policy for every task input, including goal-only tasks, and serializes the no-tools policy as a JSON object.
- Node and PHP validators accept an empty `tools` array but continue rejecting missing/non-array `tools`, malformed non-empty tool entries, invalid schemas, and invalid versions.
- Existing non-empty allowlist and tool-bridge behavior is unchanged.
- Reusable Node recipes now use the canonical empty policy factory instead of a synthetic hidden `deny-all` descriptor.

## Tests

Added coverage for:

- goal-only PHP task normalization
- JSON object serialization of the empty policy
- host recipe argument construction with `tools: []`
- reusable Node recipe construction with `tools: []`
- Node and PHP rejection of genuinely malformed policy shapes
- preservation of existing non-empty allowlist behavior

Commands run:

- `npm run build` passed
- `npm run test:php-tool-policy-normalization` passed
- `npx tsx tests/runtime-tool-policy.test.ts` passed
- `npm run test:host-recipe-builder` passed
- `npm run test:agent-task-contracts` passed
- `npx tsx tests/schema-parity.test.ts` passed
- `npm run check` reached an unrelated existing main-branch failure: `wordpress.collect-workload-result outputShape should mention outputSchema id`, tracked in #1745; the failing files are unchanged from `origin/main`

Fixes #2288