### PR TITLE
fix: make native descendant teardown deterministic

### DIFF
--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -1057,11 +1057,15 @@ async function signalOwnedNativeProcess(state: OwnedNativeProcess, signal: NodeJ
 
 async function linuxProcessStartIdentity(pid: number): Promise<string> {
   const processStat = await readFile(`/proc/${pid}/stat`, "utf8")
-  const commandEnd = processStat.lastIndexOf(")")
-  const fieldsAfterCommand = commandEnd >= 0 ? processStat.slice(commandEnd + 2).trim().split(/\s+/) : []
+  const fieldsAfterCommand = linuxProcessStatFields(processStat)
   const startTime = fieldsAfterCommand[19]
   if (!startTime || !/^\d+$/.test(startTime)) throw new Error("Owned process start identity is unavailable")
   return `${pid}:${startTime}`
+}
+
+function linuxProcessStatFields(processStat: string): string[] {
+  const commandEnd = processStat.lastIndexOf(")")
+  return commandEnd >= 0 ? processStat.slice(commandEnd + 2).trim().split(/\s+/) : []
 }
 
 async function waitForOwnedProcessExit(state: OwnedNativeProcess, timeoutMs: number): Promise<boolean> {
@@ -1080,13 +1084,31 @@ async function ownedProcessGroupExists(state: OwnedNativeProcess): Promise<boole
   try { process.kill(-state.groupId, 0); return true } catch (error) { return (error as NodeJS.ErrnoException).code !== "ESRCH" }
 }
 
+async function ownedProcessGroupHasLiveMembers(state: OwnedNativeProcess): Promise<boolean> {
+  if (process.platform !== "linux" || !state.groupId) return await ownedProcessGroupExists(state)
+  if (!await ownedProcessGroupExists(state)) return false
+  // Capturing parents can retain killed descendants as zombies; they cannot execute
+  // and only the adopting parent, not this process, can reap them.
+  for (const entry of await readdir("/proc")) {
+    if (!/^\d+$/.test(entry)) continue
+    try {
+      const fields = linuxProcessStatFields(await readFile(`/proc/${entry}/stat`, "utf8"))
+      if (Number(fields[2]) === state.groupId && !["Z", "X", "x"].includes(fields[0] ?? "")) return true
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== "ENOENT" && code !== "EACCES" && code !== "EPERM") throw error
+    }
+  }
+  return false
+}
+
 async function waitForOwnedProcessGroupExit(state: OwnedNativeProcess, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    if (!await ownedProcessGroupExists(state)) return true
+    if (!await ownedProcessGroupHasLiveMembers(state)) return true
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 10))
   }
-  return !await ownedProcessGroupExists(state)
+  return !await ownedProcessGroupHasLiveMembers(state)
 }
 
 async function ownedProcessRssMiB(state: OwnedNativeProcess): Promise<number | undefined> {

--- a/tests/native-mariadb-runtime-service.test.ts
+++ b/tests/native-mariadb-runtime-service.test.ts
@@ -14,6 +14,21 @@ const service: WorkspaceRecipeRuntimeService = {
   outputs: { host: "DB_HOST", port: "DB_PORT", username: "DB_USER", password: "NATIVE_DB_PASSWORD", database: "DB_NAME" },
 }
 
+async function assertProcessTerminated(pid: number, message: string): Promise<void> {
+  if (process.platform === "linux") {
+    try {
+      const processStat = await readFile(`/proc/${pid}/stat`, "utf8")
+      const commandEnd = processStat.lastIndexOf(")")
+      const state = commandEnd >= 0 ? processStat.slice(commandEnd + 2).trim().split(/\s+/)[0] : undefined
+      assert.ok(state === "Z" || state === "X" || state === "x", message)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+    return
+  }
+  assert.throws(() => process.kill(pid, 0), (error: unknown) => (error as NodeJS.ErrnoException).code === "ESRCH", message)
+}
+
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [service] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, true)
 assert.deepEqual(runtimeServicePlan([service]), [{ id: "native-db", kind: "mysql", provider: "native", version: "mariadb:native", bind: "loopback", port: "ephemeral", persistentVolume: false, configuration: service.configuration, outputs: service.outputs }])
 assert.equal(validateWorkspaceRecipeJsonSchema({ schema: "wp-codebox/workspace-recipe/v1", inputs: { services: [{ ...service, configuration: { provider: "native", engine: "mysql" } }] }, workflow: { steps: [{ command: "wordpress.run-php" }] } }).valid, false)
@@ -152,7 +167,7 @@ fs.writeFileSync(process.env.HOME + '/initializer-child-pid', String(child.pid))
   const descendantRoot = (await readdir(tmpdir())).find((name) => name.startsWith("wp-codebox-mariadb-") && !before.has(name))
   assert.ok(descendantRoot)
   const descendantPid = Number(await readFile(join(tmpdir(), descendantRoot, "storage", "tmp", "initializer-child-pid"), "utf8"))
-  assert.throws(() => process.kill(descendantPid, 0), (error: unknown) => (error as NodeJS.ErrnoException).code === "ESRCH", "initializer descendants are gone before provisioning continues")
+  await assertProcessTerminated(descendantPid, "initializer descendants are terminated before provisioning continues")
   await descendantProvisioned.release()
   await writeFile(join(fixture, "mariadb-install-db"), initializerScript)
   await chmod(join(fixture, "mariadb-install-db"), 0o700)


### PR DESCRIPTION
## Summary

- distinguish live Linux process-group members from terminated zombies retained by an outer capture subreaper
- keep process-group signaling and bounded SIGTERM/SIGKILL escalation unchanged while allowing teardown to finish once no descendant can execute
- preserve the initializer-descendant regression proof by requiring the descendant to be absent or in a terminal zombie/dead state before provisioning continues

## Root cause

`kill(-pgid, 0)` reports that a process group exists even when its only remaining member is a killed zombie. During captured release execution, the capturing parent can adopt and retain the initializer's orphaned descendant long enough for both bounded group-exit waits to expire. WP Codebox cannot reap that non-child, but the old predicate treated the retained process-table entry as a runnable containment leak.

## Lifecycle correction

On Linux, group-exit waits now inspect `/proc/<pid>/stat` after confirming the process group still exists. Teardown remains pending for every runnable, sleeping, stopped, or otherwise live member and still escalates through SIGTERM and SIGKILL. It completes only when the group is absent or contains terminal `Z`/`X` entries that cannot execute and can only be reaped by their adopting parent.

## Verification

- `npm run build`
- `npm run test:runtime-services` (3 direct runs)
- `bash -o pipefail -c 'npm run test:runtime-services | tee /dev/null'` (2 captured, non-TTY runs)
- `npm run test:runtime-services-lifecycle`
- `npm run test:runtime-capture-status`
- `git diff --check`

Fixes #2293
