### PR TITLE
fix: synchronize shrinkwrap package versions

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -5693,7 +5693,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -5715,14 +5715,14 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
         "ajv": "^8.20.0"
       }
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@php-wasm/node": "3.1.46",


### PR DESCRIPTION
## Summary

- synchronize root and workspace package versions in `npm-shrinkwrap.json` with the existing `0.21.0` manifests
- keep guarded release dependency hydration from dirtying the tracked lockfile

## Verification

- `npm install --package-lock-only --ignore-scripts --no-audit --no-fund`
- `git diff --check`
- Homeboy release preflight previously reproduced the tracked-file mutation and rolled back without creating a tag

Fixes #2291