### PR TITLE
fix: preserve adaptive oracle evidence

### DIFF
--- a/packages/cli/src/adversarial-recipe.ts
+++ b/packages/cli/src/adversarial-recipe.ts
@@ -266,7 +266,9 @@ async function executeRecipeAdversarialCase(
   const fuzzCase = Array.isArray(parsed?.cases) ? parseObjectValue(parsed.cases[0]) : undefined
   const diagnostics = Array.isArray(fuzzCase?.diagnostics) ? fuzzCase.diagnostics.flatMap((item) => {
     const diagnostic = parseObjectValue(item)
-    return diagnostic ? [{ code: String(diagnostic.code ?? "fuzz-suite-diagnostic"), message: String(diagnostic.message ?? "Fuzz suite diagnostic"), severity: typeof diagnostic.severity === "string" ? diagnostic.severity : undefined }] : []
+    if (!diagnostic) return []
+    const message = String(diagnostic.message ?? "Fuzz suite diagnostic")
+    return [{ code: adaptiveBrowserDiagnosticCode(String(diagnostic.code ?? "fuzz-suite-diagnostic"), message), message, severity: typeof diagnostic.severity === "string" ? diagnostic.severity : undefined }]
   }) : []
   const artifactRefs = Array.isArray(fuzzCase?.artifactRefs) ? fuzzCase.artifactRefs.flatMap((item) => {
     const ref = parseObjectValue(item)
@@ -297,6 +299,13 @@ async function executeRecipeAdversarialCase(
     stateDigest: createHash("sha256").update(JSON.stringify({ campaignId: declaration.id, status, signals, matrix: plan.matrix })).digest("hex"),
     metadata: { fuzzSuite: parsed, resetPolicy: declaration.resetPolicy ?? { mode: "none" }, faultSchedule: declaration.faultSchedule, ...(smtpSinkResets.length > 0 ? { smtpSinkResets } : {}) },
   }) as AdversarialExecutionObservation
+}
+
+function adaptiveBrowserDiagnosticCode(code: string, message: string): string {
+  if (/Adaptive browser exploration found \d+ reproducible oracle failure/i.test(message)) return "adaptive-browser-oracle-failure"
+  if (/Target page, context or browser has been closed|browser (?:has been |is )?closed/i.test(message)) return "adaptive-browser-runtime-closed"
+  if (/browser[^\n]*(?:cancelled|canceled|aborted)|(?:cancelled|canceled|aborted)[^\n]*browser/i.test(message)) return "adaptive-browser-cancelled"
+  return code
 }
 
 function findIncompleteAdaptiveExploration(value: unknown): { budgetExhausted?: string } | undefined {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -2,7 +2,7 @@ import { stripUndefined } from "./object-utils.js"
 import { planBrowserRandomWalk } from "./browser-interaction.js"
 import { FUZZ_RUNNER_CAPABILITIES_SCHEMA, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzRunnerCapabilitiesContract, fuzzSuiteCaseResetPolicy, fuzzSuiteRequiredRunnerCapabilities, fuzzSuiteResetPolicyDiagnostics, fuzzSuiteResultEnvelope, unsupportedRequiredFuzzRunnerCapabilities, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResetResult, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteResetPolicy, type FuzzSuiteRunnerCapabilities, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
 import { DELETE_BOUNDARY_ARTIFACT_KIND, DELETE_BOUNDARY_ARTIFACT_SCHEMA, MUTATION_ISOLATION_ARTIFACT_KIND, MUTATION_ISOLATION_ARTIFACT_SCHEMA, isRestMutationMethod } from "./mutation-isolation-contracts.js"
-import { RuntimeActionExecutionError, type RuntimeAction, type RuntimeActionObservation } from "./runtime-action-adapter.js"
+import type { RuntimeAction, RuntimeActionObservation } from "./runtime-action-adapter.js"
 import type { ExecutionResult, ExecutionSpec, RuntimeCommandDiagnosticsCaptureSpec, RuntimeEpisodeTraceRef, WorkspaceRecipeStep } from "./runtime-contracts.js"
 import { WORDPRESS_CRUD_OPERATION_SCHEMA, normalizeWordPressCrudOperation } from "./wordpress-crud-contracts.js"
 import { WORDPRESS_DB_OPERATION_SCHEMA, normalizeWordPressDbOperation } from "./wordpress-db-contracts.js"
@@ -370,6 +370,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
           target,
           reset,
           diagnostics: [diagnostic],
+          artifactRefs: fuzzSuiteErrorArtifactRefs(error),
           metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-workload", executorKind: "episode" } }),
         })
       }
