### PR TITLE
fix(preview): serialize requests across listeners

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -91,15 +91,18 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   const target = new URL(targetUrl)
   const routes = createPreviewRouteRegistry()
   const requestTrace = createPreviewProxyRequestTrace()
-  const proxy = previewProxyServer(target, routes, requestTrace)
+  const upstreamQueue = createPreviewProxyQueue()
+  const proxy = previewProxyServer(target, routes, requestTrace, upstreamQueue)
   const servers = [proxy]
 
   await listenPreviewProxy(proxy, port, bind)
+  const address = proxy.address()
+  const resolvedPort = address && typeof address === "object" ? address.port : port
 
   if (bind === "127.0.0.1") {
-    const ipv6Proxy = previewProxyServer(target, routes, requestTrace)
+    const ipv6Proxy = previewProxyServer(target, routes, requestTrace, upstreamQueue)
     try {
-      await listenPreviewProxy(ipv6Proxy, port, "::1")
+      await listenPreviewProxy(ipv6Proxy, resolvedPort, "::1")
       servers.push(ipv6Proxy)
     } catch (error) {
       if (!errorHasCode(error, "EADDRNOTAVAIL")) {
@@ -109,8 +112,6 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
     }
   }
 
-  const address = proxy.address()
-  const resolvedPort = address && typeof address === "object" ? address.port : port
   const reportedHost = bind === "0.0.0.0" ? "127.0.0.1" : bind
 
   return {
@@ -133,9 +134,7 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   }
 }
 
-function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry, requestTrace: PlaygroundPreviewProxyRequestTrace): PreviewProxyServer {
-  const upstreamQueue = createPreviewProxyQueue()
-
+function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry, requestTrace: PlaygroundPreviewProxyRequestTrace, upstreamQueue: ReturnType<typeof createPreviewProxyQueue>): PreviewProxyServer {
   return createHttpServer(async (incoming, outgoing) => {
     try {
       if (await routes.handle(incoming, outgoing)) {

--- a/tests/service-worker-preview-proxy.browser.test.ts
+++ b/tests/service-worker-preview-proxy.browser.test.ts
@@ -67,6 +67,86 @@ test("the preview proxy registers a service worker after transient upstream redi
   }
 })
 
+test("one UI action queues same-origin requests across preview listeners", async () => {
+  let activeUpstreamRequests = 0
+  let releaseHeldRequest: (() => void) | undefined
+  let heldRequestReached: (() => void) | undefined
+  const heldRequest = new Promise<void>((resolve) => {
+    heldRequestReached = resolve
+  })
+  const upstream = createServer(async (request, response) => {
+    activeUpstreamRequests += 1
+    if (activeUpstreamRequests > 1) {
+      activeUpstreamRequests -= 1
+      response.writeHead(503, { "content-type": "text/plain" })
+      response.end("serialized Playground is busy")
+      return
+    }
+
+    if (request.url === "/hold") {
+      heldRequestReached?.()
+      await new Promise<void>((resolve) => {
+        releaseHeldRequest = resolve
+      })
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    }
+    activeUpstreamRequests -= 1
+
+    if (request.url === "/application-503") {
+      response.writeHead(503, { "content-type": "text/plain", "x-application-response": "true" })
+      response.end("application unavailable")
+      return
+    }
+    if (request.url === "/") {
+      response.writeHead(200, { "content-type": "text/html" })
+      response.end(`<!doctype html><button id="load">Load tab</button><output></output><script>
+        document.querySelector('#load').addEventListener('click', async () => {
+          const responses = await Promise.all(['/data/one', '/data/two'].map((path) => fetch(path)))
+          document.querySelector('output').textContent = responses.map((item) => item.status).join(',')
+        })
+      </script>`)
+      return
+    }
+    response.end("ok")
+  })
+  const upstreamUrl = await listenLocalHttpServer(upstream)
+  const proxy = await withPreviewProxy({
+    playground: { async run() { return { text: "", exitCode: 0 } } },
+    serverUrl: upstreamUrl,
+    async [Symbol.asyncDispose]() {},
+  } satisfies PlaygroundCliServer, 0)
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const port = new URL(proxy.serverUrl).port
+    const ipv6Origin = `http://[::1]:${port}`
+    const page = await browser.newPage()
+    await page.goto(ipv6Origin)
+
+    const heldResponse = fetch(`${proxy.serverUrl}/hold`)
+    await heldRequest
+    await page.click("#load")
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    assert.equal(activeUpstreamRequests, 1, "all preview listeners must share one upstream slot")
+
+    releaseHeldRequest?.()
+    assert.equal(await (await heldResponse).text(), "ok")
+    await page.waitForFunction(() => document.querySelector("output")?.textContent === "200,200")
+    assert.equal(await page.locator("output").textContent(), "200,200")
+
+    const applicationFailure = await page.evaluate(async () => {
+      const response = await fetch("/application-503")
+      return { status: response.status, marker: response.headers.get("x-application-response"), body: await response.text() }
+    })
+    assert.deepEqual(applicationFailure, { status: 503, marker: "true", body: "application unavailable" })
+  } finally {
+    releaseHeldRequest?.()
+    await browser.close()
+    await proxy[Symbol.asyncDispose]()
+    await closeHttpServer(upstream)
+  }
+})
+
 test("the preview proxy returns a connected client from the packaged Playground remote", { timeout: 60_000 }, async () => {
   const app = createServer((_request, response) => {
     response.writeHead(200, { "content-type": "text/html" })


### PR DESCRIPTION
## Summary

- share one FIFO upstream queue across the preview proxy's IPv4 and IPv6 listeners
- bind companion listeners to the resolved primary port when an ephemeral port is requested
- cover a browser click that launches multiple same-origin requests while a serialized upstream is occupied

## Root cause

Each local preview listener constructed its own queue. The diagnostics described the preview as globally serialized with `maxConcurrentUpstreamRequests: 1`, but IPv4 and IPv6 traffic could each acquire an independent upstream slot. A serialized Playground upstream could therefore receive concurrent requests and manufacture `503 Service Unavailable` responses even though the proxy advertised FIFO queueing.

The queue now belongs to the preview instance and is passed to every listener, so all local entry points enforce the same single upstream slot. No overload response or retry layer is added.

## Application responses

The proxy still forwards upstream status codes, headers, and bodies unchanged. The regression sends an intentional application 503 after the concurrency check and verifies its `503` status, marker header, and body in the browser. Console-error oracles and application failure visibility are not filtered or weakened.

## Regression

The browser regression holds an IPv4 proxy request open, loads the same preview through its IPv6 listener, and clicks one button that starts two same-origin fetches. Its serialized upstream emits 503 whenever more than one request reaches it. The test proves the click's requests remain queued until the held request completes, both fetches return 200, and a genuine application 503 remains observable.

## Verification

- `npm ci`
- `npm run test:service-worker-preview-proxy`
- `npm run test:browser-canonical-preview-origin`
- `npm run test:browser-preview-routing`
- `npm run build`

`npm run test:browser-callback-materialization-contracts` was also run on Node 25.7.0. It stops at an existing Node-version-sensitive diagnostics assertion because Node 25 automatically adds response metadata (`content-length` and `bodyRewritten`) before reaching the queue assertions; this patch does not change that response metadata path.

Fixes #2320