### PR TITLE
fix(runtime): keep checkpoint state on a coherent VFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,6 +267,7 @@
     "test:runtime-backed-multisite-workload-integration": "tsx tests/runtime-backed-multisite-workload.integration.test.ts",
     "test:playground-mapped-domain-multisite-integration": "tsx tests/playground-mapped-domain-multisite.integration.test.ts",
     "test:playground-multisite-checkpoint-integration": "tsx tests/playground-multisite-checkpoint.integration.test.ts",
+    "test:playground-checkpoint-maintenance-integration": "tsx tests/playground-checkpoint-maintenance.integration.test.ts",
     "test:runtime-workers": "tsx tests/runtime-workers.test.ts",
     "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
     "test:recipe-runtime-setup-staged-materialization": "tsx tests/recipe-runtime-setup-staged-materialization.test.ts",

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -154,7 +154,8 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           quiet: true,
           verbosity: "quiet",
           skipBrowser: true,
-          workers: spec.environment.workers ?? 6,
+          // Mutable runtime state must stay on one VFS unless callers explicitly opt into worker concurrency.
+          workers: spec.environment.workers ?? 1,
           mount: [
             ...postinstallMounts.map((mount) => ({
               hostPath: mount.source,

--- a/tests/playground-checkpoint-maintenance.integration.test.ts
+++ b/tests/playground-checkpoint-maintenance.integration.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-checkpoint-maintenance-"))
+const recipePath = join(root, "recipe.json")
+const artifactsPath = join(root, "artifacts")
+
+try {
+  const maintenanceCase = (id: string) => ({
+    id,
+    target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" },
+    input: {
+      schema: "wp-codebox/wordpress-workload-run/v1",
+      steps: [
+        {
+          command: "wordpress.run-php",
+          args: ["code=$path=ABSPATH.'.maintenance'; file_put_contents(ABSPATH.'remove-maintenance.php',\"<?php unlink(__DIR__ . '/.maintenance'); echo file_exists(__DIR__ . '/.maintenance') ? 'present' : 'absent';\"); file_put_contents($path,'<?php $upgrading = time();'); clearstatcache(true); file_exists($path); echo 'primed';"],
+        },
+        { command: "wordpress.http-request", args: ["url=/remove-maintenance.php", "expect-status=200"] },
+      ],
+    },
+  })
+  const suite = {
+    schema: "wp-codebox/fuzz-suite/v1",
+    id: "checkpoint-maintenance-coherence",
+    resetPolicy: { mode: "checkpoint-per-case", checkpointName: "maintenance-baseline" },
+    cases: [maintenanceCase("maintenance-one"), maintenanceCase("maintenance-two"), maintenanceCase("maintenance-three")],
+  }
+
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { backend: "wordpress-playground", wp: "nightly", phpVersion: "8.3", blueprint: { steps: [] } },
+    workflow: {
+      steps: [{ command: "wp-codebox/run-fuzz-suite", args: [`input-json=${JSON.stringify(suite)}`] }],
+    },
+  })}\n`)
+
+  const output = await runRecipe()
+  if (output) {
+    assert.equal(output.success, true, JSON.stringify(output))
+    const result = JSON.parse(output.executions?.[0]?.stdout ?? "{}")
+    assert.equal(result.status, "passed", JSON.stringify(result))
+    assert.deepEqual(result.cases.map((fuzzCase: { reset?: { mode?: string; status?: string } }) => [fuzzCase.reset?.mode, fuzzCase.reset?.status]), [
+      ["checkpoint-per-case", "passed"],
+      ["checkpoint-per-case", "passed"],
+      ["checkpoint-per-case", "passed"],
+    ])
+    for (const fuzzCase of result.cases) {
+      assert.equal(JSON.stringify(fuzzCase).includes("absent"), true, JSON.stringify(fuzzCase))
+    }
+  }
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+async function runRecipe(): Promise<RecipeRunOutput | undefined> {
+  try {
+    const result = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--artifacts", artifactsPath, "--json"], {
+      cwd: process.cwd(),
+      timeout: 300_000,
+      maxBuffer: 4 * 1024 * 1024,
+    })
+    return JSON.parse(result.stdout) as RecipeRunOutput
+  } catch (error) {
+    const output = recipeRunOutput(error && typeof error === "object" && "stdout" in error ? error.stdout : undefined)
+    const message = output?.phaseEvidence?.find((phase) => phase.name === "runtime_startup")?.error?.message ?? ""
+    if (/Unable to resolve Playground startup asset.*fetch failed|Could not resolve host|network is unreachable/i.test(message)) {
+      console.log("playground checkpoint maintenance integration skipped: WordPress runtime source unavailable")
+      return undefined
+    }
+    if (output?.executions?.[0]?.stdout) {
+      const result = JSON.parse(output.executions[0].stdout) as { cases?: unknown }
+      throw new Error(`Checkpoint maintenance fuzz failure: ${JSON.stringify(result.cases)}`)
+    }
+    throw error
+  }
+}
+
+function recipeRunOutput(value: unknown): RecipeRunOutput | undefined {
+  if (typeof value !== "string") return undefined
+  try { return JSON.parse(value) as RecipeRunOutput } catch { return undefined }
+}
+
+interface RecipeRunOutput {
+  success?: boolean
+  executions?: Array<{ stdout: string }>
+  phaseEvidence?: Array<{ name?: string; error?: { message?: string } }>
+}
+
+console.log("playground checkpoint maintenance integration ok")


### PR DESCRIPTION
## Summary
- default mutable Playground runtimes to one worker so checkpoint state, PHP stat caches, and the worker VFS cannot diverge
- preserve explicit worker-count configuration for callers that intentionally opt into concurrency
- add a WordPress nightly/PHP 8.3 regression that repeatedly restores a checkpoint after cross-request `.maintenance` creation and deletion

## Root cause
WP Codebox defaulted Playground CLI runtimes to six workers. Playground workers retain independent PHP filesystem/stat state over a shared mutable site. A case could cache `/wordpress/.maintenance` as present on one worker while another worker removed the file. A later checkpoint restore or workload scheduled on the stale worker made WordPress core's `file_exists()` pass and the immediately following `require` fail before structured output.

This is a runtime ownership issue rather than a fuzz consumer issue. Keeping mutable runtime state on one VFS by default removes the incoherent state for checkpoints and all other stateful runtime commands. Callers can still explicitly configure more workers where they accept the concurrency semantics.

## Regression
The new integration runs a real recipe-backed `checkpoint-per-case` fuzz suite for three cases on WordPress nightly and PHP 8.3. Each case creates and caches `.maintenance`, removes it through a separate HTTP request, and verifies absence. With the previous six-worker default, the negative control reproduced the exact `wp-includes/load.php:444` missing-file fatal. With this change, all three resets and cases pass with structured output.

## Tests
- `npm run build`
- `npm run test:playground-checkpoint-maintenance-integration`
- `npm run test:playground-multisite-checkpoint-integration`
- `npm run test:runtime-workers`
- `npx tsx tests/runtime-checkpoint-primitives.test.ts`
- `npx tsx tests/nested-fuzz-suite-recipe-command.test.ts`
- `npx tsx tests/playground-public-runtime-primitives.test.ts`

Fixes #2318