@@ -1446,9 +1447,21 @@ function fuzzSuiteRuntimeActionArtifactRefs(observation: RuntimeActionObservatio
 }
 
 function fuzzSuiteRuntimeActionErrorArtifactRefs(error: unknown): FuzzSuiteArtifactRef[] | undefined {
-  if (!(error instanceof RuntimeActionExecutionError)) return undefined
-  const refs = error.artifactRefs.map(fuzzSuiteArtifactRefFromTrace).filter((ref): ref is FuzzSuiteArtifactRef => Boolean(ref))
-  return refs.length > 0 ? refs : undefined
+  return fuzzSuiteErrorArtifactRefs(error)
+}
+
+function fuzzSuiteErrorArtifactRefs(error: unknown): FuzzSuiteArtifactRef[] | undefined {
+  const refs: FuzzSuiteArtifactRef[] = []
+  const visited = new Set<unknown>()
+  let current: unknown = error
+  while (current && typeof current === "object" && !visited.has(current)) {
+    visited.add(current)
+    const record = current as { artifactRefs?: unknown; cause?: unknown }
+    if (Array.isArray(record.artifactRefs)) refs.push(...record.artifactRefs.map(fuzzSuiteArtifactRefFromTrace).filter((ref): ref is FuzzSuiteArtifactRef => Boolean(ref)))
+    current = record.cause
+  }
+  const deduped = dedupeFuzzSuiteArtifactRefs(refs)
+  return deduped
 }
 
 function fuzzSuiteRuntimeActionMutationArtifactRefs(observation: RuntimeActionObservation): FuzzSuiteArtifactRef[] {

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -111,8 +111,29 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
       recipe_path: stringValue(result.recipePath),
       package_provenance: objectOrUndefined(objectValue(result.provenance).packages),
       managed_runtime_services: result.managedRuntimeServices === undefined ? undefined : arrayObjects(result.managedRuntimeServices),
+      adversarial_campaigns: adversarialCampaignFindingSummaries(result.adversarialCampaigns),
     }),
   }) as RecipeRunSummary
+}
+
+function adversarialCampaignFindingSummaries(value: unknown): Array<Record<string, unknown>> | undefined {
+  const campaigns = arrayObjects(value).filter((campaign) => stringValue(objectValue(campaign.result).status) === "findings")
+  if (campaigns.length === 0) return undefined
+  return campaigns.map((campaign) => {
+    const result = objectValue(campaign.result)
+    return stripUndefined({
+      campaign_id: stringValue(result.campaignId) || stringValue(objectValue(campaign.declaration).id),
+      status: "findings",
+      summary: objectOrUndefined(result.summary),
+      evidence_ref: stringValue(objectValue(campaign.evidence).path),
+      findings: arrayObjects(result.findings).slice(0, 10).map((finding) => stripUndefined({
+        fingerprint: stringValue(finding.fingerprint),
+        status: stringValue(finding.status),
+        oracle_ids: Array.isArray(finding.oracleIds) ? finding.oracleIds.filter((id): id is string => typeof id === "string") : undefined,
+        artifact_refs: arrayObjects(finding.artifactRefs).map((ref) => stripUndefined({ path: stringValue(ref.path), kind: stringValue(ref.kind) })),
+      })),
+    })
+  })
 }
 
 function objectOrUndefined(value: unknown): Record<string, unknown> | undefined {

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -342,7 +342,8 @@ export async function runBrowserActionsCommand({
         }
         finalUrl = page.url()
         if (result.findings.length > 0 && adaptiveContract.failOnFinding) {
-          pendingError = new Error(`Adaptive browser exploration found ${result.findings.length} reproducible oracle failure(s).`)
+          const findingRefs = result.findings.slice(0, 3).map((finding) => `${finding.fingerprint}@${finding.transitionId}`).join(", ")
+          pendingError = new Error(`Adaptive browser exploration found ${result.findings.length} reproducible oracle failure(s): ${findingRefs}. Evidence: files/browser/adaptive-exploration.json`)
         }
       }
     }

--- a/packages/runtime-playground/src/browser-command-artifact-error.ts
+++ b/packages/runtime-playground/src/browser-command-artifact-error.ts
@@ -1,14 +1,19 @@
-import type { BrowserArtifact } from "./browser-artifacts.js"
+import { browserArtifactFileManifest, type BrowserArtifact, type BrowserArtifactFiles } from "./browser-artifacts.js"
 import { sanitizeBrowserArtifact, sanitizeBrowserResultValue } from "./browser-result-sanitization.js"
 
 export class BrowserCommandArtifactError extends Error {
   readonly artifact: BrowserArtifact
+  readonly artifactRefs
 
   constructor(message: string, artifact: BrowserArtifact, readonly artifactRoot?: string) {
     super(sanitizeBrowserResultValue(message, "message"))
     this.name = "BrowserCommandArtifactError"
     Object.assign(artifact, sanitizeBrowserArtifact(artifact))
     this.artifact = artifact
+    this.artifactRefs = Object.entries(artifact.files).flatMap(([key, value]) => {
+      const manifest = browserArtifactFileManifest(key as keyof BrowserArtifactFiles)
+      return (Array.isArray(value) ? value : [value]).flatMap((path, index) => typeof path === "string" ? [{ kind: manifest.kind, id: `${artifact.artifactType}:${key}:${index}`, path, contentType: manifest.contentType }] : [])
+    })
   }
 }
 

