### PR TITLE
Fix service worker requests through the preview proxy

### DIFF
--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -199,6 +199,9 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     })
     return {
       ...proxiedServer,
+      get previewProxyDiagnostics() {
+        return proxiedServer.previewProxyDiagnostics
+      },
       async [Symbol.asyncDispose]() {
         try {
           await proxiedServer[Symbol.asyncDispose]()
@@ -258,6 +261,9 @@ async function withPreviewLeaseProvider(server: PlaygroundCliServer, spec: Runti
 
   return {
     ...server,
+    get previewProxyDiagnostics() {
+      return server.previewProxyDiagnostics
+    },
     previewLease: lease,
     async [Symbol.asyncDispose]() {
       try {

--- a/packages/runtime-playground/src/preview-proxy-request-trace.ts
+++ b/packages/runtime-playground/src/preview-proxy-request-trace.ts
@@ -18,7 +18,7 @@ export interface PlaygroundPreviewProxyRequestTraceEntry {
   path: string
   destination: string | null
   serviceWorker: boolean
-  outcome: "response" | "upstream-error"
+  outcome: "response" | "upstream-error" | "client-canceled" | "canceled-before-upstream"
   status?: number
   upstreamLocation?: string
   visibleLocation?: string
@@ -35,8 +35,9 @@ export function snapshotPreviewProxyRequestTrace(trace: PlaygroundPreviewProxyRe
 }
 
 export function recordPreviewProxyRequest(trace: PlaygroundPreviewProxyRequestTrace, incoming: IncomingMessage, path: string, outcome: PlaygroundPreviewProxyRequestOutcome): void {
-  const serviceWorker = incoming.headers["service-worker"] === "script"
-  if (!serviceWorker) {
+  const destination = previewProxyFetchDestination(incoming.headers["sec-fetch-dest"])
+  const serviceWorker = incoming.headers["service-worker"] === "script" || destination === "serviceworker"
+  if (!serviceWorker && !isServiceWorkerScriptPath(path)) {
     return
   }
 
@@ -45,9 +46,10 @@ export function recordPreviewProxyRequest(trace: PlaygroundPreviewProxyRequestTr
     sequence: trace.total,
     method: incoming.method ?? "GET",
     path: redactPreviewProxyUrl(path),
-    destination: previewProxyFetchDestination(incoming.headers["sec-fetch-dest"]),
+    destination,
     serviceWorker,
-    ...outcome,
+    outcome: outcome.outcome,
+    ...(outcome.status !== undefined ? { status: outcome.status } : {}),
     ...(outcome.upstreamLocation ? { upstreamLocation: redactPreviewProxyUrl(outcome.upstreamLocation) } : {}),
     ...(outcome.visibleLocation ? { visibleLocation: redactPreviewProxyUrl(outcome.visibleLocation) } : {}),
   })
@@ -57,8 +59,20 @@ export function recordPreviewProxyRequest(trace: PlaygroundPreviewProxyRequestTr
   }
 }
 
+export function isPreviewProxyServiceWorkerRequest(incoming: IncomingMessage, path: string): boolean {
+  return incoming.headers["service-worker"] === "script" || previewProxyFetchDestination(incoming.headers["sec-fetch-dest"]) === "serviceworker" || isServiceWorkerScriptPath(path)
+}
+
 function redactPreviewProxyUrl(value: string): string {
   return redactString(value, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
+}
+
+function isServiceWorkerScriptPath(path: string): boolean {
+  try {
+    return new URL(path, "http://localhost").pathname === "/sw.js"
+  } catch {
+    return false
+  }
 }
 
 function headerValue(value: string | string[] | undefined): string | undefined {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -2,7 +2,7 @@ import { createServer as createHttpServer, request as httpRequest, type Incoming
 import { createServer as createNetServer } from "node:net"
 import { Transform } from "node:stream"
 import type { PreviewLease } from "@automattic/wp-codebox-core"
-import { createPreviewProxyRequestTrace, recordPreviewProxyRequest, snapshotPreviewProxyRequestTrace, type PlaygroundPreviewProxyRequestOutcome, type PlaygroundPreviewProxyRequestTrace } from "./preview-proxy-request-trace.js"
+import { createPreviewProxyRequestTrace, isPreviewProxyServiceWorkerRequest, recordPreviewProxyRequest, snapshotPreviewProxyRequestTrace, type PlaygroundPreviewProxyRequestOutcome, type PlaygroundPreviewProxyRequestTrace } from "./preview-proxy-request-trace.js"
 
 export interface PlaygroundServerRunResponse {
   exitCode?: number
@@ -156,6 +156,7 @@ function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry, r
           outgoing.off("close", cancel)
         }
       },
+      () => recordPreviewProxyRequest(requestTrace, incoming, incoming.url ?? "/", { outcome: "canceled-before-upstream" }),
     ).catch((error: Error) => writeProxyError(outgoing, error))
   })
 }
@@ -188,6 +189,13 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
     let settled = false
     let clientCanceled = false
     let targetResponse: IncomingMessage | undefined
+    let outcomeRecorded = false
+    const recordOutcome = (outcome: PlaygroundPreviewProxyRequestOutcome) => {
+      if (!outcomeRecorded) {
+        outcomeRecorded = true
+        recordPreviewProxyRequest(requestTrace, incoming, requestTarget.path, outcome)
+      }
+    }
     const settle = () => {
       if (settled) {
         return
@@ -197,6 +205,7 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
     }
     const abortUpstream = () => {
       clientCanceled = true
+      recordOutcome({ outcome: "client-canceled" })
       targetRequest.destroy()
       targetResponse?.destroy()
       settle()
@@ -220,12 +229,9 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
           upstreamLocation: headerValue(response.headers.location),
           visibleLocation: headerValue(headers.location),
         }
-        let outcomeRecorded = false
-        const recordOutcome = (outcome: PlaygroundPreviewProxyRequestOutcome) => {
-          if (!outcomeRecorded) {
-            outcomeRecorded = true
-            recordPreviewProxyRequest(requestTrace, incoming, requestTarget.path, outcome)
-          }
+        if (isPreviewProxyServiceWorkerRequest(incoming, requestTarget.path) && responseOutcome.status !== undefined && responseOutcome.status >= 300 && responseOutcome.status < 400) {
+          // Browsers reject and cancel redirected service-worker scripts as soon as headers arrive.
+          recordOutcome(responseOutcome)
         }
         const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target)
         if (bodyTransform) {
@@ -262,7 +268,7 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
 
     targetRequest.on("error", (error) => {
       if (!clientCanceled) {
-        recordPreviewProxyRequest(requestTrace, incoming, requestTarget.path, { outcome: "upstream-error" })
+        recordOutcome({ outcome: "upstream-error" })
       }
       writeProxyError(outgoing, error)
       settle()
@@ -312,12 +318,14 @@ function createPreviewProxyQueue(): (
   task: () => Promise<void>,
   isCanceled: () => boolean,
   observeCancellation: (cancel: () => void) => () => void,
+  onCanceledBeforeRun: () => void,
 ) => Promise<void> {
   let active = false
   interface PendingRequest {
     task: () => Promise<void>
     isCanceled: () => boolean
     stopObservingCancellation: () => void
+    onCanceledBeforeRun: () => void
     resolve: () => void
     reject: (error: unknown) => void
   }
@@ -331,6 +339,7 @@ function createPreviewProxyQueue(): (
         run(next)
         return
       }
+      next.onCanceledBeforeRun()
       next.resolve()
       next = pending.shift()
     }
@@ -340,6 +349,7 @@ function createPreviewProxyQueue(): (
   function run(request: PendingRequest): void {
     request.stopObservingCancellation()
     if (request.isCanceled()) {
+      request.onCanceledBeforeRun()
       request.resolve()
       release()
       return
@@ -355,11 +365,12 @@ function createPreviewProxyQueue(): (
     task.then(request.resolve, request.reject).finally(release)
   }
 
-  return (task, isCanceled, observeCancellation) => new Promise<void>((resolve, reject) => {
+  return (task, isCanceled, observeCancellation, onCanceledBeforeRun) => new Promise<void>((resolve, reject) => {
     const request: PendingRequest = {
       task,
       isCanceled,
       stopObservingCancellation: () => {},
+      onCanceledBeforeRun,
       resolve,
       reject,
     }
@@ -370,6 +381,7 @@ function createPreviewProxyQueue(): (
       }
       pending.splice(index, 1)
       request.stopObservingCancellation()
+      request.onCanceledBeforeRun()
       resolve()
     }
     request.stopObservingCancellation = observeCancellation(cancel)
@@ -416,6 +428,10 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: Previe
   delete forwarded["x-forwarded-host"]
   delete forwarded["x-forwarded-port"]
   delete forwarded["x-forwarded-proto"]
+  if (headers["service-worker"] === "script" || headers["sec-fetch-dest"] === "serviceworker") {
+    delete forwarded["service-worker"]
+    delete forwarded["sec-fetch-dest"]
+  }
   if (requestTarget.rewriteTargetOrigin) {
     forwarded["accept-encoding"] = "identity"
   }

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -189,18 +189,26 @@ assert.match(browserPreviewReadinessError(unsupportedCanonicalTopology.preview)?
 
 let activeUpstreamRequests = 0
 let maxActiveUpstreamRequests = 0
+let forwardedServiceWorkerHeaders: { serviceWorker?: string | string[]; destination?: string | string[] } | undefined
 const targetServer = createServer(async (request, response) => {
   activeUpstreamRequests += 1
   maxActiveUpstreamRequests = Math.max(maxActiveUpstreamRequests, activeUpstreamRequests)
   await new Promise((resolveDelay) => setTimeout(resolveDelay, 25))
   activeUpstreamRequests -= 1
   if (request.url?.startsWith("/service-worker-redirect")) {
+    forwardedServiceWorkerHeaders = { serviceWorker: request.headers["service-worker"], destination: request.headers["sec-fetch-dest"] }
     response.writeHead(302, { location: `${targetServerUrl}/login?token=PRIVATE_REDIRECT_TOKEN` })
     response.end()
     return
   }
+  if (request.url === "/canceled-service-worker-redirect") {
+    response.writeHead(302, { location: `${targetServerUrl}/login?token=PRIVATE_CANCELED_TOKEN` })
+    response.flushHeaders()
+    setTimeout(() => response.end(), 100)
+    return
+  }
   if (request.url === "/truncated-service-worker") {
-    response.writeHead(302, { location: `${targetServerUrl}/login?token=PRIVATE_TRUNCATED_TOKEN` })
+    response.writeHead(200, { "content-type": "application/javascript" })
     response.flushHeaders()
     response.socket?.destroy()
     return
@@ -233,15 +241,26 @@ try {
   assert.equal(maxActiveUpstreamRequests, 1)
   await fetch(`${proxied.serverUrl}/service-worker-redirect?nonce=PRIVATE_ORDINARY_NONCE`, { redirect: "manual" })
   assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 0, "ordinary redirects remain outside the service-worker trace")
+  await fetch(`${proxied.serverUrl}/sw.js`)
+  assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
+    sequence: 1,
+    method: "GET",
+    path: "/sw.js",
+    destination: null,
+    serviceWorker: false,
+    outcome: "response",
+    status: 200,
+  })
   const redirectResponse = await fetch(`${proxied.serverUrl}/service-worker-redirect?nonce=PRIVATE_REQUEST_NONCE`, {
     headers: { "service-worker": "script", "sec-fetch-dest": "serviceworker" },
     redirect: "manual",
   })
   assert.equal(redirectResponse.status, 302)
-  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 1)
+  assert.deepEqual(forwardedServiceWorkerHeaders, { serviceWorker: undefined, destination: undefined })
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 2)
   assert.equal(proxied.previewProxyDiagnostics?.requestTrace.dropped, 0)
   assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
-    sequence: 1,
+    sequence: 2,
     method: "GET",
     path: "/service-worker-redirect?nonce=[redacted]",
     destination: "serviceworker",
@@ -253,26 +272,41 @@ try {
   })
   assert.equal(initialProxyDiagnostics?.requestTrace.total, 0, "completed diagnostics snapshots do not mutate with later proxy requests")
   assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_REQUEST_NONCE|PRIVATE_REDIRECT_TOKEN/)
+  const canceledRedirect = new AbortController()
+  const canceledRedirectResponse = await fetch(`${proxied.serverUrl}/canceled-service-worker-redirect`, { headers: { "service-worker": "script" }, redirect: "manual", signal: canceledRedirect.signal })
+  assert.equal(canceledRedirectResponse.status, 302)
+  canceledRedirect.abort()
+  await canceledRedirectResponse.body?.cancel().catch(() => undefined)
+  assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
+    sequence: 3,
+    method: "GET",
+    path: "/canceled-service-worker-redirect",
+    destination: null,
+    serviceWorker: true,
+    outcome: "response",
+    status: 302,
+    upstreamLocation: `${targetServerUrl}/login?token=[redacted]`,
+    visibleLocation: `${proxied.serverUrl}/login?token=[redacted]`,
+  })
+  assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_CANCELED_TOKEN/)
   await fetch(`${proxied.serverUrl}/truncated-service-worker`, { headers: { "service-worker": "script" }, redirect: "manual" }).then((response) => response.text()).catch(() => undefined)
   assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
-    sequence: 2,
+    sequence: 4,
     method: "GET",
     path: "/truncated-service-worker",
     destination: null,
     serviceWorker: true,
     outcome: "upstream-error",
-    status: 302,
-    upstreamLocation: `${targetServerUrl}/login?token=[redacted]`,
-    visibleLocation: `${proxied.serverUrl}/login?token=[redacted]`,
+    status: 200,
   })
   assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_TRUNCATED_TOKEN/)
   await Promise.all(Array.from({ length: 64 }, (_, index) => fetch(`${proxied.serverUrl}/bounded-trace/${index}`, { headers: { "service-worker": "script", ...(index === 0 ? { "sec-fetch-dest": "PRIVATE_DESTINATION" } : {}) } })))
-  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 66)
-  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.dropped, 2)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 68)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.dropped, 4)
   assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries.length, 64)
-  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries[0]?.sequence, 3)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries[0]?.sequence, 5)
   assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries[0]?.destination, null)
