### PR TITLE
Fix adversarial browser action cancellation

### DIFF
--- a/packages/cli/src/adversarial-recipe.ts
+++ b/packages/cli/src/adversarial-recipe.ts
@@ -261,7 +261,7 @@ async function executeRecipeAdversarialCase(
     phase: "adversarial:action",
     index: plan.iteration,
     step: { command: "wp-codebox/run-fuzz-suite", args: [`input-json=${JSON.stringify(suite)}`], metadata: { campaignId: declaration.id, caseId: plan.caseId } },
-  }, options.recipeDirectory, options.sandboxWorkspace, options.artifactRoot, options.runOptions, options.inputMountPathMap)
+  }, options.recipeDirectory, options.sandboxWorkspace, options.artifactRoot, options.runOptions, options.inputMountPathMap, undefined, signal)
   const parsed = parseObject(execution.stdout)
   const fuzzCase = Array.isArray(parsed?.cases) ? parseObjectValue(parsed.cases[0]) : undefined
   const diagnostics = Array.isArray(fuzzCase?.diagnostics) ? fuzzCase.diagnostics.flatMap((item) => {

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -232,7 +232,7 @@ function recipeCommandProducesBrowserEvidence(command: string): boolean {
   return command.startsWith("wordpress.browser-") || command === "wordpress.editor-canvas-probe" || command === "wordpress.editor-validate-blocks" || command === "wordpress.html-capture" || command === "wordpress.visual-compare"
 }
 
-export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions, inputMountPathMap: readonly InputMountPathMapping[] = [], onContinuationProgress?: (progress: RecipeContinuationProgress) => void): Promise<RecipeExecutionResult> {
+export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions, inputMountPathMap: readonly InputMountPathMapping[] = [], onContinuationProgress?: (progress: RecipeContinuationProgress) => void, signal?: AbortSignal): Promise<RecipeExecutionResult> {
   const originalArgs = workflowStep.step.args ?? []
   const resolvedArgs = rewriteWorkflowStepArgs(workflowStep.step.command, originalArgs, inputMountPathMap)
   assertResolvedInputMountPathArgs(resolvedArgs, inputMountPathMap, `Recipe workflow ${workflowStep.phase}[${workflowStep.index}] ${workflowStep.step.command}`)
@@ -245,7 +245,7 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
       if (recipeCommandHandlesItsOwnExecution(step.command)) {
         throw new Error(`Continuation is unavailable for recipe command ${step.command}.`)
       }
-      return await executeRecipeStepContinuation(runtime, mappedWorkflowStep, recipeDirectory, sandboxWorkspace, inputMountPathMap, onContinuationProgress)
+      return await executeRecipeStepContinuation(runtime, mappedWorkflowStep, recipeDirectory, sandboxWorkspace, inputMountPathMap, onContinuationProgress, signal)
     }
     if (step.command === "wp-codebox.agent-fanout") {
       const startedAt = new Date().toISOString()
@@ -299,13 +299,13 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
       return phase(await executeRuntimeCheckpointRecipeCommand(runtime, step.command, step.args ?? []))
     }
     if (step.command === "wp-codebox/run-fuzz-suite") {
-      return phase(await executeRunFuzzSuiteRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, inputMountPathMap))
+      return phase(await executeRunFuzzSuiteRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, inputMountPathMap, signal))
     }
     if (step.command === "wordpress.run-workload" && commandArgValue(step.args ?? [], "workload-json")) {
-      return phase(await executeWordPressRunWorkloadJsonRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap))
+      return phase(await executeWordPressRunWorkloadJsonRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap, signal))
     }
     const spec = await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace, { inputMountPathMap })
-    const execution = await runtime.execute(spec)
+    const execution = await runtime.execute({ ...spec, signal })
     return {
       ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, step.command, recipeWorkflowArgsEvidence(spec.originalArgs, spec.resolvedArgs), step.metadata),
       ...(workflowStep.fuzzCaseId ? { fuzzCaseId: workflowStep.fuzzCaseId } : {}),
@@ -339,7 +339,7 @@ export class RecipeContinuationError extends Error {
   }
 }
 
