### PR TITLE
Fix runtime-backed multisite fuzz previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,8 @@
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
     "test:site-seed-multisite": "tsx tests/site-seed-multisite.test.ts",
+    "test:playground-runtime-multisite": "tsx tests/playground-runtime-multisite.test.ts",
+    "test:runtime-backed-multisite-workload-integration": "tsx tests/runtime-backed-multisite-workload.integration.test.ts",
     "test:playground-mapped-domain-multisite-integration": "tsx tests/playground-mapped-domain-multisite.integration.test.ts",
     "test:playground-multisite-checkpoint-integration": "tsx tests/playground-multisite-checkpoint.integration.test.ts",
     "test:runtime-workers": "tsx tests/runtime-workers.test.ts",

--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -576,11 +576,12 @@ register_shutdown_function(static function () use ($plugin, $plugin_file): void 
     ), JSON_UNESCAPED_SLASHES) . "\n";
 });
 wp_codebox_activate_plugin_preload_recipe_plugin($plugin, false, 'activation-recipe-plugin', 'recipe-runtime-setup activate_plugin');
-if (is_plugin_active($plugin_file)) {
-    deactivate_plugins($plugin_file, true, false);
+$network_wide = is_multisite() && is_network_only_plugin($plugin_file);
+if (is_plugin_active($plugin_file) || is_plugin_active_for_network($plugin_file)) {
+    deactivate_plugins($plugin_file, true, $network_wide);
 }
 $lifecycle = wp_codebox_activate_plugin_component_lifecycle_replay_prepare();
-$result = activate_plugin($plugin_file, '', false, false);
+$result = activate_plugin($plugin_file, '', $network_wide, false);
 wp_codebox_activate_plugin_component_lifecycle_replay_complete($lifecycle);
 if (is_wp_error($result)) {
     throw new RuntimeException('Failed to activate extra plugin ' . $plugin_file . ': ' . $result->get_error_message());

--- a/packages/runtime-playground/src/blueprint.ts
+++ b/packages/runtime-playground/src/blueprint.ts
@@ -50,7 +50,7 @@ export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpe
 }
 
 export function playgroundRuntimeBlueprint(spec: RuntimeCreateSpec): unknown {
-  const siteUrl = playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl
+  const siteUrl = playgroundRuntimeSiteUrl(spec)
   const base = playgroundBlueprint(spec.environment.blueprint, spec.policy, siteUrl)
   const multisiteSteps = playgroundSiteSeedMultisiteBlueprintSteps(spec)
   if (multisiteSteps.length === 0) return base
@@ -63,6 +63,28 @@ export function playgroundRuntimeBlueprint(spec: RuntimeCreateSpec): unknown {
     ...normalized,
     steps: [...steps.slice(0, insertAt), ...multisiteSteps, ...steps.slice(insertAt)],
   }
+}
+
+export function playgroundRuntimeSiteUrl(spec: RuntimeCreateSpec | undefined): string | undefined {
+  const declaredSiteUrl = playgroundSiteSeedPrimaryUrl(spec) ?? spec?.preview?.siteUrl
+  if (declaredSiteUrl || !spec || !blueprintNeedsPortlessMultisiteUrl(spec.environment.blueprint)) {
+    return declaredSiteUrl
+  }
+
+  return "http://127.0.0.1"
+}
+
+function blueprintNeedsPortlessMultisiteUrl(blueprint: unknown): boolean {
+  if (!blueprint || typeof blueprint !== "object" || Array.isArray(blueprint)) return false
+  const steps = Array.isArray((blueprint as Record<string, unknown>).steps) ? (blueprint as { steps: unknown[] }).steps : []
+  let hasDefinedSiteUrl = false
+  for (const step of steps) {
+    if (!step || typeof step !== "object" || Array.isArray(step)) continue
+    const stepName = (step as { step?: unknown }).step
+    if (stepName === "defineSiteUrl") hasDefinedSiteUrl = true
+    if (stepName === "enableMultisite") return !hasDefinedSiteUrl
+  }
+  return false
 }
 
 export function preferredVersionsForEnvironment(

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -1,4 +1,4 @@
-import { playgroundRuntimeBlueprint } from "./blueprint.js"
+import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl } from "./blueprint.js"
 import { PlaygroundCliExitError, type PlaygroundCliBufferedOutput } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
 import { startProgrammaticPlaygroundServer } from "./programmatic-playground-runner.js"
@@ -14,7 +14,6 @@ import { resolveWordPressRelease } from "@wp-playground/wordpress"
 import { phpEnvAssignments, phpLiteral, phpWpConfigDefineAssignments } from "./php-snippets.js"
 import { stageReadonlyPlaygroundMounts, type ReadonlyMountStaging } from "./mount-materialization.js"
 import { acquirePlaygroundArchiveReference, isCustomPlaygroundWordPressArchive, maintainPlaygroundCustomArchiveCache, playgroundWordPressArchiveCacheDirectory, withPlaygroundArchiveCacheLock, type PlaygroundArchiveReference, type PlaygroundCustomArchiveCacheDiagnostic, type PlaygroundCustomArchiveCacheMaintenance } from "./playground-wordpress-archive-cache.js"
-import { playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 const DEFAULT_RUNTIME_PHP_INI_ENTRIES = { memory_limit: "512M" }
 
@@ -177,7 +176,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           ...playgroundBundledExtensionOptions(spec),
           phpIniEntries: pluginRuntimePhpIniEntries(spec),
           phpEnv: runtimePhpEnvironment(spec),
-          "site-url": playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl,
+          "site-url": playgroundRuntimeSiteUrl(spec),
           blueprint: playgroundCliBlueprint(spec),
         })
       } finally {

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -4,11 +4,10 @@ import { bootWordPressAndRequestHandler } from "@wp-playground/wordpress"
 import type { MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { createServer as createHttpServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http"
 import { dirname } from "node:path"
-import { playgroundRuntimeBlueprint } from "./blueprint.js"
+import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl } from "./blueprint.js"
 import { assertPhpWasmExternalExtensionsSupported } from "./php-wasm-preflight.js"
 import { phpEnvAssignments } from "./php-snippets.js"
 import type { PlaygroundCliServer, PlaygroundServerRunResponse } from "./preview-server.js"
-import { playgroundSiteSeedPrimaryUrl } from "./site-seed-multisite.js"
 
 const { createNodeFsMountHandler, loadNodeRuntime } = PHPWasmNode as unknown as {
   createNodeFsMountHandler(localPath: string): unknown
@@ -56,7 +55,7 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
     createPhpRuntime: () => loadNodeRuntime(phpVersion, programmaticNodeRuntimeOptions(spec, nextProcessId++)),
     maxPhpInstances: 1,
     phpVersion,
-    siteUrl: playgroundSiteSeedPrimaryUrl(spec) ?? spec.preview?.siteUrl ?? "http://127.0.0.1",
+    siteUrl: playgroundRuntimeSiteUrl(spec) ?? "http://127.0.0.1",
     documentRoot: "/wordpress",
     sapiName: "cli",
     wordpressInstallMode: options.wordpressInstallMode ?? "install-from-existing-files",

--- a/tests/playground-runtime-multisite.test.ts
+++ b/tests/playground-runtime-multisite.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+
+import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl } from "../packages/runtime-playground/src/blueprint.js"
+
+const spec = {
+  backend: "wordpress-playground",
+  environment: { version: "latest", blueprint: { steps: [{ step: "enableMultisite" }] } },
+  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.wp-cli"], secrets: "none", approvals: "never" },
+} as RuntimeCreateSpec
+
+assert.equal(playgroundRuntimeSiteUrl(spec), "http://127.0.0.1")
+assert.deepEqual(playgroundRuntimeBlueprint(spec), {
+  extraLibraries: ["wp-cli"],
+  steps: [
+    { step: "defineSiteUrl", siteUrl: "http://127.0.0.1" },
+    { step: "enableMultisite" },
+  ],
+})
+
+const explicitSiteUrlSpec = structuredClone(spec)
+explicitSiteUrlSpec.environment.blueprint = {
+  steps: [
+    { step: "defineSiteUrl", siteUrl: "http://network.example.test" },
+    { step: "enableMultisite" },
+  ],
+}
+assert.equal(playgroundRuntimeSiteUrl(explicitSiteUrlSpec), undefined, "an explicit pre-multisite URL remains authoritative")
+
+const explicitPreviewSpec = { ...spec, preview: { siteUrl: "http://preview.example.test" } }
+assert.equal(playgroundRuntimeSiteUrl(explicitPreviewSpec), "http://preview.example.test")
+
+console.log("playground runtime multisite URL contract ok")

--- a/tests/runtime-backed-multisite-workload.integration.test.ts
+++ b/tests/runtime-backed-multisite-workload.integration.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { runCli } from "../packages/cli/src/cli-entry.js"
+
+process.env.WP_CODEBOX_NO_JSPI_RESPAWN = "1"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-runtime-multisite-"))
+try {
+  const pluginSource = join(root, "network-fixture")
+  const suitePath = join(root, "suite.json")
+  const artifactsPath = join(root, "artifacts")
+  await mkdir(pluginSource)
+  await writeFile(join(pluginSource, "network-fixture.php"), `<?php
+/*
+Plugin Name: Runtime Multisite Fixture
+Network: true
+*/
+`, "utf8")
+  await writeFile(suitePath, JSON.stringify({
+    schema: "wp-codebox/fuzz-suite/v1",
+    id: "runtime-backed-multisite",
+    metadata: {
+      runtime_requirements: {
+        blueprint: { preferredVersions: { php: "8.4", wp: "latest" }, steps: [{ step: "enableMultisite" }] },
+        extra_plugins: [{ source: pluginSource, slug: "network-fixture", pluginFile: "network-fixture/network-fixture.php", activate: true, loadAs: "plugin" }],
+      },
+    },
+    cases: [{
+      id: "multisite-workload",
+      target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" },
+      input: {
+        schema: "wp-codebox/wordpress-workload-run/v1",
+        blueprint: { preferredVersions: { php: "8.4", wp: "latest" }, steps: [{ step: "enableMultisite" }] },
+        steps: [
+          { command: "wordpress.wp-cli", args: ["command=wp eval 'echo wp_json_encode( array( \\\"marker\\\" => \\\"WORKLOAD_REACHED\\\", \\\"multisite\\\" => is_multisite(), \\\"network_active\\\" => is_plugin_active_for_network( \\\"network-fixture/network-fixture.php\\\" ) ) );'"] },
+          { command: "wordpress.browser-probe", args: ["url=/", "capture=html,screenshot", "script=return { title: document.title };"] },
+        ],
+      },
+    }],
+  }), "utf8")
+
+  const output = await captureStdout(() => runCli(["run-fuzz-suite", "--input-file", suitePath, "--format=json", "--runner-mode=runtime-backed", "--artifacts", artifactsPath]))
+  const result = JSON.parse(output)
+  assert.equal(result.status, "passed", output)
+  assert.equal(result.cases[0]?.status, "passed", output)
+  const recipeResult = result.cases[0]?.metadata?.execution?.result?.json
+  const wpCliExecution = recipeResult?.executions?.find((execution: { command?: string }) => execution.command === "wordpress.wp-cli")
+  assert.deepEqual(JSON.parse(wpCliExecution?.stdout ?? "{}"), { marker: "WORKLOAD_REACHED", multisite: true, network_active: true })
+  const browserExecution = recipeResult?.executions?.find((execution: { command?: string }) => execution.command === "wordpress.browser-probe")
+  assert.equal(browserExecution?.exitCode, 0)
+  const browserResult = JSON.parse(browserExecution?.stdout ?? "{}")
+  assert.ok(JSON.stringify(browserResult).includes("screenshot"), browserExecution?.stdout)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (/Unable to resolve Playground startup asset.*fetch failed|Could not resolve host|network is unreachable/i.test(message)) {
+    console.log("runtime-backed multisite workload integration skipped: WordPress runtime source unavailable")
+  } else {
+    throw error
+  }
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+async function captureStdout(callback: () => Promise<number>): Promise<string> {
+  const chunks: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"))
+    return true
+  }) as typeof process.stdout.write
+  try {
+    assert.equal(await callback(), 0)
+  } finally {
+    process.stdout.write = originalWrite
+  }
+  return chunks.join("")
+}


### PR DESCRIPTION
## Summary

- Give Playground runtimes a portless loopback site URL when a blueprint enables multisite without declaring one, while retaining the random-port preview proxy.
- Activate mounted `Network: true` plugins network-wide once the disposable runtime is multisite.
- Cover blueprint normalization and a full runtime-backed fuzz workload through WP-CLI, browser probing, and screenshot capture.

Closes #2315.

## Root cause

WP Codebox passed the random `127.0.0.1:<port>` preview origin to Playground as the WordPress site URL. Playground's standard `enableMultisite` step reads its current absolute URL and rejects any custom port before WP Codebox can execute workload commands. Playground already provides the owning primitives: its CLI `site-url` option and Blueprint `defineSiteUrl` step. WP Codebox's Playground adapter owns translating a generic runtime request into those runtime-specific inputs, so the fix belongs there rather than in fuzz workloads or host WordPress.

After that startup barrier was removed, the runtime setup path still passed `network_wide=false` to `activate_plugin()`, which could not honor mounted network-only plugin contracts. Runtime setup now derives network activation from WordPress's `is_network_only_plugin()` API instead of bypassing the plugin header check.

## Before / after

Before, a runtime-backed workload with `enableMultisite` failed before its first command:

```text
The current host is 127.0.0.1:56276, but WordPress multisites do not support custom ports.
```

After, WP Codebox uses `http://127.0.0.1` as the internal WordPress/Blueprint URL only when multisite needs a portless URL and no explicit URL precedes the multisite step. The disposable preview continues listening on a random `127.0.0.1:<port>`. The original reproduction now completes with `success: true`, `wordpress.wp-cli` exit code `0`, and stdout `WORKLOAD_REACHED`.

## Changes

- `packages/runtime-playground/src/blueprint.ts`: resolve an internal portless URL from existing site-seed/preview declarations or the presence of `enableMultisite`, and inject Playground's existing `defineSiteUrl` step.
- `packages/runtime-playground/src/playground-cli-runner.ts`: pass that same resolved URL through Playground CLI's supported `site-url` option.
- `packages/runtime-playground/src/programmatic-playground-runner.ts`: keep the programmatic runner aligned with the same URL resolution.
- `packages/cli/src/commands/recipe-runtime-setup.ts`: activate network-only plugins network-wide using WordPress core header detection.
- `tests/playground-runtime-multisite.test.ts`: cover automatic, explicit Blueprint, and explicit preview URL behavior.
- `tests/runtime-backed-multisite-workload.integration.test.ts`: prove a runtime-backed fuzz case reaches WP-CLI in multisite, observes network activation, reaches a random-port browser preview, and records screenshot evidence.

This is the smallest owning-layer fix: it reuses Playground's URL controls and WordPress's plugin APIs, without adding a new preview transport, changing the multisite contract, or touching the host site.

## Verification

- `npm run build` - passed.
- `npm run test:playground-runtime-multisite` - passed.
- `npm run test:site-seed-multisite` - passed.
- `npm run test:recipe-runtime-setup-staged-materialization` - passed.
- `npm exec -- tsx tests/phpunit-project-autoload.test.ts` - passed.
- `npm run test:runtime-backed-multisite-workload-integration` - passed with multisite/network activation assertions and browser screenshot evidence.
- `npm run test:playground-mapped-domain-multisite-integration` - passed.
- `npm exec -- tsx tests/public-fuzz-workload-cli.test.ts` - passed.
- `git diff --check` - passed.
- Original random-port recipe reproduction - passed with `WORKLOAD_REACHED`.

## Residual limitations

The integration proves local random-port proxy behavior and browser artifact capture. It does not request an externally tunneled/public preview lease; that lease layer remains unchanged by this patch.