### PR TITLE
Fix warming service worker scripts through preview proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "test:browser-environment-matrix": "tsx --test tests/browser-environment-matrix.test.ts tests/browser-environment-matrix.browser.test.ts",
     "test:browser-actions-environment": "tsx --test tests/browser-actions-environment.browser.test.ts",
     "test:browser-transport-faults": "tsx --test tests/browser-transport-fault-scenarios.browser.test.ts",
+    "test:service-worker-preview-proxy": "tsx --test tests/service-worker-preview-proxy.browser.test.ts",
     "test:browser-recipe-file-payloads-integration": "tsx tests/browser-recipe-file-payloads.integration.test.ts",
     "test:browser-diagnostic-providers": "tsx tests/browser-diagnostic-providers.test.ts",
     "test:browser-redirect-diagnostics": "tsx tests/browser-redirect-diagnostics.test.ts",

--- a/packages/runtime-playground/src/preview-proxy-request-trace.ts
+++ b/packages/runtime-playground/src/preview-proxy-request-trace.ts
@@ -63,6 +63,10 @@ export function isPreviewProxyServiceWorkerRequest(incoming: IncomingMessage, pa
   return incoming.headers["service-worker"] === "script" || previewProxyFetchDestination(incoming.headers["sec-fetch-dest"]) === "serviceworker" || isServiceWorkerScriptPath(path)
 }
 