--- a/tests/adversarial-recipe-orchestration.test.ts
+++ b/tests/adversarial-recipe-orchestration.test.ts
@@ -216,6 +216,35 @@ assert.equal(adaptiveCampaigns[0]?.result.status, "incomplete")
 assert.equal(adaptiveCampaigns[0]?.result.findings.length, 0, "incomplete adaptive coverage is not an actionable finding")
 assert(adaptiveCampaigns[0]?.result.diagnostics.some((diagnostic) => diagnostic.code === "campaign-case-resource-exhausted" && diagnostic.message.includes("maxDurationMs")))
 
+const adaptiveFindingRuntime = {
+  ...runtime,
+  execute: async (spec: ExecutionSpec) => {
+    if (spec.command === "wordpress.browser-actions") {
+      throw Object.assign(new Error("Adaptive browser exploration found 1 reproducible oracle failure(s): oracle-fingerprint@transition-1. Evidence: files/browser/adaptive-exploration.json"), {
+        artifactRefs: [{ kind: "browser-adaptive-exploration", id: "actions:adaptiveExploration:0", path: "files/browser/adaptive-exploration.json", contentType: "application/json" }],
+      })
+    }
+    return { id: "adaptive-finding", command: spec.command, args: spec.args ?? [], exitCode: 0, stdout: "ok\n", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.001Z" }
+  },
+} as unknown as Runtime
+const adaptiveFindingCampaigns = await runRecipeAdversarialCampaigns({ recipe: adaptiveRecipe, recipePath: "/portable/adaptive-finding.json", recipeDirectory: "/portable", runtime: adaptiveFindingRuntime, executions: [] })
+const adaptiveFinding = adaptiveFindingCampaigns[0]!.result.findings[0]!
+assert.equal(adaptiveFindingCampaigns[0]?.result.status, "findings")
+assert.equal(adaptiveFinding.diagnostics[0]?.code, "adaptive-browser-oracle-failure")
+assert.match(adaptiveFinding.diagnostics[0]?.message ?? "", /oracle-fingerprint@transition-1/)
+assert.deepEqual(adaptiveFinding.artifactRefs.map(({ path, kind }) => ({ path, kind })), [{ path: "files/browser/adaptive-exploration.json", kind: "browser-adaptive-exploration" }])
+
+const adaptiveClosedRuntime = {
+  ...adaptiveFindingRuntime,
+  execute: async (spec: ExecutionSpec) => {
+    if (spec.command === "wordpress.browser-actions") throw new Error("page.evaluate: Target page, context or browser has been closed")
+    return { id: "adaptive-closed", command: spec.command, args: spec.args ?? [], exitCode: 0, stdout: "ok\n", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.001Z" }
+  },
+} as unknown as Runtime
+const adaptiveClosedCampaigns = await runRecipeAdversarialCampaigns({ recipe: adaptiveRecipe, recipePath: "/portable/adaptive-closed.json", recipeDirectory: "/portable", runtime: adaptiveClosedRuntime, executions: [] })
+assert.equal(adaptiveClosedCampaigns[0]?.result.findings[0]?.diagnostics[0]?.code, "adaptive-browser-runtime-closed")
+assert.notEqual(adaptiveClosedCampaigns[0]?.result.findings[0]?.diagnostics[0]?.code, adaptiveFinding.diagnostics[0]?.code)
+
 const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-adversarial-recipe-"))
 try {
   const manifestPath = join(artifactRoot, "manifest.json")

--- a/tests/recipe-run-summary-output.test.ts
+++ b/tests/recipe-run-summary-output.test.ts
@@ -10,7 +10,26 @@ const success = normalizeRecipeRunSummary({
   run: { runId: "run-ok", status: "succeeded" },
   artifacts: { directory: "/tmp/artifacts/run-ok" },
   executions: [{ command: "wordpress.wp-cli option get siteurl", exitCode: 0, durationMs: 12, recipePhase: "run_workloads", recipeStepIndex: 0 }],
+  adversarialCampaigns: [{
+    declaration: { id: "adaptive-browser" },
+    evidence: { path: "files/adversarial/adaptive-browser" },
+    result: {
+      campaignId: "adaptive-browser",
+      status: "findings",
+      summary: { generated: 2, executed: 2, findings: 1 },
+      findings: [{ fingerprint: "oracle-fingerprint", status: "failed", oracleIds: ["runtime-status"], artifactRefs: [{ path: "files/browser/adaptive-exploration.json", kind: "browser-adaptive-exploration", bytes: 2048 }] }],
+    },
+  }],
 })
+
+assert.equal(success.status, "succeeded", "retained adversarial findings remain advisory")
+assert.deepEqual(success.metadata.adversarial_campaigns, [{
+  campaign_id: "adaptive-browser",
+  status: "findings",
+  summary: { generated: 2, executed: 2, findings: 1 },
+  evidence_ref: "files/adversarial/adaptive-browser",
+  findings: [{ fingerprint: "oracle-fingerprint", status: "failed", oracle_ids: ["runtime-status"], artifact_refs: [{ path: "files/browser/adaptive-exploration.json", kind: "browser-adaptive-exploration" }] }],
+}])
 
 const successHuman = await captureStdout(() => writeRecipeSummaryHumanOutput(success))
 assert.match(successHuman, /WP Codebox recipe summary/)


### PR DESCRIPTION
## Summary

- preserve browser artifact refs across recipe workflow error causes and runtime-backed fuzz-suite failures
- retain compact adaptive oracle fingerprints, transition references, and evidence paths while classifying oracle, browser-closed, cancellation, and timeout outcomes distinctly
- project compact retained-finding references into successful parent recipe summaries without converting advisory findings into infrastructure failures

## Root cause

`BrowserCommandArtifactError` retained the browser artifact internally, but the recipe workflow wrapper converted it to a generic `Error` with a cause. The runtime-workload branch in `runFuzzSuite()` caught that wrapper and emitted only `fuzz_suite_runtime_workload_execution_error`, dropping the underlying artifact refs. `executeRecipeAdversarialCase()` therefore created a retained finding from a generic diagnostic with `artifactRefs: []`. Separately, `normalizeRecipeRunSummary()` did not project adversarial campaigns, so a successful parent recipe summary exposed no compact indication that an advisory campaign ended with `status: findings`.

The affected path was:

`wordpress.browser-actions` -> `BrowserCommandArtifactError` -> recipe workflow wrapper -> runtime-backed fuzz-suite workload catch -> adversarial observation/finding -> recipe run summary.

## Evidence before and after

Before:

```json
{
  "diagnostics": [{
    "code": "fuzz_suite_runtime_workload_execution_error",
    "message": "Adaptive browser exploration found 1 reproducible oracle failure(s)."
  }],
  "artifactRefs": []
}
```

After:

```json
{
  "diagnostics": [{
    "code": "adaptive-browser-oracle-failure",
    "message": "Adaptive browser exploration found 1 reproducible oracle failure(s): oracle-fingerprint@transition-1. Evidence: files/browser/adaptive-exploration.json"
  }],
  "artifactRefs": [{
    "path": "files/browser/adaptive-exploration.json",
    "kind": "browser-adaptive-exploration"
  }]
}
```

Successful parent summaries now include `metadata.adversarial_campaigns` with the campaign id, aggregate counts, evidence directory, finding fingerprints/status/oracle ids, and compact artifact refs. The parent remains `status: succeeded`.

## Verification

Passed:

- `npm run build:release`
- `npx tsx tests/adversarial-recipe-orchestration.test.ts`
- `npx tsx tests/recipe-run-summary-output.test.ts`
- `npx tsx tests/fuzz-suite-runner.test.ts`
- `npx tsx tests/adversarial-campaign.test.ts` (11 passed)
- `npx tsx tests/adversarial-browser.test.ts` (3 passed)
- `npm run test:release-package-coverage`
- `npm run smoke -- --group package` (package build and runtime-service suites passed; disposable Docker E2E skipped because Docker is unavailable)

The unscoped `npm run smoke` was also attempted. It stopped in the unrelated existing `browser-callback-materialization-contracts` fixture because actual callback evidence now includes `contentLength` and `bodyRewritten`; this change does not touch that contract or test.

## Relationship to #2298

#2298 fixed bounded cancellation settlement so an in-flight browser action settles before checkpoint restore or runtime teardown. This change does not alter cancellation timing, grace periods, checkpoint restoration, or campaign settlement. It preserves and classifies evidence after execution has settled, including the already-covered timed-out case path, so it does not reopen the cancellation-settlement bug.

Closes #2326.