### PR TITLE
Refactor preview proxy service worker diagnostics

### DIFF
--- a/packages/runtime-playground/src/preview-proxy-request-trace.ts
+++ b/packages/runtime-playground/src/preview-proxy-request-trace.ts
@@ -1,0 +1,71 @@
+import type { IncomingMessage } from "node:http"
+import { redactString } from "@automattic/wp-codebox-core"
+
+const PREVIEW_PROXY_REQUEST_TRACE_CAPACITY = 64
+const FETCH_DESTINATIONS = new Set(["audio", "audioworklet", "document", "embed", "empty", "font", "frame", "iframe", "image", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "track", "video", "worker", "xslt"])
+
+export interface PlaygroundPreviewProxyRequestTrace {
+  scope: "service-worker"
+  capacity: 64
+  total: number
+  dropped: number
+  entries: PlaygroundPreviewProxyRequestTraceEntry[]
+}
+
+export interface PlaygroundPreviewProxyRequestTraceEntry {
+  sequence: number
+  method: string
+  path: string
+  destination: string | null
+  serviceWorker: boolean
+  outcome: "response" | "upstream-error"
+  status?: number
+  upstreamLocation?: string
+  visibleLocation?: string
+}
+
+export type PlaygroundPreviewProxyRequestOutcome = Pick<PlaygroundPreviewProxyRequestTraceEntry, "outcome" | "status" | "upstreamLocation" | "visibleLocation">
+
+export function createPreviewProxyRequestTrace(): PlaygroundPreviewProxyRequestTrace {
+  return { scope: "service-worker", capacity: PREVIEW_PROXY_REQUEST_TRACE_CAPACITY, total: 0, dropped: 0, entries: [] }
+}
+
+export function snapshotPreviewProxyRequestTrace(trace: PlaygroundPreviewProxyRequestTrace): PlaygroundPreviewProxyRequestTrace {
+  return { ...trace, entries: trace.entries.map((entry) => ({ ...entry })) }
+}
+
+export function recordPreviewProxyRequest(trace: PlaygroundPreviewProxyRequestTrace, incoming: IncomingMessage, path: string, outcome: PlaygroundPreviewProxyRequestOutcome): void {
+  const serviceWorker = incoming.headers["service-worker"] === "script"
+  if (!serviceWorker) {
+    return
+  }
+
+  trace.total += 1
+  trace.entries.push({
+    sequence: trace.total,
+    method: incoming.method ?? "GET",
+    path: redactPreviewProxyUrl(path),
+    destination: previewProxyFetchDestination(incoming.headers["sec-fetch-dest"]),
+    serviceWorker,
+    ...outcome,
+    ...(outcome.upstreamLocation ? { upstreamLocation: redactPreviewProxyUrl(outcome.upstreamLocation) } : {}),
+    ...(outcome.visibleLocation ? { visibleLocation: redactPreviewProxyUrl(outcome.visibleLocation) } : {}),
+  })
+  if (trace.entries.length > trace.capacity) {
+    trace.entries.shift()
+    trace.dropped += 1
+  }
+}
+
+function redactPreviewProxyUrl(value: string): string {
+  return redactString(value, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function previewProxyFetchDestination(value: string | string[] | undefined): string | null {
+  const destination = headerValue(value)?.trim().toLowerCase() ?? ""
+  return FETCH_DESTINATIONS.has(destination) ? destination : null
+}

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -2,6 +2,7 @@ import { createServer as createHttpServer, request as httpRequest, type Incoming
 import { createServer as createNetServer } from "node:net"
 import { Transform } from "node:stream"
 import type { PreviewLease } from "@automattic/wp-codebox-core"
+import { createPreviewProxyRequestTrace, recordPreviewProxyRequest, snapshotPreviewProxyRequestTrace, type PlaygroundPreviewProxyRequestOutcome, type PlaygroundPreviewProxyRequestTrace } from "./preview-proxy-request-trace.js"
 
 export interface PlaygroundServerRunResponse {
   exitCode?: number
@@ -34,6 +35,7 @@ export interface PlaygroundPreviewProxyDiagnostics {
   queue: "fifo"
   bind: string
   targetOrigin: string
+  requestTrace: PlaygroundPreviewProxyRequestTrace
 }
 
 export interface PlaygroundPreviewRouteRegistry {
@@ -45,7 +47,7 @@ export type PlaygroundPreviewRouteHandler = (incoming: IncomingMessage, outgoing
 interface PlaygroundPreviewProxy {
   serverUrl: string
   previewRoutes: PlaygroundPreviewRouteRegistry
-  diagnostics: PlaygroundPreviewProxyDiagnostics
+  diagnostics(): PlaygroundPreviewProxyDiagnostics
   dispose(): Promise<void>
 }
 
@@ -74,7 +76,9 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
     serverUrl: proxy.serverUrl,
     wordpressUrl: server.wordpressUrl ?? server.serverUrl,
     previewRoutes: proxy.previewRoutes,
-    previewProxyDiagnostics: proxy.diagnostics,
+    get previewProxyDiagnostics() {
+      return proxy?.diagnostics()
+    },
     async [Symbol.asyncDispose]() {
       await proxy.dispose()
       await server[Symbol.asyncDispose]()
@@ -85,13 +89,14 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
 async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
   const target = new URL(targetUrl)
   const routes = createPreviewRouteRegistry()
-  const proxy = previewProxyServer(target, routes)
+  const requestTrace = createPreviewProxyRequestTrace()
+  const proxy = previewProxyServer(target, routes, requestTrace)
   const servers = [proxy]
 
   await listenPreviewProxy(proxy, port, bind)
 
   if (bind === "127.0.0.1") {
-    const ipv6Proxy = previewProxyServer(target, routes)
+    const ipv6Proxy = previewProxyServer(target, routes, requestTrace)
     try {
       await listenPreviewProxy(ipv6Proxy, port, "::1")
       servers.push(ipv6Proxy)
@@ -110,13 +115,16 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   return {
     serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
     previewRoutes: routes,
-    diagnostics: {
-      schema: "wp-codebox/preview-proxy-diagnostics/v1",
-      upstreamConcurrency: "serialized",
-      maxConcurrentUpstreamRequests: 1,
-      queue: "fifo",
-      bind,
-      targetOrigin: target.origin,
+    diagnostics() {
+      return {
+        schema: "wp-codebox/preview-proxy-diagnostics/v1",
+        upstreamConcurrency: "serialized",
+        maxConcurrentUpstreamRequests: 1,
+        queue: "fifo",
+        bind,
+        targetOrigin: target.origin,
+        requestTrace: snapshotPreviewProxyRequestTrace(requestTrace),
+      }
     },
     async dispose() {
       await closePreviewProxyServers(servers)
@@ -124,7 +132,7 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   }
 }
 
-function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry): PreviewProxyServer {
+function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry, requestTrace: PlaygroundPreviewProxyRequestTrace): PreviewProxyServer {
   const upstreamQueue = createPreviewProxyQueue()
 
   return createHttpServer(async (incoming, outgoing) => {
@@ -138,7 +146,7 @@ function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry): 
     }
 
     upstreamQueue(
-      () => proxyPreviewRequest(target, incoming, outgoing),
+      () => proxyPreviewRequest(target, incoming, outgoing, requestTrace),
       () => incoming.aborted || incoming.destroyed || outgoing.destroyed,
       (cancel) => {
         incoming.once("aborted", cancel)
@@ -174,10 +182,11 @@ function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
   }
 }
 
-function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
+function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse, requestTrace: PlaygroundPreviewProxyRequestTrace): Promise<void> {
   return new Promise((resolve) => {
     const requestTarget = previewProxyRequestTarget(incoming, target)
     let settled = false
+    let clientCanceled = false
     let targetResponse: IncomingMessage | undefined
     const settle = () => {
       if (settled) {
@@ -187,6 +196,7 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
       resolve()
     }
     const abortUpstream = () => {
+      clientCanceled = true
       targetRequest.destroy()
       targetResponse?.destroy()
       settle()
@@ -204,6 +214,19 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
       (response) => {
         targetResponse = response
         const headers = proxyResponseHeaders(response.headers, requestTarget, target)
+        const responseOutcome: PlaygroundPreviewProxyRequestOutcome = {
+          outcome: "response",
+          status: response.statusCode ?? 502,
+          upstreamLocation: headerValue(response.headers.location),
+          visibleLocation: headerValue(headers.location),
+        }
+        let outcomeRecorded = false
+        const recordOutcome = (outcome: PlaygroundPreviewProxyRequestOutcome) => {
+          if (!outcomeRecorded) {
+            outcomeRecorded = true
+            recordPreviewProxyRequest(requestTrace, incoming, requestTarget.path, outcome)
+          }
+        }
         const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target)
         if (bodyTransform) {
           delete headers["content-length"]
@@ -212,11 +235,20 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
         }
         outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, headers)
         response.on("error", (error) => {
+          recordOutcome({ ...responseOutcome, outcome: "upstream-error" })
           outgoing.destroy(error)
           settle()
         })
-        response.on("end", settle)
-        response.on("close", settle)
+        response.on("end", () => {
+          recordOutcome(responseOutcome)
+          settle()
+        })
+        response.on("close", () => {
+          if (!response.complete && !clientCanceled) {
+            recordOutcome({ ...responseOutcome, outcome: "upstream-error" })
+          }
+          settle()
+        })
         outgoing.on("finish", settle)
         outgoing.on("close", settle)
         if (bodyTransform) {
@@ -229,6 +261,9 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
     )
 
     targetRequest.on("error", (error) => {
+      if (!clientCanceled) {
+        recordPreviewProxyRequest(requestTrace, incoming, requestTarget.path, { outcome: "upstream-error" })
+      }
       writeProxyError(outgoing, error)
       settle()
     })

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -189,11 +189,22 @@ assert.match(browserPreviewReadinessError(unsupportedCanonicalTopology.preview)?
 
 let activeUpstreamRequests = 0
 let maxActiveUpstreamRequests = 0
-const targetServer = createServer(async (_request, response) => {
+const targetServer = createServer(async (request, response) => {
   activeUpstreamRequests += 1
   maxActiveUpstreamRequests = Math.max(maxActiveUpstreamRequests, activeUpstreamRequests)
   await new Promise((resolveDelay) => setTimeout(resolveDelay, 25))
   activeUpstreamRequests -= 1
+  if (request.url?.startsWith("/service-worker-redirect")) {
+    response.writeHead(302, { location: `${targetServerUrl}/login?token=PRIVATE_REDIRECT_TOKEN` })
+    response.end()
+    return
+  }
+  if (request.url === "/truncated-service-worker") {
+    response.writeHead(302, { location: `${targetServerUrl}/login?token=PRIVATE_TRUNCATED_TOKEN` })
+    response.flushHeaders()
+    response.socket?.destroy()
+    return
+  }
   response.end("ok")
 })
 const targetServerUrl = await listenLocalHttpServer(targetServer)
@@ -208,16 +219,61 @@ const proxied = await withPreviewProxy({
 try {
   assert.equal(proxied.wordpressUrl, targetServerUrl)
   assert.notEqual(proxied.serverUrl, proxied.wordpressUrl)
-  assert.deepEqual(proxied.previewProxyDiagnostics, {
+  const initialProxyDiagnostics = proxied.previewProxyDiagnostics
+  assert.deepEqual(initialProxyDiagnostics, {
     schema: "wp-codebox/preview-proxy-diagnostics/v1",
     upstreamConcurrency: "serialized",
     maxConcurrentUpstreamRequests: 1,
     queue: "fifo",
     bind: "127.0.0.1",
     targetOrigin: new URL(targetServerUrl).origin,
+    requestTrace: { scope: "service-worker", capacity: 64, total: 0, dropped: 0, entries: [] },
   })
   await Promise.all([fetch(proxied.serverUrl), fetch(proxied.serverUrl)])
   assert.equal(maxActiveUpstreamRequests, 1)
+  await fetch(`${proxied.serverUrl}/service-worker-redirect?nonce=PRIVATE_ORDINARY_NONCE`, { redirect: "manual" })
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 0, "ordinary redirects remain outside the service-worker trace")
+  const redirectResponse = await fetch(`${proxied.serverUrl}/service-worker-redirect?nonce=PRIVATE_REQUEST_NONCE`, {
+    headers: { "service-worker": "script", "sec-fetch-dest": "serviceworker" },
+    redirect: "manual",
+  })
+  assert.equal(redirectResponse.status, 302)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 1)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.dropped, 0)
+  assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
+    sequence: 1,
+    method: "GET",
+    path: "/service-worker-redirect?nonce=[redacted]",
+    destination: "serviceworker",
+    serviceWorker: true,
+    outcome: "response",
+    status: 302,
+    upstreamLocation: `${targetServerUrl}/login?token=[redacted]`,
+    visibleLocation: `${proxied.serverUrl}/login?token=[redacted]`,
+  })
+  assert.equal(initialProxyDiagnostics?.requestTrace.total, 0, "completed diagnostics snapshots do not mutate with later proxy requests")
+  assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_REQUEST_NONCE|PRIVATE_REDIRECT_TOKEN/)
+  await fetch(`${proxied.serverUrl}/truncated-service-worker`, { headers: { "service-worker": "script" }, redirect: "manual" }).then((response) => response.text()).catch(() => undefined)
+  assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
+    sequence: 2,
+    method: "GET",
+    path: "/truncated-service-worker",
+    destination: null,
+    serviceWorker: true,
+    outcome: "upstream-error",
+    status: 302,
+    upstreamLocation: `${targetServerUrl}/login?token=[redacted]`,
+    visibleLocation: `${proxied.serverUrl}/login?token=[redacted]`,
+  })
+  assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_TRUNCATED_TOKEN/)
+  await Promise.all(Array.from({ length: 64 }, (_, index) => fetch(`${proxied.serverUrl}/bounded-trace/${index}`, { headers: { "service-worker": "script", ...(index === 0 ? { "sec-fetch-dest": "PRIVATE_DESTINATION" } : {}) } })))
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 66)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.dropped, 2)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries.length, 64)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries[0]?.sequence, 3)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries[0]?.destination, null)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1)?.sequence, 66)
+  assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_DESTINATION/)
 } finally {
   await proxied[Symbol.asyncDispose]()
   await closeHttpServer(targetServer)


### PR DESCRIPTION
## Summary
- extract preview-proxy request tracing into a focused primitive
- expose immutable diagnostics snapshots for service-worker responses, redirects, and upstream failures
- bound the trace to 64 entries and redact request/redirect query values before storage
- preserve both upstream and browser-visible redirect locations without changing proxy behavior

## Verification
- `npm run build`
- `npm run test:generic-primitives`
- `npm run test:browser-preview-routing`
- `npm run test:production-boundary-enforcement`
- `npm run test:runtime-neutral-contracts`
- `git diff --check`

## Test Gap
- `npm run test:release-package-coverage` printed the expected darwin-arm64 packaged-CLI skip, then did not terminate within a 10-minute local timeout. It was not retried again.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate the service-worker observability gap, implement and review the refactor and tests, and run the verification commands.