+export function isPreviewProxyServiceWorkerRegistrationRequest(incoming: IncomingMessage): boolean {
+  return incoming.method === "GET" && (incoming.headers["service-worker"] === "script" || previewProxyFetchDestination(incoming.headers["sec-fetch-dest"]) === "serviceworker")
+}
+
 function redactPreviewProxyUrl(value: string): string {
   return redactString(value, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
 }

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -2,7 +2,7 @@ import { createServer as createHttpServer, request as httpRequest, type Incoming
 import { createServer as createNetServer } from "node:net"
 import { Transform } from "node:stream"
 import type { PreviewLease } from "@automattic/wp-codebox-core"
-import { createPreviewProxyRequestTrace, isPreviewProxyServiceWorkerRequest, recordPreviewProxyRequest, snapshotPreviewProxyRequestTrace, type PlaygroundPreviewProxyRequestOutcome, type PlaygroundPreviewProxyRequestTrace } from "./preview-proxy-request-trace.js"
+import { createPreviewProxyRequestTrace, isPreviewProxyServiceWorkerRegistrationRequest, isPreviewProxyServiceWorkerRequest, recordPreviewProxyRequest, snapshotPreviewProxyRequestTrace, type PlaygroundPreviewProxyRequestOutcome, type PlaygroundPreviewProxyRequestTrace } from "./preview-proxy-request-trace.js"
 
 export interface PlaygroundServerRunResponse {
   exitCode?: number
@@ -186,9 +186,12 @@ function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
 function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse, requestTrace: PlaygroundPreviewProxyRequestTrace): Promise<void> {
   return new Promise((resolve) => {
     const requestTarget = previewProxyRequestTarget(incoming, target)
+    const serviceWorkerRegistration = isPreviewProxyServiceWorkerRegistrationRequest(incoming)
     let settled = false
     let clientCanceled = false
     let targetResponse: IncomingMessage | undefined
+    let targetRequest: ReturnType<typeof httpRequest> | undefined
+    let serviceWorkerRedirectRetries = 0
     let outcomeRecorded = false
     const recordOutcome = (outcome: PlaygroundPreviewProxyRequestOutcome) => {
       if (!outcomeRecorded) {
@@ -206,21 +209,19 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
     const abortUpstream = () => {
       clientCanceled = true
       recordOutcome({ outcome: "client-canceled" })
-      targetRequest.destroy()
+      targetRequest?.destroy()
       targetResponse?.destroy()
       settle()
     }
-
-    const targetRequest = httpRequest(
-      {
+    const sendUpstreamRequest = () => {
+      targetRequest = httpRequest({
         protocol: target.protocol,
         hostname: target.hostname,
         port: target.port,
         method: incoming.method,
         path: requestTarget.path,
         headers: proxyRequestHeaders(incoming.headers, requestTarget),
-      },
-      (response) => {
+      }, (response) => {
         targetResponse = response
         const headers = proxyResponseHeaders(response.headers, requestTarget, target)
         const responseOutcome: PlaygroundPreviewProxyRequestOutcome = {
@@ -228,6 +229,29 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
           status: response.statusCode ?? 502,
           upstreamLocation: headerValue(response.headers.location),
           visibleLocation: headerValue(headers.location),
+        }
+        if (serviceWorkerRegistration && responseOutcome.status !== undefined && responseOutcome.status >= 300 && responseOutcome.status < 400 && serviceWorkerRedirectRetries < 2) {
+          // The runtime can redirect its worker script while it warms up. Chromium rejects
+          // registration scripts that see a redirect, so retry the same bounded request upstream.
+          serviceWorkerRedirectRetries += 1
+          response.resume()
+          response.once("end", () => {
+            if (!clientCanceled) {
+              sendUpstreamRequest()
+            }
+          })
+          response.once("error", (error) => {
+            recordOutcome({ ...responseOutcome, outcome: "upstream-error" })
+            outgoing.destroy(error)
+            settle()
+          })
+          response.once("close", () => {
+            if (!response.complete && !clientCanceled) {
+              recordOutcome({ ...responseOutcome, outcome: "upstream-error" })
+              settle()
+            }
+          })
+          return
         }
         if (isPreviewProxyServiceWorkerRequest(incoming, requestTarget.path) && responseOutcome.status !== undefined && responseOutcome.status >= 300 && responseOutcome.status < 400) {
           // Browsers reject and cancel redirected service-worker scripts as soon as headers arrive.
@@ -263,23 +287,27 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
         } else {
           response.pipe(outgoing)
         }
-      },
-    )
+      })
 
-    targetRequest.on("error", (error) => {
-      if (!clientCanceled) {
-        recordOutcome({ outcome: "upstream-error" })
+      targetRequest.on("error", (error) => {
+        if (!clientCanceled) {
+          recordOutcome({ outcome: "upstream-error" })
+        }
+        writeProxyError(outgoing, error)
+        settle()
+      })
+      if (serviceWorkerRedirectRetries > 0) {
+        targetRequest.end()
       }
-      writeProxyError(outgoing, error)
-      settle()
-    })
+    }
     incoming.on("aborted", abortUpstream)
     incoming.on("error", () => {
       abortUpstream()
     })
     outgoing.on("error", abortUpstream)
     outgoing.on("close", abortUpstream)
-    incoming.pipe(targetRequest)
+    sendUpstreamRequest()
+    incoming.pipe(targetRequest!)
   })
 }
 

--- a/tests/service-worker-preview-proxy.browser.test.ts
+++ b/tests/service-worker-preview-proxy.browser.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import test from "node:test"
+
+import { chromium } from "playwright"
+
+import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+
+test("the preview proxy registers a service worker after transient upstream redirects", async () => {
+  let workerRequests = 0
+  const forwardedWorkerHeaders: Array<{ serviceWorker: string | string[] | undefined; destination: string | string[] | undefined }> = []
+  const upstream = createServer((request, response) => {
+    if (request.url === "/sw.js") {
+      workerRequests += 1
+      forwardedWorkerHeaders.push({ serviceWorker: request.headers["service-worker"], destination: request.headers["sec-fetch-dest"] })
+      if (workerRequests < 3) {
+        response.writeHead(302, { location: "/sw.js" })
+        response.end()
+        return
+      }
+      response.writeHead(200, { "content-type": "application/javascript" })
+      response.end("self.addEventListener('install', () => self.skipWaiting()); self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));")
+      return
+    }
+    response.writeHead(200, { "content-type": "text/html" })
+    response.end("<!doctype html><title>preview</title>")
+  })
+  const upstreamUrl = await listenLocalHttpServer(upstream)
+  const proxy = await withPreviewProxy({
+    playground: { async run() { return { text: "", exitCode: 0 } } },
+    serverUrl: upstreamUrl,
+    async [Symbol.asyncDispose]() {},
+  } satisfies PlaygroundCliServer, 0)
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    await page.goto(proxy.serverUrl)
+    const registration = await page.evaluate(async () => {
+      const registered = await navigator.serviceWorker.register("/sw.js")
+      await navigator.serviceWorker.ready
+      return { scope: registered.scope, active: !!registered.active }
+    })
+
+    assert.equal(registration.scope, `${proxy.serverUrl}/`)
+    assert.equal(registration.active, true)
+    assert.equal(workerRequests, 3)
+    assert.deepEqual(forwardedWorkerHeaders, [
+      { serviceWorker: undefined, destination: undefined },
+      { serviceWorker: undefined, destination: undefined },
+      { serviceWorker: undefined, destination: undefined },
+    ])
+    assert.deepEqual(proxy.previewProxyDiagnostics?.requestTrace.entries, [{
+      sequence: 1,
+      method: "GET",
+      path: "/sw.js",
+      destination: "serviceworker",
+      serviceWorker: true,
+      outcome: "response",
+      status: 200,
+    }])
+  } finally {
+    await browser.close()
+    await proxy[Symbol.asyncDispose]()
+    await closeHttpServer(upstream)
+  }
+})


### PR DESCRIPTION
## Summary
- retry up to two transient upstream redirects for actual GET service-worker registration requests before exposing a response to Chromium
- retain normal proxy redirect behavior for all other requests and keep service-worker registration headers out of upstream requests
- add a Chromium integration regression that registers and activates a worker through the proxy after two upstream redirects

Closes #2305

## Reproduction and testing
Before this change, a preview upstream returning transient `302` responses for `/sw.js` causes Chromium registration to reject the script because service-worker scripts cannot be redirected.

The regression starts a real Chromium browser, loads the proxied preview, calls `navigator.serviceWorker.register("/sw.js")`, and verifies activation after two upstream `302` responses followed by `200`. It also verifies the registration headers are not forwarded upstream.

Tests run:
- `npm run build`
- `npm run test:service-worker-preview-proxy`
- `npm run test:browser-callback-materialization-contracts`
- `npm run test:browser-canonical-preview-origin`
- `npm run test:browser-actions-environment`
- `npm run check` (the aggregate run reached an existing command-registry failure: `wordpress.collect-workload-result outputShape should mention outputSchema id`; the 120-second command limit then stopped it)

## AI assistance
OpenAI gpt-5.6-sol used through OpenCode investigated the proxy and browser behavior, implemented the bounded retry and Chromium coverage, and ran the listed checks. Chris Huber reviewed and remains responsible for every line.