### PR TITLE
Keep shrinkwrap versions aligned during releases

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -58,6 +58,10 @@
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {
+      "file": "npm-shrinkwrap.json",
+      "pattern": "(?s)\"name\":\\s*\"(?:wp-codebox-workspace|@automattic/wp-codebox-(?:cli|core|playground))\",\\s*\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
       "file": "packages/wordpress-plugin/wp-codebox.php",
       "pattern": "Version:\\s*([0-9.]+)"
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -5693,7 +5693,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -5715,14 +5715,14 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "ajv": "^8.20.0"
       }
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@php-wasm/node": "3.1.46",

--- a/tests/release-target.test.ts
+++ b/tests/release-target.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
 import test from "node:test"
 
 import { normalizeReleasePlatform, releaseTargetMatchesHost } from "../scripts/lib/release-target.ts"
@@ -14,4 +15,17 @@ test("executes release packages only on a compatible host target", () => {
   assert.equal(releaseTargetMatchesHost("linux-x64", "darwin", "arm64"), false)
   assert.equal(releaseTargetMatchesHost("macos-arm64", "darwin", "arm64"), true)
   assert.equal(releaseTargetMatchesHost("windows-x64", "win32", "x64"), true)
+})
+
+test("release versioning covers every workspace package in npm-shrinkwrap", async () => {
+  const [manifest, shrinkwrap, homeboy] = await Promise.all([
+    readFile("package.json", "utf8").then(JSON.parse),
+    readFile("npm-shrinkwrap.json", "utf8").then(JSON.parse),
+    readFile("homeboy.json", "utf8").then(JSON.parse),
+  ])
+  const target = homeboy.version_targets.find(({ file }: { file: string }) => file === "npm-shrinkwrap.json")
+  assert(target, "npm-shrinkwrap.json must be a release version target")
+  const versions = [...JSON.stringify(shrinkwrap, null, 2).matchAll(new RegExp(target.pattern.replace("(?s)", ""), "gs"))].map((match) => match[1])
+  assert.equal(versions.length, 5)
+  assert.deepEqual([...new Set(versions)], [manifest.version])
 })


### PR DESCRIPTION
## Summary
- synchronize the stale root and workspace package versions in `npm-shrinkwrap.json`
- add the five authoritative shrinkwrap package entries to Homeboy release version targets
- verify release configuration covers every workspace package version

Fixes #2302.

## Verification
- `npx tsx --test tests/release-target.test.ts`
- `npm run build`
- `homeboy deps install wp-codebox --path /var/lib/datamachine/workspace/wp-codebox@fix-release-shrinkwrap-drift` leaves no additional tracked drift

No release or deployment was performed by this PR workflow.