-  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1)?.sequence, 66)
+  assert.equal(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1)?.sequence, 68)
   assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_DESTINATION/)
 } finally {
   await proxied[Symbol.asyncDispose]()
@@ -300,10 +334,14 @@ const abortableProxy = await withPreviewProxy({
 } satisfies PlaygroundCliServer, 0)
 try {
   const controller = new AbortController()
-  const abortedRequest = fetch(`${abortableProxy.serverUrl}/hang`, { signal: controller.signal }).catch((error) => error)
+  const abortedRequest = fetch(`${abortableProxy.serverUrl}/hang`, { headers: { "service-worker": "script" }, signal: controller.signal }).catch((error) => error)
   await hangingRequest
   controller.abort()
   await abortedRequest
+  for (let attempt = 0; attempt < 50 && abortableProxy.previewProxyDiagnostics?.requestTrace.total === 0; attempt += 1) {
+    await wait(10)
+  }
+  assert.equal(abortableProxy.previewProxyDiagnostics?.requestTrace.entries.at(-1)?.outcome, "client-canceled")
 
   const nextRequest = await Promise.race([
     fetch(`${abortableProxy.serverUrl}/ok`).then((response) => response.text()),
@@ -358,7 +396,7 @@ try {
   await firstQueuedRequest
 
   const controller = new AbortController()
-  const canceledRequest = fetch(`${queuedAbortProxy.serverUrl}/second`, { signal: controller.signal }).catch((error) => error)
+  const canceledRequest = fetch(`${queuedAbortProxy.serverUrl}/second`, { headers: { "sec-fetch-dest": "serviceworker" }, signal: controller.signal }).catch((error) => error)
   await secondQueuedRequest
   controller.abort()
   await canceledRequest
@@ -368,6 +406,14 @@ try {
   assert.equal(await (await firstRequest).text(), "first")
   assert.equal(await (await fetch(`${queuedAbortProxy.serverUrl}/third`)).text(), "third")
   assert.deepEqual(queuedTargetRequests, ["/first", "/third"], "a canceled queued request must not open an upstream request")
+  assert.deepEqual(queuedAbortProxy.previewProxyDiagnostics?.requestTrace.entries, [{
+    sequence: 1,
+    method: "GET",
+    path: "/second",
+    destination: "serviceworker",
+    serviceWorker: true,
+    outcome: "canceled-before-upstream",
+  }])
 } finally {
   stopObservingQueuedRequest?.()
   await queuedAbortProxy[Symbol.asyncDispose]()


### PR DESCRIPTION
Closes #2305

## Summary
- normalize service-worker-only request headers before forwarding to Playground so `/sw.js` resolves as JavaScript instead of self-redirecting
- preserve bounded proxy diagnostics for responses canceled after headers, upstream truncation, active cancellation, and queued cancellation
- retain service-worker classification from the original browser request while keeping ordinary requests outside the trace

## Verification
- `npm run build`
- `npm run test:generic-primitives`
- `npm run test:browser-preview-routing`
- `npm run test:production-boundary-enforcement`
- `npm run test:runtime-neutral-contracts`
- `git diff --check`

## AI assistance
OpenCode using OpenAI gpt-5.6-sol investigated the captured service-worker redirect, implemented and reviewed the proxy normalization and diagnostics, and ran verification. Chris Huber reviewed and remains responsible for every line.