### PR TITLE
Fix incomplete adaptive exploration propagation

### DIFF
--- a/packages/cli/src/adversarial-recipe.ts
+++ b/packages/cli/src/adversarial-recipe.ts
@@ -272,7 +272,15 @@ async function executeRecipeAdversarialCase(
     const ref = parseObjectValue(item)
     return ref && typeof ref.path === "string" ? [{ path: ref.path, kind: String(ref.kind ?? "fuzz-artifact"), bytes: typeof ref.bytes === "number" ? ref.bytes : undefined, sha256: typeof ref.sha256 === "string" ? ref.sha256 : undefined }] : []
   }) : []
-  const status = fuzzCase?.status === "passed" && execution.exitCode === 0 ? "passed" : fuzzCase?.status === "failed" ? "failed" : "error"
+  const incompleteAdaptive = findIncompleteAdaptiveExploration(fuzzCase)
+  if (incompleteAdaptive) diagnostics.unshift({
+    code: "adaptive-exploration-incomplete",
+    message: incompleteAdaptive.budgetExhausted
+      ? `Adaptive browser exploration stopped at the ${incompleteAdaptive.budgetExhausted} bound and retained partial evidence.`
+      : "Adaptive browser exploration retained partial evidence but did not complete coverage.",
+    severity: "warning",
+  })
+  const status = incompleteAdaptive ? "resource-exhausted" : fuzzCase?.status === "passed" && execution.exitCode === 0 ? "passed" : fuzzCase?.status === "failed" ? "failed" : "error"
   options.executions.push(execution)
   const signals = [
     `status:${status}`,
@@ -289,6 +297,27 @@ async function executeRecipeAdversarialCase(
     stateDigest: createHash("sha256").update(JSON.stringify({ campaignId: declaration.id, status, signals, matrix: plan.matrix })).digest("hex"),
     metadata: { fuzzSuite: parsed, resetPolicy: declaration.resetPolicy ?? { mode: "none" }, faultSchedule: declaration.faultSchedule, ...(smtpSinkResets.length > 0 ? { smtpSinkResets } : {}) },
   }) as AdversarialExecutionObservation
+}
+
+function findIncompleteAdaptiveExploration(value: unknown): { budgetExhausted?: string } | undefined {
+  if (!value || typeof value !== "object") return undefined
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const result = findIncompleteAdaptiveExploration(item)
+      if (result) return result
+    }
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  if (record.schema === "wp-codebox/browser-adaptive-exploration/v1" && record.status === "incomplete") {
+    const summary = parseObjectValue(record.summary)
+    return { budgetExhausted: typeof record.budgetExhausted === "string" ? record.budgetExhausted : typeof summary?.budgetExhausted === "string" ? summary.budgetExhausted : undefined }
+  }
+  for (const item of Object.values(record)) {
+    const result = findIncompleteAdaptiveExploration(item)
+    if (result) return result
+  }
+  return undefined
 }
 
 function stableAdversarialDiagnosticMessage(message: string, caseId: string): string {

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -524,11 +524,12 @@ async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, ar
   }
   const failed = executions.find((execution) => execution.exitCode !== 0)
   const artifacts = recipeWorkloadExecutionArtifacts(executions)
+  const incompleteResults = recipeIncompleteWorkloadResults(executions)
   if (workloadAlias && !artifacts[workloadAlias]) {
     const aliasPayloads = dedupeRecipeArtifactPayloads(executions.flatMap(recipeAllWorkloadArtifactPayloadsFromExecution))
     if (aliasPayloads.length === 1) artifacts[workloadAlias] = aliasPayloads[0]!.payload
   }
-  const payload = stripUndefined({ schema: "wp-codebox/wordpress-workload-run-result/v1", steps: executions.length, exitCode: failed?.exitCode ?? 0, artifacts: Object.keys(artifacts).length > 0 ? artifacts : undefined })
+  const payload = stripUndefined({ schema: "wp-codebox/wordpress-workload-run-result/v1", steps: executions.length, exitCode: failed?.exitCode ?? 0, artifacts: Object.keys(artifacts).length > 0 ? artifacts : undefined, incompleteResults: incompleteResults.length > 0 ? incompleteResults : undefined })
   return {
     id: `wordpress-run-workload:${startedAt}`,
     command: "wordpress.run-workload",
@@ -541,6 +542,22 @@ async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, ar
     finishedAt: executions.at(-1)?.finishedAt ?? new Date().toISOString(),
     artifactRefs: executions.flatMap((execution) => [...(execution.artifactRefs ?? []), ...recipeWorkloadResultArtifactRefs(execution)]),
   }
