### PR TITLE
fix(preview): support packaged Playground worker remote

### DIFF
--- a/packages/runtime-playground/src/preview-proxy-request-trace.ts
+++ b/packages/runtime-playground/src/preview-proxy-request-trace.ts
@@ -18,13 +18,18 @@ export interface PlaygroundPreviewProxyRequestTraceEntry {
   path: string
   destination: string | null
   serviceWorker: boolean
+  workerModule?: boolean
   outcome: "response" | "upstream-error" | "client-canceled" | "canceled-before-upstream"
   status?: number
+  contentType?: string
+  contentLength?: string
+  serviceWorkerAllowed?: string
+  bodyRewritten?: boolean
   upstreamLocation?: string
   visibleLocation?: string
 }
 
-export type PlaygroundPreviewProxyRequestOutcome = Pick<PlaygroundPreviewProxyRequestTraceEntry, "outcome" | "status" | "upstreamLocation" | "visibleLocation">
+export type PlaygroundPreviewProxyRequestOutcome = Pick<PlaygroundPreviewProxyRequestTraceEntry, "outcome" | "status" | "contentType" | "contentLength" | "serviceWorkerAllowed" | "bodyRewritten" | "upstreamLocation" | "visibleLocation">
 
 export function createPreviewProxyRequestTrace(): PlaygroundPreviewProxyRequestTrace {
   return { scope: "service-worker-and-failed-script", capacity: PREVIEW_PROXY_REQUEST_TRACE_CAPACITY, total: 0, dropped: 0, entries: [] }
@@ -37,7 +42,8 @@ export function snapshotPreviewProxyRequestTrace(trace: PlaygroundPreviewProxyRe
 export function recordPreviewProxyRequest(trace: PlaygroundPreviewProxyRequestTrace, incoming: IncomingMessage, path: string, outcome: PlaygroundPreviewProxyRequestOutcome): void {
   const destination = previewProxyFetchDestination(incoming.headers["sec-fetch-dest"])
   const serviceWorker = incoming.headers["service-worker"] === "script" || destination === "serviceworker"
-  if (!serviceWorker && !isServiceWorkerScriptPath(path) && !isFailedScriptRequest(destination, outcome)) {
+  const workerModule = isPreviewProxyServiceWorkerModuleRequest(incoming, destination)
+  if (!serviceWorker && !workerModule && !isServiceWorkerScriptPath(path) && !isFailedScriptRequest(destination, outcome)) {
     return
   }
 
@@ -48,8 +54,13 @@ export function recordPreviewProxyRequest(trace: PlaygroundPreviewProxyRequestTr
     path: redactPreviewProxyUrl(path),
     destination,
     serviceWorker,
+    ...(workerModule ? { workerModule: true } : {}),
     outcome: outcome.outcome,
     ...(outcome.status !== undefined ? { status: outcome.status } : {}),
+    ...(outcome.contentType ? { contentType: outcome.contentType } : {}),
+    ...(outcome.contentLength ? { contentLength: outcome.contentLength } : {}),
+    ...(outcome.serviceWorkerAllowed ? { serviceWorkerAllowed: outcome.serviceWorkerAllowed } : {}),
+    ...(outcome.bodyRewritten !== undefined ? { bodyRewritten: outcome.bodyRewritten } : {}),
     ...(outcome.upstreamLocation ? { upstreamLocation: redactPreviewProxyUrl(outcome.upstreamLocation) } : {}),
     ...(outcome.visibleLocation ? { visibleLocation: redactPreviewProxyUrl(outcome.visibleLocation) } : {}),
   })
@@ -69,6 +80,23 @@ export function isPreviewProxyServiceWorkerRequest(incoming: IncomingMessage, pa
 
 export function isPreviewProxyServiceWorkerRegistrationRequest(incoming: IncomingMessage): boolean {
   return incoming.method === "GET" && (incoming.headers["service-worker"] === "script" || previewProxyFetchDestination(incoming.headers["sec-fetch-dest"]) === "serviceworker")
+}
+
+function isPreviewProxyServiceWorkerModuleRequest(incoming: IncomingMessage, destination = previewProxyFetchDestination(incoming.headers["sec-fetch-dest"])): boolean {
+  if (destination !== "script") {
+    return false
+  }
+
+  const referrer = headerValue(incoming.headers.referer)
+  if (!referrer) {
+    return false
+  }
+
+  try {
+    return new URL(referrer).pathname.endsWith("/sw.js")
+  } catch {
+    return false
+  }
 }
 
 function redactPreviewProxyUrl(value: string): string {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -1,4 +1,5 @@
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http"
+import { request as httpsRequest } from "node:https"
 import { createServer as createNetServer } from "node:net"
 import { Transform } from "node:stream"
 import type { PreviewLease } from "@automattic/wp-codebox-core"
@@ -214,7 +215,8 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
       settle()
     }
     const sendUpstreamRequest = () => {
-      targetRequest = httpRequest({
+      const request = target.protocol === "https:" ? httpsRequest : httpRequest
+      targetRequest = request({
         protocol: target.protocol,
         hostname: target.hostname,
         port: target.port,
@@ -224,9 +226,14 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
       }, (response) => {
         targetResponse = response
         const headers = proxyResponseHeaders(response.headers, requestTarget, target)
+        const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target)
         const responseOutcome: PlaygroundPreviewProxyRequestOutcome = {
           outcome: "response",
           status: response.statusCode ?? 502,
+          contentType: headerValue(headers["content-type"]),
+          contentLength: headerValue(headers["content-length"]),
+          serviceWorkerAllowed: headerValue(headers["service-worker-allowed"]),
+          bodyRewritten: Boolean(bodyTransform),
           upstreamLocation: headerValue(response.headers.location),
           visibleLocation: headerValue(headers.location),
         }
@@ -257,7 +264,6 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
           // Browsers reject and cancel redirected service-worker scripts as soon as headers arrive.
           recordOutcome(responseOutcome)
         }
-        const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target)
         if (bodyTransform) {
           delete headers["content-length"]
           delete headers["content-md5"]

--- a/tests/playground-contained-scope.browser.test.ts
+++ b/tests/playground-contained-scope.browser.test.ts
@@ -148,6 +148,8 @@ test("CLI-started previews preserve browser sessions while credential-less worke
       serviceWorker: false,
       outcome: "response",
       status: 503,
+      contentType: "application/javascript",
+      bodyRewritten: true,
     })
     assert.doesNotMatch(JSON.stringify(trace), /PRIVATE_WORKER_TOKEN|PRIVATE_DYNAMIC_IMPORT_TOKEN|browser_session/)
   } finally {

--- a/tests/service-worker-preview-proxy.browser.test.ts
+++ b/tests/service-worker-preview-proxy.browser.test.ts
@@ -57,10 +57,75 @@ test("the preview proxy registers a service worker after transient upstream redi
       serviceWorker: true,
       outcome: "response",
       status: 200,
+      contentType: "application/javascript",
+      bodyRewritten: true,
     }])
   } finally {
     await browser.close()
     await proxy[Symbol.asyncDispose]()
     await closeHttpServer(upstream)
+  }
+})
+
+test("the preview proxy returns a connected client from the packaged Playground remote", { timeout: 60_000 }, async () => {
+  const app = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html" })
+    response.end("<!doctype html><title>Playground proxy integration</title>")
+  })
+  const appUrl = await listenLocalHttpServer(app)
+  const proxy = await withPreviewProxy({
+    playground: { async run() { return { text: "", exitCode: 0 } } },
+    serverUrl: "https://playground.wordpress.net",
+    async [Symbol.asyncDispose]() {},
+  } satisfies PlaygroundCliServer, 5400)
+  const browser = await chromium.launch({ headless: true })
+  const consoleMessages: string[] = []
+  const pageErrors: string[] = []
+  try {
+    const page = await browser.newPage()
+    page.on("console", (message) => {
+      if (consoleMessages.length < 32) consoleMessages.push(`${message.type()}: ${message.text()}`)
+    })
+    page.on("pageerror", (error) => {
+      if (pageErrors.length < 32) pageErrors.push(error.message)
+    })
+    await page.goto(appUrl)
+    const startup = page.evaluate(async (remoteUrl) => {
+      const { startPlaygroundWeb } = await import("https://playground.wordpress.net/client/index.js")
+      const iframe = document.createElement("iframe")
+      document.body.append(iframe)
+      const client = await startPlaygroundWeb({
+        iframe,
+        remoteUrl,
+        corsProxyUrl: "https://wordpress-playground-cors-proxy.net/?",
+        blueprint: { steps: [] },
+      })
+      await client.isConnected()
+      return { connected: true, url: await client.getCurrentURL() }
+    }, `${proxy.serverUrl}/remote.html`)
+    const result: { connected?: boolean; url?: string; error?: string; timeout?: true } = await Promise.race([
+      startup.catch((error: Error) => ({ error: error.message })),
+      new Promise<{ timeout: true }>((resolve) => setTimeout(() => resolve({ timeout: true }), 45_000)),
+    ])
+    const trace = proxy.previewProxyDiagnostics?.requestTrace
+
+    assert.equal(result.connected, true, JSON.stringify({ consoleMessages, pageErrors, trace }, null, 2))
+    assert.equal(typeof result.url, "string", JSON.stringify({ consoleMessages, pageErrors, trace }, null, 2))
+    assert.deepEqual(pageErrors, [], JSON.stringify({ consoleMessages, trace }, null, 2))
+    assert.deepEqual(consoleMessages.filter((message) => /service worker|worker script|failed to load/i.test(message)), [], JSON.stringify({ pageErrors, trace }, null, 2))
+    const workerResponse = trace?.entries.find((entry) => entry.path === "/sw.js" && entry.serviceWorker)
+    assert.deepEqual(workerResponse && {
+      status: workerResponse.status,
+      contentType: workerResponse.contentType,
+      bodyRewritten: workerResponse.bodyRewritten,
+    }, {
+      status: 200,
+      contentType: "application/javascript",
+      bodyRewritten: true,
+    })
+  } finally {
+    await browser.close()
+    await proxy[Symbol.asyncDispose]()
+    await closeHttpServer(app)
   }
 })


### PR DESCRIPTION
## Summary
- select the HTTPS client transport when the preview proxy targets an HTTPS packaged Playground remote
- record bounded worker response metadata and worker-module import traces without retaining response bodies or URL query values
- prove Chromium can start the packaged remote through the preview proxy, receive a connected client, and make a client RPC

## Testing
- `npm run build`
- `npm run test:service-worker-preview-proxy`
- `npm run test:playground-contained-scope`

Fixes #2305

AI assistance: OpenCode using OpenAI gpt-5.6-sol diagnosed the proxy transport and worker evaluation boundary, implemented the fix and Chromium coverage, and ran the focused tests. Chris Huber reviewed and remains responsible for this change.