### PR TITLE
fix(cli): preserve trusted workload command fields

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -301,8 +301,10 @@ WordPress-hosted orchestration that shells through WP-CLI can use the matching
 `runtime descriptor`, `run-runtime-task`, `run-wordpress-workload`,
 `run-runtime-package`, `resolve-runtime-requirements`, `run-fuzz-suite`, and
 artifact inspection/apply commands. The WP-CLI wrappers parse JSON payloads from
-`--input-json` or `--input-file` and delegate through
-`WP_Codebox_API` rather than backend internals.
+`--input-json` or `--input-file`. Most delegate through `WP_Codebox_API`;
+`run-wordpress-workload` and `run-fuzz-suite` invoke their owning PHP runners
+directly because WP-CLI is a trusted operator transport. Their Ability and
+`WP_Codebox_API` surfaces retain the raw-execution input guard.
 
 The workspace package mirrors the core entrypoints as `./core`,
 `./core/public`, `./core/contracts`, `./core/artifacts`, `./core/run-results`,

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -315,9 +315,9 @@ list. CLI output is JSON-first for automation.
 
 WP-CLI commands run in trusted operator context. They do not call the Ability
 permission callbacks; shell/WP-CLI access is the permission boundary. The command
-methods delegate to the same PHP services as Abilities, so validation, artifact
-digest checks, pending-action staging, apply adapters, and runner errors behave
-the same way.
+methods delegate to the same PHP services as Abilities without entering the
+Ability-only raw-execution guard, so validation, artifact digest checks,
+pending-action staging, apply adapters, and runner errors behave the same way.
 
 The `run-fuzz-suite` wrapper exposes the same public fuzz-suite contract as
 `WP_Codebox_API::run_fuzz_suite()`. Its WordPress-plugin execution path reports

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -160,14 +160,14 @@ final class WP_Codebox_CLI_Command {
 	}
 
 	/**
-	 * Run a safe WordPress workload through the public API facade.
+	 * Run a WordPress workload in trusted operator context.
 	 *
 	 * @param array<int,string>   $args       Positional arguments.
 	 * @param array<string,mixed> $assoc_args Associated arguments.
 	 */
 	public function run_wordpress_workload( array $args, array $assoc_args ): void {
 		unset( $args );
-		$this->emit( WP_Codebox_API::run_wordpress_workload( $this->input_from_args( $assoc_args ) ), $assoc_args );
+		$this->emit( ( new WP_Codebox_WordPress_Workload_Runner() )->run( $this->input_from_args( $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -204,14 +204,14 @@ final class WP_Codebox_CLI_Command {
 	}
 
 	/**
-	 * Run a public fuzz suite through the public API facade.
+	 * Run a public fuzz suite in trusted operator context.
 	 *
 	 * @param array<int,string>   $args       Positional arguments.
 	 * @param array<string,mixed> $assoc_args Associated arguments.
 	 */
 	public function run_fuzz_suite( array $args, array $assoc_args ): void {
 		unset( $args );
-		$this->emit( WP_Codebox_API::run_fuzz_suite( $this->input_from_args( $assoc_args ) ), $assoc_args );
+		$this->emit( ( new WP_Codebox_Fuzz_Suite_Runner() )->run( $this->input_from_args( $assoc_args ) ), $assoc_args );
 	}
 
 	/**

--- a/scripts/php-cli-command-smoke.php
+++ b/scripts/php-cli-command-smoke.php
@@ -83,6 +83,22 @@ final class WP_Codebox_Abilities {
 	}
 }
 
+final class WP_Codebox_WordPress_Workload_Runner {
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public function run( array $input ): array {
+		$GLOBALS['wp_codebox_runner_calls'][] = array( 'runner' => 'wordpress-workload', 'input' => $input );
+		return array( 'success' => true, 'runner' => 'wordpress-workload', 'input' => $input );
+	}
+}
+
+final class WP_Codebox_Fuzz_Suite_Runner {
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public function run( array $input ): array {
+		$GLOBALS['wp_codebox_runner_calls'][] = array( 'runner' => 'fuzz-suite', 'input' => $input );
+		return array( 'success' => true, 'runner' => 'fuzz-suite', 'input' => $input );
+	}
+}
+
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-api.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-cli-command.php';
 
@@ -155,10 +171,42 @@ expect( 'run_runtime_package' === $runtime_package['call']['method'], 'Runtime p
 expect( 'package' === $runtime_package['call']['input']['goal'], 'input-json payload should be preserved.' );
 expect( 'wp-codebox/runtime-package/v1' === $runtime_package['call']['input']['package']['schema'], 'package flag should decode as JSON object.' );
 
-$fuzz_suite = run_cli_command( 'codebox run-fuzz-suite', array(), array( 'suite' => '{"id":"php-in-process-suite"}', 'cases' => '[{"id":"rest-status"}]' ) );
-expect( 'run_fuzz_suite' === $fuzz_suite['call']['method'], 'Fuzz suite command must dispatch through public API.' );
-expect( 'php-in-process-suite' === $fuzz_suite['call']['input']['suite']['id'], 'suite flag should decode as JSON object.' );
-expect( 'rest-status' === $fuzz_suite['call']['input']['cases'][0]['id'], 'cases flag should decode as JSON array.' );
+$GLOBALS['wp_codebox_runner_calls'] = array();
+WP_CLI::$lines = array();
+WP_Codebox_Abilities::$calls = array();
+$fuzz_suite_input = array(
+	'schema' => 'wp-codebox/fuzz-suite/v1',
+	'id'     => 'trusted-cli-suite',
+	'cases'  => array(
+		array(
+			'id'     => 'workload',
+			'target' => array( 'kind' => 'runtime', 'id' => 'wordpress.run-workload', 'entrypoint' => 'wordpress.run-workload' ),
+			'input'  => array(
+				'schema' => 'wp-codebox/wordpress-workload-run/v1',
+				'steps'  => array( array( 'command' => 'wordpress.wp-cli', 'args' => array( 'command=wp user list' ) ) ),
+			),
+		),
+	),
+);
+WP_CLI::$commands['codebox run-fuzz-suite']( array(), array( 'input-json' => wp_json_encode( $fuzz_suite_input ), 'suite' => '{"id":"php-in-process-suite"}' ) );
+expect( 0 === count( WP_Codebox_Abilities::$calls ), 'Trusted fuzz suite WP-CLI command must not dispatch through the Ability facade.' );
+expect( 1 === count( $GLOBALS['wp_codebox_runner_calls'] ), 'Trusted fuzz suite WP-CLI command must invoke its owning runner.' );
+expect( 'fuzz-suite' === $GLOBALS['wp_codebox_runner_calls'][0]['runner'], 'Fuzz suite WP-CLI command must use the fuzz suite runner.' );
+expect( 'php-in-process-suite' === $GLOBALS['wp_codebox_runner_calls'][0]['input']['suite']['id'], 'Fuzz suite flag should decode as a JSON object.' );
+expect( 'wordpress.wp-cli' === $GLOBALS['wp_codebox_runner_calls'][0]['input']['cases'][0]['input']['steps'][0]['command'], 'Fuzz suite WP-CLI command must preserve schema-owned workload command fields.' );
+
+$GLOBALS['wp_codebox_runner_calls'] = array();
+WP_CLI::$lines = array();
+WP_Codebox_Abilities::$calls = array();
+$workload_input = array(
+	'schema' => 'wp-codebox/wordpress-workload-run/v1',
+	'steps'  => array( array( 'command' => 'wordpress.wp-cli', 'args' => array( 'command=wp option get home' ) ) ),
+);
+WP_CLI::$commands['codebox run-wordpress-workload']( array(), array( 'input-json' => wp_json_encode( $workload_input ) ) );
+expect( 0 === count( WP_Codebox_Abilities::$calls ), 'Trusted workload WP-CLI command must not dispatch through the Ability facade.' );
+expect( 1 === count( $GLOBALS['wp_codebox_runner_calls'] ), 'Trusted workload WP-CLI command must invoke its owning runner.' );
+expect( 'wordpress-workload' === $GLOBALS['wp_codebox_runner_calls'][0]['runner'], 'Workload WP-CLI command must use the workload runner.' );
+expect( 'wordpress.wp-cli' === $GLOBALS['wp_codebox_runner_calls'][0]['input']['steps'][0]['command'], 'Workload WP-CLI command must preserve schema-owned command fields.' );
 
 $requirements = run_cli_command( 'codebox resolve-runtime-requirements', array(), array( 'runtime-provider' => 'local', 'capabilities' => 'php-in-process,rest' ) );
 expect( 'resolve_runtime_requirements' === $requirements['call']['method'], 'Requirements command must dispatch through public API.' );


### PR DESCRIPTION
## Summary

- route the trusted `wp codebox run-wordpress-workload` and `wp codebox run-fuzz-suite` wrappers directly to their owning PHP runners
- keep `WP_Codebox_API` and Ability execution behind the existing fail-closed raw-execution guard
- add regression coverage for schema-owned `steps[].command` fields through both WP-CLI wrappers

Closes #2324.

## Root cause and boundary

The two trusted-operator WP-CLI methods called `WP_Codebox_API`, which delegates to `WP_Codebox_Abilities`. That made the shell/WP-CLI transport enter an Ability-facing raw-execution guard even though the plugin documents shell access as the WP-CLI permission boundary.

The guard remains correct for Ability and public PHP facade calls: it rejects the top-level `command` escape hatch and recursively rejects `code`, `php`, `php_code`, `raw_code`, `eval`, and `shell` outside opaque metadata. The fix does not broaden that checker or globally allow arbitrary `command` keys. It moves only these two trusted WP-CLI methods to the existing workload and fuzz runner services, matching the documented transport boundary.

Schema-owned workload commands are safe on this path because they are interpreted by the existing workload/fuzz contracts and runner command policies in trusted operator context. Raw Ability input still fails before either runner is invoked.

## Behavior

| Surface | Before | After |
| --- | --- | --- |
| WP-CLI workload/fuzz wrappers | Entered `WP_Codebox_API` and the Ability raw-execution guard | Invoke the owning PHP runner directly and preserve valid schema-owned workload commands |
| Ability and `WP_Codebox_API` | Rejected top-level command escapes and recursive raw-code fields | Unchanged; still fail closed |
| Native Node CLI | Executed runtime-backed suites without the WordPress Ability guard | Unchanged |

The supplied native artifact evidence shows the runtime-backed path completed successfully and executed three `wordpress.wp-cli` steps. On the current checkout, a minimal installed-plugin nested-command reproduction reached the PHP runner and returned the expected runtime-backed-mode-unavailable envelope rather than the issue's rejection; the underlying transport misrouting was still present and is now covered explicitly by asserting that trusted WP-CLI never enters the Ability facade.

## Verification

Passed:

- `php -l packages/wordpress-plugin/src/class-wp-codebox-cli-command.php`
- `php -l scripts/php-cli-command-smoke.php`
- `npm ci` (install and forced release build passed; npm reported 4 existing high-severity audit findings)
- `npm run build`
- `npm run test:php-cli-command`
- `php -d zend.assertions=1 -d assert.exception=1 scripts/php-wordpress-workload-runner-smoke.php`
- `npm run test:php-fuzz-suite-runner`
- `npm run test:wordpress-plugin-public-runtime-abilities`
- `npm run test:public-api-contract`
- `npm run test:production-boundary-enforcement`
- `npm run test:runtime-contract-manifest`
- `npm run test:public-ability-aliases`
- `git diff --check`

Existing unrelated failure:

- `npm run test:docs-boundary-language` fails on unchanged `docs/agent-task-reusable-workflow.md` examples containing `agents/...`; this branch does not modify that file or introduce the match.

## Residual limitations

- The WordPress-plugin fuzz runner remains PHP in-process only. Runtime-backed fuzz execution still belongs to the native `wp-codebox run-fuzz-suite --runner-mode=runtime-backed` path, as documented.
- This change does not alter runner command policy or permit raw execution through Ability-facing surfaces.