### PR TITLE
fix: propagate failed fanout worker results

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php
@@ -76,16 +76,30 @@ final class WP_Codebox_Agent_Run_Result_Builder {
 
 	/** @param array<string,mixed> $worker Worker metadata. @param array<string,mixed> $result Worker result. @return array<string,mixed> */
 	public function fanout_worker_success_result( array $worker, array $result, float $started_at, float $ended_at ): array {
-		$session   = is_array( $result['session'] ?? null ) ? $result['session'] : array();
-		$artifacts = is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array();
+		$session         = is_array( $result['session'] ?? null ) ? $result['session'] : array();
+		$artifacts       = is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array();
+		$exit_code       = (int) ( $result['exit_code'] ?? 0 );
+		$result_status   = (string) ( $result['status'] ?? '' );
+		$session_status  = (string) ( $session['status'] ?? '' );
+		$failed_statuses = array( 'failed', 'skipped', 'cancelled', 'timed_out', 'timeout', 'provider_error', 'unable_to_remediate' );
+		$success         = ( ! array_key_exists( 'success', $result ) || true === $result['success'] )
+			&& 0 === $exit_code
+			&& ! in_array( $result_status, $failed_statuses, true )
+			&& ! in_array( $session_status, $failed_statuses, true );
+		$status = 'completed';
+		if ( ! $success ) {
+			$status = in_array( $result_status, array( 'skipped', 'cancelled', 'timed_out', 'timeout' ), true )
+				? $result_status
+				: ( in_array( $session_status, array( 'skipped', 'cancelled', 'timed_out', 'timeout' ), true ) ? $session_status : 'failed' );
+		}
 
-		return array(
+		$worker_result = array(
 			'worker_id'          => (string) $worker['id'],
 			'index'              => (int) $worker['index'],
-			'success'            => true,
-			'status'             => 'completed',
+			'success'            => $success,
+			'status'             => $status,
 			'agent'              => (string) ( $worker['prepared']['input']['agent'] ?? '' ),
-			'exit_code'          => (int) ( $result['exit_code'] ?? 0 ),
+			'exit_code'          => $exit_code,
 			'session'            => $session,
 			'artifacts'          => array_merge( $artifacts, array( 'namespace' => (string) $worker['id'], 'result' => 'result.json' ) ),
 			'diagnostics'        => is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array(),
@@ -93,6 +107,11 @@ final class WP_Codebox_Agent_Run_Result_Builder {
 			'completion_outcome' => is_array( $result['completion_outcome'] ?? null ) ? $result['completion_outcome'] : array(),
 			'timings'            => $this->timings( $started_at, $ended_at ),
 		);
+		if ( is_array( $result['error'] ?? null ) ) {
+			$worker_result['error'] = $result['error'];
+		}
+
+		return $worker_result;
 	}
 
 	/** @param array<string,mixed> $worker Worker metadata. @return array<string,mixed> */

--- a/scripts/php-run-plan-contract-smoke.php
+++ b/scripts/php-run-plan-contract-smoke.php
@@ -40,6 +40,8 @@ function is_wp_error( mixed $value ): bool {
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-run-plan.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-status-taxonomy.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php';
 
 function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
@@ -101,6 +103,75 @@ $worker_result = $builder->fanout_worker_success_result(
 assert_same_contract( 'completed', $worker_result['status'], 'fanout worker success status' );
 assert_same_contract( array( 'path' => '/tmp/artifacts', 'bundle_id' => 'bundle-1', 'namespace' => 'design', 'result' => 'result.json' ), $worker_result['artifacts'], 'fanout artifact result shaping' );
 
+$failed_worker_result = $builder->fanout_worker_success_result(
+    array(
+        'id'       => 'failed-worker',
+        'index'    => 0,
+        'prepared' => array( 'input' => array( 'agent' => '' ) ),
+    ),
+    array(
+        'success'   => false,
+        'status'    => 'failed',
+        'exit_code' => 127,
+        'session'   => array( 'id' => 'child-failed', 'status' => 'failed' ),
+        'error'     => array( 'code' => 'wp_codebox_run_failed', 'message' => 'Worker process failed.' ),
+    ),
+    1000.0,
+    1001.25
+);
+assert_same_contract( false, $failed_worker_result['success'], 'nonzero fanout worker success' );
+assert_same_contract( 'failed', $failed_worker_result['status'], 'nonzero fanout worker status' );
+assert_same_contract( 127, $failed_worker_result['exit_code'], 'nonzero fanout worker exit code' );
+assert_same_contract( 'wp_codebox_run_failed', $failed_worker_result['error']['code'], 'nonzero fanout worker error' );
+
+$nested_failed_worker_result = $builder->fanout_worker_success_result(
+    array(
+        'id'       => 'nested-failed-worker',
+        'index'    => 1,
+        'prepared' => array( 'input' => array( 'agent' => 'planner' ) ),
+    ),
+    array(
+        'success'   => true,
+        'status'    => 'completed',
+        'exit_code' => 0,
+        'session'   => array( 'id' => 'child-nested-failed', 'status' => 'failed' ),
+    ),
+    1000.0,
+    1001.25
+);
+assert_same_contract( false, $nested_failed_worker_result['success'], 'nested failed fanout worker success' );
+assert_same_contract( 'failed', $nested_failed_worker_result['status'], 'nested failed fanout worker status' );
+
+$failed_counts = $builder->status_counts( array( $failed_worker_result, $nested_failed_worker_result ) );
+assert_same_contract( array( 'total' => 2, 'completed' => 0, 'failed' => 2, 'skipped' => 0, 'cancelled' => 0, 'timed_out' => 0 ), $failed_counts, 'failed fanout counts' );
+
+$aggregation = new WP_Codebox_Fanout_Aggregation();
+$failed_aggregate = $aggregation->aggregate(
+    $aggregation->input_from_worker_artifacts(
+        array(
+            'plan' => array(
+                'id'      => 'failed-fanout',
+                'workers' => array(
+                    array( 'id' => 'failed-worker', 'required' => true ),
+                    array( 'id' => 'nested-failed-worker', 'required' => true ),
+                ),
+            ),
+            'workerResultRefs' => array_map(
+                static fn( array $run ): array => array(
+                    'workerId' => $run['worker_id'],
+                    'status'   => $run['status'],
+                    'success'  => $run['success'],
+                    'required' => true,
+                    'error'    => $run['error'] ?? null,
+                ),
+                array( $failed_worker_result, $nested_failed_worker_result )
+            ),
+        )
+    )
+);
+assert_same_contract( 'failed', $failed_aggregate['status'], 'failed fanout aggregate status' );
+assert_same_contract( array( 'failed', 'failed' ), array_column( $failed_aggregate['workerResultRefs'], 'status' ), 'failed aggregate worker ref statuses' );
+
 $paths = $run_plan->paths( '/tmp/root', 'fanout' );
 $fanout_result = $builder->fanout_result(
     'wp-codebox/agent-fanout-result/v1',
@@ -119,6 +190,24 @@ $fanout_result = $builder->fanout_result(
 assert_same_contract( true, $fanout_result['success'], 'fanout result success' );
 assert_same_contract( 'wp-codebox/agent-fanout-artifacts/v1', $fanout_result['artifacts']['schema'], 'fanout artifacts schema' );
 assert_same_contract( 'child-1', $fanout_result['session']['children'][0]['session_id'], 'fanout child session ref' );
+
+$failed_fanout_result = $builder->fanout_result(
+    'wp-codebox/agent-fanout-result/v1',
+    'wp-codebox/agent-fanout-artifacts/v1',
+    'bounded-concurrent-isolated-sandboxes',
+    'parent-failed',
+    'failed',
+    array( 'session_id' => 'agent-session-failed' ),
+    $paths,
+    $failed_counts,
+    1000.0,
+    1001.25,
+    $run_plan->plan( 'wp-codebox/agent-fanout-plan/v1', 'parent-failed', 2, array(), $descriptors ),
+    array( $failed_worker_result, $nested_failed_worker_result )
+);
+assert_same_contract( false, $failed_fanout_result['success'], 'failed fanout result success' );
+assert_same_contract( 2, $failed_fanout_result['failed'], 'failed fanout result failed count' );
+assert_same_contract( 2, count( $failed_fanout_result['failures'] ), 'failed fanout failures' );
 
 $batch_result = $builder->batch_result(
     'wp-codebox/agent-task-batch/v1',


### PR DESCRIPTION
## Summary

- Preserve normalized worker failure signals instead of rewriting every structured fanout result as successful.
- Propagate nonzero exits and nested failed sessions through worker status, counters, failure records, aggregate worker refs, aggregate status, and top-level success.
- Preserve successful workers and terminal skipped, cancelled, and timeout statuses.

## Root cause

`WP_Codebox_Host_Run_Result_Normalizer` correctly returns structured failure envelopes for nonzero exits and failed sessions. `WP_Codebox_Agent_Sandbox_Runner` passed every non-`WP_Error` envelope to `fanout_worker_success_result()`, which then unconditionally emitted `success: true` and `status: completed`. All downstream fanout fields therefore derived from a falsely successful worker.

## Contract corrections

- `runs[*].success` now reflects the normalized result, exit code, and nested session status.
- `runs[*].status` is `failed` for failed execution while preserving skipped, cancelled, and timeout terminal statuses.
- `runs[*].error` retains the normalized worker error payload.
- `completed`, `failed`, and `failures` now derive from truthful worker results.
- `aggregate.workerResultRefs[*].status`, aggregate `status`, and top-level `success` now propagate required-worker failures.

## Tests

Added focused PHP contract coverage proving:

- exit code 127 cannot be reported as a successful/completed worker;
- a nested failed session cannot be reported as a successful/completed worker;
- failure counters and `failures` include both workers;
- aggregate worker refs are failed and aggregate status is failed;
- the existing successful worker contract remains successful.

Commands run:

- `npm run test:php-run-plan-contract` (pass)
- `npm run test:php-fanout-aggregation-contract` (pass)
- `npm run test:php-host-run-result-normalizer` (pass)
- `npm run test:fanout-execution` (pass)
- `npm run test:agent-fanout-executor` (pass)
- `npm run test:fanout-aggregation-contract-parity` (pass)
- `npm run build` (pass)
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php` (pass)
- `php -l scripts/php-run-plan-contract-smoke.php` (pass)
- `git diff --check` (pass)
- `npm run check` (blocked by the pre-existing unrelated `command-registry-smoke` assertion: `wordpress.collect-workload-result outputShape should mention outputSchema id`)
- `npm run smoke -- --command=command-registry-smoke` (same isolated unrelated failure)

## Out of scope

No new preflight rejection was added for omitted agent selection. The existing host recipe path already resolves an omitted agent through `wp_codebox_default_agent` and then the `sandbox-agent` fallback; changing that contract is not required to correct fanout result truthfulness.

Fixes #2287