### PR TITLE
Fix browser screenshot artifact manifests

### DIFF
--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -141,6 +141,7 @@ export async function runBrowserActionsCommand({
   let finalUrl = requestedUrl
   let htmlSha256: string | undefined
   let screenshotSha256: string | undefined
+  const screenshots: string[] = []
   const domSnapshots: Array<{ screenshot: string; snapshot: string; step?: { index: number; name?: string; kind: string }; elementCount: number; capturedElements: number; truncated: boolean }> = []
   const verifierResults: NonNullable<BrowserArtifact["summary"]["verifierResults"]> = []
   let viewport: BrowserProbeViewport | null = null
@@ -292,6 +293,7 @@ export async function runBrowserActionsCommand({
               return {}
             }
             await artifactSession.writeGenerated("screenshot", `${basename}.png`, (path) => writeFile(path, screenshot))
+            screenshots.push(screenshotRef)
             try {
               const snapshot = await captureBrowserActionDomSnapshot({
                 artifactSession,
@@ -380,6 +382,9 @@ export async function runBrowserActionsCommand({
         }
         if (outcome.screenshot && capture.has("screenshot") && outcome.screenshotIsDefault) {
           screenshotSha256 = await fileSha256(screenshotPath)
+        }
+        if (outcome.screenshot && !outcome.screenshotIsDefault) {
+          screenshots.push(outcome.screenshot)
         }
         if (outcome.screenshot && capture.has("dom-snapshot")) {
           domSnapshots.push(await captureBrowserActionDomSnapshot({
@@ -528,6 +533,7 @@ export async function runBrowserActionsCommand({
         ...(capture.has("websocket") ? { websocket: "files/browser/websocket.json" } : {}),
         ...(redirectDiagnostics ? { redirectDiagnostics: "files/browser/redirect-diagnostics.json" } : {}),
         ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
+        ...(screenshots.length > 0 ? { screenshots } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots: domSnapshots.map((snapshot) => snapshot.snapshot) } : {}),
         ...(verifierResults.length > 0 ? { verifierResults: verifierResults.map((result) => result.artifact) } : {}),
         ...(actionCorpusArtifact ? { actionCorpus: "files/browser/action-corpus.json" } : {}),

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -83,6 +83,7 @@ export interface BrowserArtifactFiles {
   performance?: string
   review?: string
   screenshot?: string
+  screenshots?: string[]
   traces?: string[]
   domSnapshots?: string[]
   verifierResults?: string[]
@@ -1179,6 +1180,7 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   performance: { kind: "browser-performance", contentType: "application/json", redact: true },
   review: { kind: "browser-review", contentType: "application/json", redact: true },
   screenshot: { kind: "browser-screenshot", contentType: "image/png", redact: false },
+  screenshots: { kind: "browser-screenshot", contentType: "image/png", redact: false },
   traces: { kind: "browser-trace", contentType: "application/zip", redact: true },
   domSnapshots: { kind: "browser-dom-snapshot", contentType: "application/json", redact: true },
   verifierResults: { kind: "browser-verifier-result", contentType: "application/json", redact: true },

--- a/tests/browser-artifact-session.test.ts
+++ b/tests/browser-artifact-session.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { resolve } from "node:path"
 
 import { BrowserArtifactSession } from "../packages/runtime-playground/src/browser-artifact-session.js"
-import { browserReviewSummary, type BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
+import { browserManifestFiles, browserReviewSummary, type BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
 import { browserWebSocketPayloadBytes, createBrowserWebSocketRecord } from "../packages/runtime-playground/src/browser-capture-session.js"
 import { browserProbeWebSocketArtifact, browserRequestCoverageArtifact } from "../packages/runtime-playground/src/browser-probe-support.js"
 import { assertJsonFile, assertTextFile, withTempDir } from "../scripts/test-kit.js"
@@ -20,6 +20,8 @@ await session.writeJson("waterfall", "waterfall.json", { schema: "wp-codebox/bro
 await session.writeJson("websocket", "websocket.json", { schema: "wp-codebox/browser-websocket/v1", summary: { sockets: 0 } })
 await session.writeJson("summary", "summary.json", { schema: "wp-codebox/browser-probe/v1", ok: true })
 await session.writeBuffer("screenshot", "screenshot.png", Buffer.from([0, 1, 2]))
+await session.writeBuffer("screenshots", "screenshot-before-save.png", Buffer.from([3, 4, 5]))
+await session.writeBuffer("screenshots", "accessibility-000.png", Buffer.from([6, 7, 8]))
 
 await assertTextFile(resolve(artifactRoot, "files/browser/snapshot.html"), "<html><body>secret</body></html>")
 await assertTextFile(resolve(artifactRoot, "files/browser/console.jsonl"), '{"type":"log","text":"visible"}\n')
@@ -55,6 +57,24 @@ assert.equal(files.get("files/browser/websocket.json")?.redaction?.policy, "requ
 assert.equal(files.get("files/browser/screenshot.png")?.kind, "browser-screenshot")
 assert.equal(files.get("files/browser/screenshot.png")?.contentType, "image/png")
 assert.deepEqual(files.get("files/browser/screenshot.png")?.redaction, { policy: "none", sensitive: false })
+
+const manifestScreenshots = browserManifestFiles(artifactRoot, [{
+  artifactType: "actions",
+  requestedUrl: "https://example.test/",
+  url: "https://example.test/",
+  preview: { requestedMode: "local", effectiveMode: "local", localOrigin: "https://example.test", effectiveOrigin: "https://example.test", diagnostics: [] },
+  files: {
+    screenshot: "files/browser/screenshot.png",
+    screenshots: ["files/browser/screenshot-before-save.png", "files/browser/accessibility-000.png"],
+    summary: "files/browser/summary.json",
+  },
+  summary: { actions: 0, steps: 0, consoleMessages: 0, errors: 0, finalUrl: "https://example.test/", htmlSnapshot: false, networkEvents: 0, replayability: "partial", screenshot: true, viewport: null },
+} satisfies BrowserArtifact]).filter((file) => file.kind === "browser-screenshot")
+assert.deepEqual(manifestScreenshots.map((file) => file.path).sort(), [
+  resolve(artifactRoot, "files/browser/accessibility-000.png"),
+  resolve(artifactRoot, "files/browser/screenshot-before-save.png"),
+  resolve(artifactRoot, "files/browser/screenshot.png"),
+])
 
 const visualSession = new BrowserArtifactSession(artifactRoot, "files/browser/visual-compare/mobile", { source: "wordpress.visual-compare", operation: "visual-compare" })
 await visualSession.writeJson("visualDiff", "visual-diff.json", { schema: "wp-codebox/visual-compare/v1", status: "different" })


### PR DESCRIPTION
## Summary
- record named browser-action screenshots in the browser artifact contract
- record adaptive accessibility screenshots alongside default screenshots
- cover all screenshot variants at the manifest boundary

Fixes #2296.

## Verification
- `npm run build`
- `npx tsx tests/browser-artifact-session.test.ts`
- `npx tsx tests/runtime-command-artifact-bounds.test.ts`