-async function executeRecipeStepContinuation(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace: ReturnType<typeof sandboxWorkspaceContract> | undefined, inputMountPathMap: readonly InputMountPathMapping[], onProgress?: (progress: RecipeContinuationProgress) => void): Promise<RecipeExecutionResult> {
+async function executeRecipeStepContinuation(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace: ReturnType<typeof sandboxWorkspaceContract> | undefined, inputMountPathMap: readonly InputMountPathMapping[], onProgress?: (progress: RecipeContinuationProgress) => void, signal?: AbortSignal): Promise<RecipeExecutionResult> {
   const continuation = workflowStep.step.continuation!
   let args = rewriteWorkflowStepArgs(workflowStep.step.command, workflowStep.step.args ?? [], inputMountPathMap)
   const policy = continuationPolicyEvidence(continuation)
@@ -354,7 +354,7 @@ async function executeRecipeStepContinuation(runtime: Runtime, workflowStep: Ret
     let execution: ExecutionResult | undefined
     try {
       const spec = await recipeExecutionSpec({ ...workflowStep.step, args }, recipeDirectory, sandboxWorkspace, { inputMountPathMap })
-      execution = await runtime.execute(spec)
+      execution = await runtime.execute({ ...spec, signal })
       args = spec.resolvedArgs
     } catch (error) {
       fail("execution-error", error instanceof Error ? error.message : String(error))
@@ -503,7 +503,7 @@ function rewriteWorkflowStepArgs(command: string, args: readonly string[], input
   return rewritten
 }
 
-async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, suite?: FuzzSuiteContract, fuzzCase?: unknown, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<ExecutionResult> {
+async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, suite?: FuzzSuiteContract, fuzzCase?: unknown, inputMountPathMap: readonly InputMountPathMapping[] = [], signal?: AbortSignal): Promise<ExecutionResult> {
   const startedAt = new Date().toISOString()
   const workloadJson = commandArgValue(args, "workload-json")
   if (!workloadJson) {
@@ -516,7 +516,7 @@ async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, ar
   for (const [index, step] of steps.entries()) {
     const execution = step.command === "wordpress.collect-workload-result"
       ? executeRecipeCollectWorkloadResult(step, executions, startedAt, workloadAlias)
-      : await executeRecipeWorkflowStep(runtime, { phase: "steps", index, step }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap)
+      : await executeRecipeWorkflowStep(runtime, { phase: "steps", index, step }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap, undefined, signal)
     executions.push(execution)
     if (execution.exitCode !== 0 && !step.allowFailure && !step.advisory) {
       break
@@ -759,16 +759,16 @@ function safeArtifactSegment(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "artifact"
 }
 
-async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<ExecutionResult> {
+async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, inputMountPathMap: readonly InputMountPathMapping[] = [], signal?: AbortSignal): Promise<ExecutionResult> {
   const startedAt = new Date().toISOString()
   const suite = await fuzzSuiteFromRecipeCommandArgs(args, recipeDirectory)
   const result = await runFuzzSuite(suite, {
     runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
-    executor: async (spec) => executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: workflowStepFromExecutionSpec(spec) }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap),
-    resetExecutor: createWordPressFuzzSuiteResetExecutor(recipeRuntimeFuzzSuiteResetEpisode(runtime, recipeDirectory, sandboxWorkspace, inputMountPathMap)),
+    executor: async (spec) => executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: workflowStepFromExecutionSpec(spec) }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap, undefined, signal),
+    resetExecutor: createWordPressFuzzSuiteResetExecutor(recipeRuntimeFuzzSuiteResetEpisode(runtime, recipeDirectory, sandboxWorkspace, inputMountPathMap, signal)),
     runtimeWorkloadExecutor: async ({ suite, workload, case: fuzzCase }) => {
       const workloadJson = JSON.stringify(workload)
-      const execution = await executeWordPressRunWorkloadJsonRecipeCommand(runtime, [`workload-json=${workloadJson}`], recipeDirectory, sandboxWorkspace, suite, fuzzCase, inputMountPathMap)
+      const execution = await executeWordPressRunWorkloadJsonRecipeCommand(runtime, [`workload-json=${workloadJson}`], recipeDirectory, sandboxWorkspace, suite, fuzzCase, inputMountPathMap, signal)
       const parsed = parseCommandJsonObject(execution.stdout, "wordpress.run-workload stdout")
       return {
         ...execution,
@@ -795,7 +795,7 @@ async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[]
   }
 }
 
-function recipeRuntimeFuzzSuiteResetEpisode(runtime: Runtime, recipeDirectory: string, sandboxWorkspace: ReturnType<typeof sandboxWorkspaceContract> | undefined, inputMountPathMap: readonly InputMountPathMapping[]) {
+function recipeRuntimeFuzzSuiteResetEpisode(runtime: Runtime, recipeDirectory: string, sandboxWorkspace: ReturnType<typeof sandboxWorkspaceContract> | undefined, inputMountPathMap: readonly InputMountPathMapping[], signal?: AbortSignal) {
   let index = 0
   return {
     async step(action: { command: string; args?: string[]; metadata?: Record<string, unknown> }) {
@@ -805,7 +805,7 @@ function recipeRuntimeFuzzSuiteResetEpisode(runtime: Runtime, recipeDirectory: s
         phase: "steps",
         index,
         step: { command: action.command, args: action.args, metadata: action.metadata },
-      }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap)
+      }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap, undefined, signal)
       return {
         id,
         index,

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -63,6 +63,7 @@ interface BrowserRunPlan {
 }
 
 export async function runBrowserActionsCommand({
+  abortSignal,
   artifactRoot,
   plan,
   runtimeSpec,
@@ -72,6 +73,7 @@ export async function runBrowserActionsCommand({
   onProgress,
   session,
 }: {
+  abortSignal?: AbortSignal
   artifactRoot: string
   plan?: BrowserActionsRunPlan
   runtimeSpec: RuntimeCreateSpec
@@ -159,8 +161,19 @@ export async function runBrowserActionsCommand({
   let activePage: Page | undefined
   let installedTransportFaults: InstalledBrowserTransportFaults | undefined
   let transportFaultReport: BrowserTransportFaultReport | undefined
+  const abortHandler = () => {
+    pendingError ??= new Error("Browser command aborted during runtime cleanup")
+    void activePage?.close().catch(() => undefined)
+    void environmentRuntime?.close().catch(() => undefined)
+    if (!session) void browser.close().catch(() => undefined)
+  }
+  abortSignal?.addEventListener("abort", abortHandler, { once: true })
 
   try {
+    if (abortSignal?.aborted) {
+      abortHandler()
+      throw pendingError
+    }
     const previewReadinessError = browserPreviewReadinessError(preview)
     if (previewReadinessError) {
       throw previewReadinessError
@@ -281,7 +294,7 @@ export async function runBrowserActionsCommand({
           observations: { consoleMessages, errors, network },
           navigationScope: topology.navigationScope,
           networkPolicy: topology.networkPolicy,
-          signal: spec.signal,
+          signal: abortSignal,
           accessibilityCollector: adaptiveContract.accessibility ? createBrowserAccessibilityCollector(page, adaptiveContract.accessibility) : undefined,
           onAccessibilityFindingEvidence: adaptiveContract.accessibility ? async (scan) => {
             const basename = `accessibility-${String(scan.index).padStart(3, "0")}`
@@ -601,6 +614,7 @@ export async function runBrowserActionsCommand({
       environment: environmentEvidence,
       summary: artifact.summary,
     })
+    abortSignal?.removeEventListener("abort", abortHandler)
   }
 
   if (pendingError) {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -930,7 +930,7 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     let result: Awaited<ReturnType<typeof runBrowserActionsCommand>>
     try {
-      result = await runBrowserActionsCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec, onProgress: (event) => this.recordEvent("runtime.browser-command-progress", { ...event, specCommand: spec.command }) })
+      result = await runBrowserActionsCommand({ abortSignal: this.executionSignals.getStore(), artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec, onProgress: (event) => this.recordEvent("runtime.browser-command-progress", { ...event, specCommand: spec.command }) })
     } catch (error) {
       if (isBrowserCommandArtifactError(error)) {
         this.browserProbes.push(error.artifact)

--- a/tests/adversarial-recipe-orchestration.test.ts
+++ b/tests/adversarial-recipe-orchestration.test.ts
@@ -122,6 +122,58 @@ const failedClockRuntime = {
 await runRecipeAdversarialCampaigns({ recipe: noResetRecipe, recipePath: "/portable/no-reset.json", recipeDirectory: "/portable", runtime: failedClockRuntime, executions: [] })
 assert(noResetExecutions.some((execution) => execution.args.some((arg) => arg.includes("server-clock-cleanup"))), "failed no-reset cases clean injected clock state")
 
+const cancellationRecipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  adversarialCampaigns: [{
+    schema: "wp-codebox/adversarial-recipe-campaign/v1",
+    id: "browser-cancellation",
+    seed: "browser-cancellation-seed",
+    corpus: [{ id: "adaptive-browser", actions: [{ type: "explore-browser" }] }],
+    caseTemplates: [{ id: "explore-browser", phases: { action: [{ command: "wordpress.browser-actions", args: ["adaptive-exploration-json={\"startUrl\":\"/\"}"] }] } }],
+    mutators: ["scalar"],
+    oracles: [],
+    budgets: { maxCases: 2, maxCaseTimeMs: 20, maxWallTimeMs: 2_000, maxArtifactBytes: 100_000 },
+    resetPolicy: { mode: "checkpoint-per-case", checkpointName: "browser-baseline" },
+    shrinking: { enabled: false },
+  }],
+}
+let browserCommands = 0
+let activeBrowserCommands = 0
+let cancelledBrowserCommands = 0
+let restoredWhileActive = false
+const cancellationRuntime = {
+  info: async () => ({ id: "playground", backend: "wordpress-playground", environment: { kind: "wordpress", name: "Playground" }, createdAt: "2026-01-01T00:00:00.000Z", status: "created" }),
+  createCheckpoint: async ({ name }: { name: string }) => ({ schema: "wp-codebox/runtime-checkpoint-result/v1", operation: "create", status: "created", name, supported: true }),
+  restoreCheckpoint: async (name: string) => {
+    restoredWhileActive ||= activeBrowserCommands > 0
+    return { schema: "wp-codebox/runtime-checkpoint-result/v1", operation: "restore", status: "restored", name, supported: true }
+  },
+  execute: async (spec: ExecutionSpec) => {
+    browserCommands += 1
+    if (browserCommands === 1) {
+      assert(spec.signal, "the adversarial case signal reaches the runtime-backed browser command")
+      activeBrowserCommands += 1
+      await new Promise<void>((resolve) => spec.signal!.aborted ? resolve() : spec.signal!.addEventListener("abort", () => resolve(), { once: true }))
+      activeBrowserCommands -= 1
+      cancelledBrowserCommands += 1
+      throw new Error("browser action cancelled")
+    }
+    assert.equal(activeBrowserCommands, 0, "the next case starts after the cancelled browser command settles")
+    return { id: `browser-${browserCommands}`, command: spec.command, args: spec.args ?? [], exitCode: 0, stdout: "ok\n", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.001Z" }
+  },
+} as unknown as Runtime
+const cancellationCampaigns = await runRecipeAdversarialCampaigns({ recipe: cancellationRecipe, recipePath: "/portable/browser-cancellation.json", recipeDirectory: "/portable", runtime: cancellationRuntime, executions: [] })
+const cancellationResult = cancellationCampaigns[0]!.result
+assert.equal(cancelledBrowserCommands, 1)
+assert.equal(browserCommands, 2, "the campaign continues with a clean runtime after cancellation")
+assert.equal(restoredWhileActive, false, "checkpoint restoration waits for browser cleanup")
+assert.equal(cancellationResult.summary.timedOut, 1)
+assert.equal(cancellationResult.status, "findings")
+assert.equal(cancellationResult.findings[0]?.status, "timed-out")
+assert(cancellationResult.findings[0]?.diagnostics.some(({ code }) => code === "case-time-budget-exhausted"))
+assert(!cancellationResult.diagnostics.some(({ code }) => code === "campaign-timeout-unsettled"))
+
 assert.equal(resolveAdversarialReplayPath("files/replay.json", "/workspace"), "/workspace/files/replay.json")
 assert.throws(() => resolveAdversarialReplayPath("../replay.json", "/workspace"), /escapes the invocation workspace/)
 assert.throws(() => resolveAdversarialReplayPath("/outside/replay.json", "/workspace"), /escapes the invocation workspace/)

--- a/tests/browser-actions-environment.browser.test.ts
+++ b/tests/browser-actions-environment.browser.test.ts
@@ -312,6 +312,31 @@ test("adaptive actions retain their declared environment through routed preview 
   }
 })
 
+test("browser actions close active Playwright work when the runtime signal aborts", async () => {
+  const fixture = await browserFixture()
+  const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-browser-actions-cancellation-"))
+  const controller = new AbortController()
+  const started = Date.now()
+  const timer = setTimeout(() => controller.abort(), 50)
+  try {
+    await assert.rejects(runBrowserActionsCommand({
+      abortSignal: controller.signal,
+      artifactRoot,
+      runtimeSpec,
+      server: fixture.server,
+      spec: {
+        command: "wordpress.browser-actions",
+        args: [`steps-json=${JSON.stringify([{ kind: "navigate", url: "/" }, { kind: "evaluate", expression: "await new Promise(() => {})" }])}`, "capture=steps"],
+      },
+    }), /aborted during runtime cleanup/)
+    assert(Date.now() - started < 1_000, "browser cleanup must settle within the adversarial cancellation grace period")
+  } finally {
+    clearTimeout(timer)
+    await fixture.close()
+    await rm(artifactRoot, { recursive: true, force: true })
+  }
+})
+
 test("scenario steps-json file payloads execute instead of being dropped", async () => {
   const fixture = await browserFixture()
   const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-browser-scenario-steps-file-"))


### PR DESCRIPTION
## Summary
- propagate adversarial case cancellation through the recipe workflow, nested fuzz suite, and WordPress workload execution layers to each runtime command
- pass the Playground runtime's merged execution signal into `wordpress.browser-actions` and actively close its page, context, and owned browser so in-flight Playwright work settles promptly
- preserve bounded case terminalization and checkpoint isolation: timed-out cases settle before restore, report `case-time-budget-exhausted`, and do not poison later campaign cases

## Root cause
The recipe adversarial adapter received the case deadline's `AbortSignal`, but dropped it when invoking the nested `wp-codebox/run-fuzz-suite` workflow. The nested runtime workload therefore created `wordpress.browser-actions` execution specs without the case signal. Separately, the Playground browser-actions runner read `spec.signal` instead of the runtime's merged execution signal and had no abort cleanup hook, so a Playwright operation already in flight could continue beyond cancellation.

The owning layers now carry the signal through nested recipe execution, while the Playground browser runner consumes the merged runtime signal and closes active Playwright resources on abort. Cleanup completes before the adversarial executor's `finally` restores its checkpoint.

## Verification
- `npx tsx tests/adversarial-recipe-orchestration.test.ts`
- `npx tsx tests/nested-fuzz-suite-recipe-command.test.ts`
- `npx tsx --test tests/adversarial-campaign.test.ts`
- `npx tsx --test tests/browser-actions-environment.browser.test.ts`
- `npx tsx tests/wordpress-runtime-actions.test.ts`
- `npx tsx tests/recipe-step-continuation.test.ts`
- `npm run build`
- `git diff --check`

The regression covers a runtime-backed browser action crossing its case deadline, observing cancellation, settling within the grace bound, producing an accurate timed-out result, restoring its checkpoint only after settlement, and allowing the next campaign case to run. A real Playwright regression also verifies a hanging browser action settles promptly when the runtime signal aborts.

Fixes #2298

No release or deploy was performed.