+}
+
+function recipeIncompleteWorkloadResults(executions: ExecutionResult[]): Array<{ schema: string; status: "incomplete"; budgetExhausted?: string }> {
+  const results = executions.flatMap((execution) => incompleteResultSummaries(isRecord(execution.result?.json) ? execution.result.json : parseJsonObject(execution.stdout)))
+  return results.filter((result, index) => results.findIndex((candidate) => JSON.stringify(candidate) === JSON.stringify(result)) === index)
+}
+
+function incompleteResultSummaries(value: unknown): Array<{ schema: string; status: "incomplete"; budgetExhausted?: string }> {
+  if (!value || typeof value !== "object") return []
+  if (Array.isArray(value)) return value.flatMap(incompleteResultSummaries)
+  const record = value as Record<string, unknown>
+  const summary = isRecord(record.summary) ? record.summary : undefined
+  const current = typeof record.schema === "string" && record.status === "incomplete"
+    ? [{ schema: record.schema, status: "incomplete" as const, budgetExhausted: typeof record.budgetExhausted === "string" ? record.budgetExhausted : typeof summary?.budgetExhausted === "string" ? summary.budgetExhausted : undefined }]
+    : []
+  return [...current, ...Object.values(record).flatMap(incompleteResultSummaries)]
 }
 
 export function executeRecipeCollectWorkloadResult(step: WorkspaceRecipe["workflow"]["steps"][number], priorExecutions: ExecutionResult[], startedAt: string, workloadAlias?: string): ExecutionResult {

--- a/packages/runtime-core/src/adversarial-campaign.ts
+++ b/packages/runtime-core/src/adversarial-campaign.ts
@@ -244,6 +244,11 @@ export async function runAdversarialCampaign(campaignInput: AdversarialCampaign,
       const observation = observations[index] as AdversarialExecutionObservation
       executed += 1
       if (observation.status === "timed-out") timedOut += 1
+      if (observation.status === "resource-exhausted") {
+        incomplete = true
+        diagnostics.push({ code: "campaign-case-resource-exhausted", message: observation.diagnostics?.[0]?.message ?? `Campaign stopped because ${plan.caseId} exhausted a runtime resource before coverage completed.` })
+        break
+      }
       if (observation.diagnostics?.some(({ code }) => code === "case-timeout-unsettled")) {
         incomplete = true
         diagnostics.push({ code: "campaign-timeout-unsettled", message: `Campaign stopped because ${plan.caseId} did not settle after cancellation. The runtime must be torn down before further work.` })

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -324,6 +324,7 @@ export async function runBrowserActionsCommand({
           states: result.summary.states,
           transitions: result.summary.transitions,
           findings: result.summary.findings,
+          ...(result.summary.budgetExhausted ? { budgetExhausted: result.summary.budgetExhausted } : {}),
           artifact: "files/browser/adaptive-exploration.json",
         }
         finalUrl = page.url()

--- a/packages/runtime-playground/src/browser-adaptive-explorer.ts
+++ b/packages/runtime-playground/src/browser-adaptive-explorer.ts
@@ -90,7 +90,7 @@ export async function exploreAdaptiveBrowserStateMachine({
     remainingBytes: Math.floor(contract.budgets.maxArtifactBytes / 8),
   }
 
-  const initial = await captureAdaptiveState(page, contract, 0, navigationScope)
+  const initial = await stabilizeAdaptiveState(page, contract, 0, now, navigationScope)
   appendDiagnostics(diagnostics, initial.diagnostics, contract.descriptorLimits.maxDiagnostics)
   states.set(initial.state.digest, initial.state)
   const frontier: FrontierEntry[] = [{ state: initial.state, path: [] }]

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import { artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactReviewBrowserSummary, type BrowserEnvironment, type BrowserEnvironmentCapabilityResult, type BrowserGeolocation, type ResolvedBrowserEnvironment, type TransportFaultCapability } from "@automattic/wp-codebox-core"
+import { artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactReviewBrowserSummary, type BrowserAdaptiveExplorationResult, type BrowserEnvironment, type BrowserEnvironmentCapabilityResult, type BrowserGeolocation, type ResolvedBrowserEnvironment, type TransportFaultCapability } from "@automattic/wp-codebox-core"
 import type { PlaygroundPreviewProxyDiagnostics } from "./preview-server.js"
 import type { Request } from "playwright"
 
@@ -181,6 +181,7 @@ export interface BrowserArtifactSummary {
     states: number
     transitions: number
     findings: number
+    budgetExhausted?: BrowserAdaptiveExplorationResult["summary"]["budgetExhausted"]
     artifact: string
   }
   networkPolicy?: BrowserProbeNetworkPolicySummary

--- a/tests/adversarial-campaign.test.ts
+++ b/tests/adversarial-campaign.test.ts
@@ -190,6 +190,23 @@ test("an uncooperative timed-out case terminalizes the campaign without starting
   assert(result.diagnostics.some(({ code }) => code === "campaign-timeout-unsettled"))
 })
 
+test("resource-exhausted cases make coverage incomplete without creating findings", async () => {
+  const result = await runAdversarialCampaign(adversarialCampaign({
+    id: "partial-coverage",
+    seed: "partial-coverage-seed",
+    corpus: [{ id: "seed", actions: [{ type: "explore" }] }],
+    mutationKinds: ["sequence"],
+    budgets: { maxCases: 2, workers: 1, maxCaseTimeMs: 1_000, maxWallTimeMs: 5_000 },
+    oracles: [{ schema: "wp-codebox/adversarial-oracle/v1", id: "runtime-status", severity: "high" }],
+  }), {
+    execute: async () => ({ status: "resource-exhausted", diagnostics: [{ code: "adaptive-exploration-incomplete", message: "Adaptive browser exploration stopped at the maxDurationMs bound and retained partial evidence." }], artifacts: [{ path: "adaptive-exploration.json", kind: "browser-adaptive-exploration" }] }),
+  })
+  assert.equal(result.status, "incomplete")
+  assert.equal(result.summary.executed, 1)
+  assert.equal(result.findings.length, 0)
+  assert(result.diagnostics.some((diagnostic) => diagnostic.code === "campaign-case-resource-exhausted" && diagnostic.message.includes("maxDurationMs")))
+})
+
 test("minimization preserves the exact oracle and state fingerprint", async () => {
   const exactState = adversarialCampaign({
     id: "exact-state",

--- a/tests/adversarial-recipe-orchestration.test.ts
+++ b/tests/adversarial-recipe-orchestration.test.ts
@@ -142,6 +142,28 @@ const incompleteCampaigns = structuredClone(findingCampaigns)
 incompleteCampaigns[0]!.result.status = "incomplete"
 assert.equal(recipeAdversarialCampaignFailure(incompleteCampaigns)?.code, "adversarial-campaign-incomplete")
 
+const adaptiveRecipe = structuredClone(recipe)
+adaptiveRecipe.adversarialCampaigns![0]!.budgets.maxCases = 1
+adaptiveRecipe.adversarialCampaigns![0]!.corpus[0]!.actions = [{ type: "option-roundtrip" }]
+adaptiveRecipe.adversarialCampaigns![0]!.caseTemplates[0]!.phases.action = [{ command: "wordpress.browser-actions", args: ["adaptive-exploration-json={}"] }]
+const adaptiveRuntime = {
+  ...runtime,
+  execute: async (spec: ExecutionSpec) => ({
+    id: "adaptive-incomplete",
+    command: spec.command,
+    args: spec.args ?? [],
+    exitCode: 0,
+    stdout: spec.command === "wordpress.browser-actions" ? JSON.stringify({ summary: { adaptiveExploration: { schema: "wp-codebox/browser-adaptive-exploration/v1", status: "incomplete", budgetExhausted: "maxDurationMs" } } }) : "ok\n",
+    stderr: "",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: "2026-01-01T00:00:00.001Z",
+  }),
+} as unknown as Runtime
+const adaptiveCampaigns = await runRecipeAdversarialCampaigns({ recipe: adaptiveRecipe, recipePath: "/portable/adaptive.json", recipeDirectory: "/portable", runtime: adaptiveRuntime, executions: [] })
+assert.equal(adaptiveCampaigns[0]?.result.status, "incomplete")
+assert.equal(adaptiveCampaigns[0]?.result.findings.length, 0, "incomplete adaptive coverage is not an actionable finding")
+assert(adaptiveCampaigns[0]?.result.diagnostics.some((diagnostic) => diagnostic.code === "campaign-case-resource-exhausted" && diagnostic.message.includes("maxDurationMs")))
+
 const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-adversarial-recipe-"))
 try {
   const manifestPath = join(artifactRoot, "manifest.json")

--- a/tests/browser-adaptive-exploration.test.ts
+++ b/tests/browser-adaptive-exploration.test.ts
@@ -70,6 +70,19 @@ document.querySelector('#continue').addEventListener('click', () => {
 });
 </script>`
 
+const asynchronousMountFixture = `<!doctype html>
+<style>button,[role="progressbar"] { display:block; width:180px; height:30px; margin:8px; }</style>
+<div id="loading" role="progressbar">Loading editor...</div>
+<script>
+setTimeout(() => {
+  document.querySelector('#loading').remove();
+  const button = document.createElement('button');
+  button.id = 'editor-control';
+  button.textContent = 'Edit document';
+  document.body.append(button);
+}, 80);
+</script>`
+
 test("adaptive browser exploration is an additive public browser-actions mode", () => {
   const definition = getCommandDefinition("wordpress.browser-actions")
   const argument = definition?.acceptedArgs.find((candidate) => candidate.name === "adaptive-exploration-json")
@@ -351,6 +364,19 @@ test("bounded stabilization captures delayed conditional fields and route state"
   assert(destination?.descriptors.some((descriptor) => descriptor.selector === "#conditional-field"))
 })
 
+test("initial adaptive frontier waits for asynchronous mount readiness", async () => {
+  const run = await runFixture(asynchronousMountFixture, {
+    seed: "asynchronous-initial-mount",
+    failOnFinding: false,
+    budgets: { maxActions: 1, maxStates: 2, maxTransitions: 1, maxDurationMs: 5_000 },
+    actionFamilies: ["click"],
+  })
+  const initial = run.result.states[0]
+  assert.equal(initial?.loadingIndicators, 0)
+  assert(initial?.descriptors.some((descriptor) => descriptor.selector === "#editor-control"), "initial frontier includes controls mounted after the loading state clears")
+  assert(run.result.transitions.some((transition) => transition.action.steps[0]?.selector === "#editor-control"))
+})
+
 test("identical seed and DOM produce deterministic state and action graph identity", async () => {
   const input = {
     seed: "deterministic-graph",
@@ -444,7 +470,7 @@ test("cancellation during a partially failed action retains bounded non-replayab
     failOnFinding: false,
     budgets: { maxActions: 8, maxStates: 8, maxTransitions: 8, maxDurationMs: 15_000, maxErrors: 4 },
     actionFamilies: ["repeat"],
-  }, controller.signal, () => setTimeout(() => controller.abort("cancel during intercepted click"), 250))
+  }, controller.signal, () => setTimeout(() => controller.abort("cancel during intercepted click"), 500))
   const failed = run.result.transitions.find((transition) => transition.status === "error")
   assert(failed)
   assert.equal(run.result.status, "incomplete")


### PR DESCRIPTION
## Summary
- stabilize the initial adaptive browser state with the existing bounded loading and quiet-window logic before planning its first action frontier
- retain compact schema-tagged incomplete workload results and map incomplete adaptive coverage to the existing `resource-exhausted` adversarial status
- terminalize resource-exhausted campaigns as `incomplete` while preserving partial artifacts and avoiding false actionable findings

## Root Causes And Behavior
The adaptive explorer captured its initial state immediately, unlike every post-transition and reset capture. Asynchronously mounted controls could therefore be omitted while loading indicators were still visible. The initial state now goes through `stabilizeAdaptiveState()` with the contract's existing `pollIntervalMs`, `quietWindowMs`, and `maxWaitMs` bounds before descriptors are used to build the frontier.

The runtime-backed workload envelope also reduced successful command output to counts and artifact references, dropping the adaptive result's `incomplete` status before the adversarial `runtime-status` oracle evaluated the case. Workload mapping now retains compact schema-tagged incomplete summaries, including `budgetExhausted`; the adversarial recipe adapter maps incomplete adaptive exploration to `resource-exhausted`. The campaign runner treats that status as incomplete coverage, stops scheduling further cases, preserves partial evidence, and does not create a defect finding. Completed and finding-bearing adaptive runs retain their existing behavior.

## Tests
- `npx tsx --test tests/browser-adaptive-exploration.test.ts`
- `npx tsx --test tests/adversarial-campaign.test.ts`
- `npx tsx tests/adversarial-recipe-orchestration.test.ts`
- `npm run build`

Fixes #2299.

No release or deploy was performed.