### PR TITLE
Own nested Playground preview replacement lifecycle

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -504,6 +504,10 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: Previ
   delete forwarded.connection
   delete forwarded["transfer-encoding"]
 
+  if (new URL(requestTarget.path, "http://localhost").pathname.endsWith("/sw.js")) {
+    forwarded["service-worker-allowed"] = "/"
+  }
+
   if (typeof forwarded.location === "string") {
     try {
       const location = new URL(forwarded.location, target)

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -1043,21 +1043,25 @@
 		if ( typeof value === 'boolean' ) {
 			return {
 				client_released: value,
+				runtime_termination_requested: false,
 				runtime_terminated: false,
 				client_release_evidence: null,
 			};
 		}
 		if ( value && typeof value === 'object' && ! Array.isArray( value ) ) {
 			const client_released = value.client_released === true;
+			const runtime_termination_requested = value.runtime_termination_requested === true;
 			const runtime_terminated = value.runtime_terminated === true;
 			return {
 				client_released,
+				runtime_termination_requested,
 				runtime_terminated,
-				client_release_evidence: Object.freeze( { client_released, runtime_terminated } ),
+				client_release_evidence: Object.freeze( { client_released, runtime_termination_requested, runtime_terminated } ),
 			};
 		}
 		return {
 			client_released: false,
+			runtime_termination_requested: false,
 			runtime_terminated: false,
 			client_release_evidence: null,
 		};
@@ -1126,6 +1130,7 @@
 					}
 					let client_release_requested = false;
 					let client_released = false;
+					let runtime_termination_requested = false;
 					let runtime_terminated = false;
 					let client_release_evidence = null;
 					let client_release_error = null;
@@ -1133,6 +1138,7 @@
 						const clientRelease = await lifecycle.releaseClient();
 						client_release_requested = clientRelease.requested;
 						client_released = clientRelease.client_released;
+						runtime_termination_requested = clientRelease.runtime_termination_requested;
 						runtime_terminated = clientRelease.runtime_terminated;
 						client_release_evidence = clientRelease.client_release_evidence;
 					} catch ( error ) {
@@ -1154,6 +1160,7 @@
 						client_release_error,
 						client_release_evidence,
 						runtime_release_requested: iframe_reset,
+						runtime_termination_requested,
 						runtime_terminated,
 						lifecycle_released: true,
 					} );

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -945,7 +945,7 @@
 
 	const resolvePlaygroundClientModule = async ( boot, options = {} ) => {
 		if ( typeof options.startPlaygroundWeb === 'function' ) {
-			return { startPlaygroundWeb: options.startPlaygroundWeb, zipWpContent: options.zipWpContent };
+			return { startPlaygroundWeb: options.startPlaygroundWeb, zipWpContent: options.zipWpContent, disposePlaygroundClient: options.disposePlaygroundClient };
 		}
 
 		const moduleUrl = String( options.clientModuleUrl || boot.client_module_url || '' );
@@ -959,10 +959,13 @@
 			throw runtimeError( 'browser_preview_start', 'browser_preview_start_unavailable', 'Codebox browser preview client module does not export startPlaygroundWeb.' );
 		}
 
-		return { startPlaygroundWeb: module.startPlaygroundWeb, zipWpContent: module.zipWpContent };
+		return { startPlaygroundWeb: module.startPlaygroundWeb, zipWpContent: module.zipWpContent, disposePlaygroundClient: module.disposePlaygroundClient };
 	};
 
 	const browserPreviewLifecycles = new Map();
+	const browserPreviewSlotRoots = new WeakMap();
+	const browserPreviewSlotIframes = new WeakMap();
+	const browserPreviewSlotLifecycles = new WeakMap();
 	const browserPreviewReplaySources = new WeakMap();
 	const defaultBrowserPreviewStartupTimeoutMs = 30000;
 	const browserPreviewAbortError = () => runtimeError( 'browser_preview_start', 'browser_preview_aborted', 'Browser preview start was aborted.' );
@@ -991,8 +994,44 @@
 		}
 	);
 
-	const resetBrowserPreviewIframe = ( iframe ) => {
+	const browserPreviewSlot = ( iframe ) => {
+		if ( ! iframe || ( typeof iframe !== 'object' && typeof iframe !== 'function' ) ) return null;
+		const slot = browserPreviewSlotRoots.get( iframe ) || iframe;
+		browserPreviewSlotRoots.set( iframe, slot );
+		if ( ! browserPreviewSlotIframes.has( slot ) ) browserPreviewSlotIframes.set( slot, iframe );
+		return slot;
+	};
+	const currentBrowserPreviewIframe = ( slot, fallback ) => slot ? ( browserPreviewSlotIframes.get( slot ) || fallback ) : fallback;
+	const resetBrowserPreviewIframe = async ( iframe, slot ) => {
 		if ( iframe && typeof iframe === 'object' && 'src' in iframe ) {
+			if ( iframe.parentNode && typeof iframe.cloneNode === 'function' && typeof iframe.parentNode.replaceChild === 'function' ) {
+				const replacement = iframe.cloneNode( false );
+				replacement.src = 'about:blank';
+				iframe.parentNode.replaceChild( replacement, iframe );
+				if ( slot ) {
+					browserPreviewSlotRoots.set( replacement, slot );
+					browserPreviewSlotIframes.set( slot, replacement );
+				}
+				return true;
+			}
+			if ( typeof iframe.addEventListener === 'function' && typeof iframe.removeEventListener === 'function' ) {
+				await new Promise( ( resolve ) => {
+					let settled = false;
+					const finish = () => {
+						if ( settled ) {
+							return;
+						}
+						settled = true;
+						iframe.removeEventListener( 'load', finish );
+						clearTimeout( timeout );
+						resolve();
+					};
+					const timeout = setTimeout( finish, 5000 );
+					iframe.addEventListener( 'load', finish, { once: true } );
+					iframe.src = 'about:blank';
+				} );
+				return true;
+			}
 			iframe.src = 'about:blank';
 			return true;
 		}
@@ -1024,7 +1063,7 @@
 		};
 	};
 
-	const createBrowserPreviewLifecycle = ( scope, iframe, signal, disposeClient ) => {
+	const createBrowserPreviewLifecycle = ( scope, slot, iframe, signal, disposeClient ) => {
 		let active = true;
 		let cancelled = false;
 		let client;
@@ -1037,6 +1076,9 @@
 		} );
 		const lifecycle = {
 			isActive: () => active,
+			setDisposeClient: ( nextDisposeClient ) => {
+				if ( typeof nextDisposeClient === 'function' ) disposeClient = nextDisposeClient;
+			},
 			wait: ( promise ) => Promise.race( [ promise, cancellation ] ),
 			ownClient: ( nextClient ) => {
 				if ( ! active ) {
@@ -1079,7 +1121,9 @@
 					if ( scope && browserPreviewLifecycles.get( scope ) === lifecycle ) {
 						browserPreviewLifecycles.delete( scope );
 					}
-					const iframe_reset = resetBrowserPreviewIframe( iframe );
+					if ( slot && browserPreviewSlotLifecycles.get( slot ) === lifecycle ) {
+						browserPreviewSlotLifecycles.delete( slot );
+					}
 					let client_release_requested = false;
 					let client_released = false;
 					let runtime_terminated = false;
@@ -1094,6 +1138,7 @@
 					} catch ( error ) {
 						client_release_error = error?.message || 'Browser preview client cleanup failed.';
 					}
+					const iframe_reset = await resetBrowserPreviewIframe( iframe, slot );
 					return Object.freeze( {
 						schema: 'wp-codebox/browser-preview-dispose-result/v1',
 						success: true,
@@ -1140,21 +1185,26 @@
 			throw browserPreviewAbortError();
 		}
 		const boot = browserPreviewBootConfig( input );
-		const iframe = options.iframe || input?.iframe || ( typeof document !== 'undefined' && options.iframeSelector ? document.querySelector( options.iframeSelector ) : null );
+		const requestedIframe = options.iframe || input?.iframe || ( typeof document !== 'undefined' && options.iframeSelector ? document.querySelector( options.iframeSelector ) : null );
+		const slot = browserPreviewSlot( requestedIframe );
+		let iframe = currentBrowserPreviewIframe( slot, requestedIframe );
 		const scope = String( boot.scope || '' );
 		const startupTimeoutMs = browserPreviewStartupTimeoutMs( options );
 		let lifecycle;
 		let startupTimeout;
-		if ( startupTimeoutMs !== null ) {
-			startupTimeout = setTimeout( () => {
-				lifecycle?.cancel( browserPreviewStartupTimeoutError( boot, scope, startupTimeoutMs ) );
-			}, startupTimeoutMs );
-		}
 		const previousLifecycle = scope ? browserPreviewLifecycles.get( scope ) : null;
 		if ( previousLifecycle ) {
 			previousLifecycle.cancel( browserPreviewReplacedError() );
 		}
-		lifecycle = createBrowserPreviewLifecycle( scope, iframe, options.signal, options.disposeClient );
+		const previousSlotLifecycle = slot ? browserPreviewSlotLifecycles.get( slot ) : null;
+		if ( previousSlotLifecycle && previousSlotLifecycle !== previousLifecycle ) {
+			previousSlotLifecycle.cancel( browserPreviewReplacedError() );
+		}
+		if ( previousSlotLifecycle ) {
+			await previousSlotLifecycle.dispose();
+			iframe = currentBrowserPreviewIframe( slot, iframe );
+		}
+		lifecycle = createBrowserPreviewLifecycle( scope, slot, iframe, options.signal, options.disposeClient );
 		if ( options.signal?.aborted ) {
 			await lifecycle.dispose();
 			throw browserPreviewAbortError();
@@ -1162,9 +1212,18 @@
 		if ( scope ) {
 			browserPreviewLifecycles.set( scope, lifecycle );
 		}
+		if ( slot ) {
+			browserPreviewSlotLifecycles.set( slot, lifecycle );
+		}
+		if ( startupTimeoutMs !== null ) {
+			startupTimeout = setTimeout( () => {
+				lifecycle.cancel( browserPreviewStartupTimeoutError( boot, scope, startupTimeoutMs ) );
+			}, startupTimeoutMs );
+		}
 
 		try {
 			const playgroundModule = await lifecycle.wait( resolvePlaygroundClientModule( boot, options ) );
+			if ( typeof options.disposeClient !== 'function' ) lifecycle.setDisposeClient( playgroundModule.disposePlaygroundClient );
 			const blueprint = await lifecycle.wait( hydrateBrowserPreviewBlueprint( boot, options ) );
 			const startOptions = options.startOptions && typeof options.startOptions === 'object' ? options.startOptions : {};
 			const guardedStartOptions = { ...startOptions };

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -820,6 +820,7 @@ await assert.rejects(
         client_release_error: null,
         client_release_evidence: null,
         runtime_release_requested: true,
+        runtime_termination_requested: false,
         runtime_terminated: false,
         lifecycle_released: true,
       },
@@ -958,7 +959,7 @@ const lifecyclePreview = await api.v1.startBrowserPreview(lifecycleBoot, {
     assert.equal(client.client, "lifecycle-playground")
     lifecycleClientReleased = true
     releasedClients += 1
-    return { client_released: true, runtime_terminated: false }
+    return { client_released: true, runtime_termination_requested: false, runtime_terminated: false }
   },
 })
 lifecycleCallbacks.onBlueprintStepCompleted()
@@ -979,8 +980,9 @@ assert.deepEqual(plain(disposed), {
   client_release_requested: true,
   client_released: true,
   client_release_error: null,
-  client_release_evidence: { client_released: true, runtime_terminated: false },
+  client_release_evidence: { client_released: true, runtime_termination_requested: false, runtime_terminated: false },
   runtime_release_requested: true,
+  runtime_termination_requested: false,
   runtime_terminated: false,
   lifecycle_released: true,
 })
@@ -1012,7 +1014,7 @@ const moduleDisposePreview = await api.v1.startBrowserPreview({ ...lifecycleBoot
     startPlaygroundWeb: async () => lifecycleClient,
     disposePlaygroundClient: async (client: unknown) => {
       moduleDisposedClient = client
-      return { client_released: true, runtime_terminated: true }
+      return { client_released: true, runtime_termination_requested: true, runtime_terminated: false }
     },
   }),
 })
@@ -1020,7 +1022,8 @@ const moduleDisposeResult = await moduleDisposePreview.dispose()
 assert.equal(moduleDisposedClient, lifecycleClient, "default disposal delegates runtime teardown to the imported Playground module")
 assert.equal(moduleDisposeResult.client_release_requested, true, "module-owned runtime teardown is reported as requested")
 assert.equal(moduleDisposeResult.client_released, true, "module-owned client release evidence is preserved")
-assert.equal(moduleDisposeResult.runtime_terminated, true, "module-owned runtime termination evidence is preserved")
+assert.equal(moduleDisposeResult.runtime_termination_requested, true, "module-owned runtime termination request evidence is preserved")
+assert.equal(moduleDisposeResult.runtime_terminated, false, "module-owned teardown does not overstate confirmed runtime termination")
 
 let replacementReleased = 0
 const replacementCallbacks: Record<string, () => unknown> = {}

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -1004,6 +1004,24 @@ assert.equal(defaultDispose.client_released, false, "default disposal does not v
 assert.equal(defaultDispose.runtime_release_requested, true, "iframe reset requests runtime release")
 assert.equal(defaultDispose.runtime_terminated, false, "default disposal does not verify runtime termination")
 
+let moduleDisposedClient: unknown
+const moduleDisposePreview = await api.v1.startBrowserPreview({ ...lifecycleBoot, client_module_url: "https://playground.example/client/index.js", scope: "preview-module-dispose-test" }, {
+  iframe: { src: "https://playground.example/remote.html" },
+  hydrateBlueprintRef: async () => ({ blueprint: { steps: [] } }),
+  importModule: async () => ({
+    startPlaygroundWeb: async () => lifecycleClient,
+    disposePlaygroundClient: async (client: unknown) => {
+      moduleDisposedClient = client
+      return { client_released: true, runtime_terminated: true }
+    },
+  }),
+})
+const moduleDisposeResult = await moduleDisposePreview.dispose()
+assert.equal(moduleDisposedClient, lifecycleClient, "default disposal delegates runtime teardown to the imported Playground module")
+assert.equal(moduleDisposeResult.client_release_requested, true, "module-owned runtime teardown is reported as requested")
+assert.equal(moduleDisposeResult.client_released, true, "module-owned client release evidence is preserved")
+assert.equal(moduleDisposeResult.runtime_terminated, true, "module-owned runtime termination evidence is preserved")
+
 let replacementReleased = 0
 const replacementCallbacks: Record<string, () => unknown> = {}
 const firstReplacement = await api.v1.startBrowserPreview({ ...lifecycleBoot, scope: "preview-replacement-test" }, {

--- a/tests/service-worker-preview-proxy.browser.test.ts
+++ b/tests/service-worker-preview-proxy.browser.test.ts
@@ -7,14 +7,15 @@ import { chromium } from "playwright"
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
 test("the preview proxy registers a service worker after transient upstream redirects", async () => {
+  const workerPath = "/runtime/version/sw.js"
   let workerRequests = 0
   const forwardedWorkerHeaders: Array<{ serviceWorker: string | string[] | undefined; destination: string | string[] | undefined }> = []
   const upstream = createServer((request, response) => {
-    if (request.url === "/sw.js") {
+    if (request.url === workerPath) {
       workerRequests += 1
       forwardedWorkerHeaders.push({ serviceWorker: request.headers["service-worker"], destination: request.headers["sec-fetch-dest"] })
       if (workerRequests < 3) {
-        response.writeHead(302, { location: "/sw.js" })
+        response.writeHead(302, { location: workerPath })
         response.end()
         return
       }
@@ -36,7 +37,7 @@ test("the preview proxy registers a service worker after transient upstream redi
     const page = await browser.newPage()
     await page.goto(proxy.serverUrl)
     const registration = await page.evaluate(async () => {
-      const registered = await navigator.serviceWorker.register("/sw.js")
+      const registered = await navigator.serviceWorker.register("/runtime/version/sw.js", { scope: "/" })
       await navigator.serviceWorker.ready
       return { scope: registered.scope, active: !!registered.active }
     })
@@ -52,12 +53,13 @@ test("the preview proxy registers a service worker after transient upstream redi
     assert.deepEqual(proxy.previewProxyDiagnostics?.requestTrace.entries, [{
       sequence: 1,
       method: "GET",
-      path: "/sw.js",
+      path: workerPath,
       destination: "serviceworker",
       serviceWorker: true,
       outcome: "response",
       status: 200,
       contentType: "application/javascript",
+      serviceWorkerAllowed: "/",
       bodyRewritten: true,
     }])
   } finally {

--- a/tests/service-worker-preview-proxy.browser.test.ts
+++ b/tests/service-worker-preview-proxy.browser.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
 import { createServer } from "node:http"
 import test from "node:test"
 
@@ -205,6 +206,157 @@ test("the preview proxy returns a connected client from the packaged Playground 
       contentType: "application/javascript",
       bodyRewritten: true,
     })
+  } finally {
+    await browser.close()
+    await proxy[Symbol.asyncDispose]()
+    await closeHttpServer(app)
+  }
+})
+
+test("the browser SDK replaces a packaged Playground preview in one slot", { timeout: 120_000 }, async () => {
+  const app = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html" })
+    response.end("<!doctype html><title>Playground replacement integration</title><iframe></iframe>")
+  })
+  const appUrl = await listenLocalHttpServer(app)
+  const proxy = await withPreviewProxy({
+    playground: { async run() { return { text: "", exitCode: 0 } } },
+    serverUrl: "https://playground.wordpress.net",
+    async [Symbol.asyncDispose]() {},
+  } satisfies PlaygroundCliServer, 5400)
+  const browser = await chromium.launch({ headless: true })
+  const consoleMessages: string[] = []
+  const pageErrors: string[] = []
+  try {
+    const page = await browser.newPage()
+    page.on("console", (message) => {
+      if (consoleMessages.length < 64) consoleMessages.push(`${message.type()}: ${message.text()}`)
+    })
+    page.on("pageerror", (error) => {
+      if (pageErrors.length < 64) pageErrors.push(error.message)
+    })
+    await page.goto(appUrl)
+    await page.evaluate("globalThis.__name = (value) => value")
+    await page.addScriptTag({ content: await readFile(new URL("../packages/wordpress-plugin/assets/browser-runtime.js", import.meta.url), "utf8") })
+    const result = await page.evaluate(async ({ remoteUrl }) => {
+      const { startPlaygroundWeb } = await import("https://playground.wordpress.net/client/index.js")
+      const iframe = document.querySelector("iframe")
+      const phases: string[] = []
+      const heavyBlueprint = (marker: string) => ({
+        steps: [
+          ...Array.from({ length: 6 }, (_, index) => ({
+            step: "writeFile",
+            path: `/tmp/codebox-${marker}-${index}.txt`,
+            data: `${marker}:${index}:` + "x".repeat(256 * 1024),
+          })),
+          {
+            step: "writeFile",
+            path: "/wordpress/wp-content/mu-plugins/codebox-site-marker.php",
+            data: `<?php add_action( 'wp_head', static function () { echo '<meta name="codebox-site-marker" content="${marker}">'; } );`,
+          },
+        ],
+      })
+      const markerEvidence = async (client: any) => {
+        const response = await client.request({ url: "/" })
+        const html = new TextDecoder().decode(response.bytes)
+        return { a: html.includes('content="marker-a"'), b: html.includes('content="marker-b"') }
+      }
+      try {
+        phases.push("a:starting")
+        const first = await window.wpCodeboxBrowser.v1.startBrowserPreview({
+          schema: "wp-codebox/browser-preview-boot-config/v1",
+          session_id: "replacement-a",
+          remote_url: remoteUrl,
+          scope: "replacement-a",
+          blueprint_ref: { schema: "wp-codebox/browser-blueprint-ref/v1", ref: "prepared:replacement-a", hydratable: true },
+        }, {
+          iframe,
+          startupTimeoutMs: 45_000,
+          hydrateBlueprintRef: async () => ({ blueprint: heavyBlueprint("marker-a") }),
+          startPlaygroundWeb,
+          startOptions: {
+            disableProgressBar: true,
+            onClientConnected: () => phases.push("replacement-a:client-connected"),
+            onBlueprintValidated: () => phases.push("replacement-a:blueprint-validated"),
+          },
+        })
+        phases.push("a:started")
+        const firstMarkers = await markerEvidence(first.client)
+        const firstIframe = document.querySelector("iframe")
+        const second = await window.wpCodeboxBrowser.v1.startBrowserPreview({
+          schema: "wp-codebox/browser-preview-boot-config/v1",
+          session_id: "replacement-b",
+          remote_url: remoteUrl,
+          scope: "replacement-b",
+          blueprint_ref: { schema: "wp-codebox/browser-blueprint-ref/v1", ref: "prepared:replacement-b", hydratable: true },
+        }, {
+          iframe,
+          startupTimeoutMs: 45_000,
+          hydrateBlueprintRef: async () => ({ blueprint: heavyBlueprint("marker-b") }),
+          startPlaygroundWeb,
+          startOptions: {
+            disableProgressBar: true,
+            onClientConnected: () => phases.push("replacement-b:client-connected"),
+            onBlueprintValidated: () => phases.push("replacement-b:blueprint-validated"),
+          },
+        })
+        phases.push("b:started")
+        const secondMarkers = await markerEvidence(second.client)
+        const secondIframe = document.querySelector("iframe")
+        const third = await window.wpCodeboxBrowser.v1.startBrowserPreview({
+          schema: "wp-codebox/browser-preview-boot-config/v1",
+          session_id: "replacement-a-return",
+          remote_url: remoteUrl,
+          scope: "replacement-a",
+          blueprint_ref: { schema: "wp-codebox/browser-blueprint-ref/v1", ref: "prepared:replacement-a-return", hydratable: true },
+        }, {
+          iframe,
+          startupTimeoutMs: 45_000,
+          hydrateBlueprintRef: async () => ({ blueprint: heavyBlueprint("marker-a") }),
+          startPlaygroundWeb,
+          startOptions: {
+            disableProgressBar: true,
+            onClientConnected: () => phases.push("replacement-a-return:client-connected"),
+            onBlueprintValidated: () => phases.push("replacement-a-return:blueprint-validated"),
+          },
+        })
+        phases.push("a-return:started")
+        const thirdMarkers = await markerEvidence(third.client)
+        const thirdIframe = document.querySelector("iframe")
+        await third.dispose()
+        return {
+          success: true,
+          phases,
+          firstMarkers,
+          secondMarkers,
+          thirdMarkers,
+          slotReplacedAB: firstIframe !== secondIframe,
+          slotReplacedBA: secondIframe !== thirdIframe,
+        }
+      } catch (error) {
+        return { success: false, phases, error: { name: error?.name, code: error?.code, message: error?.message, data: error?.data } }
+      }
+    }, { remoteUrl: `${proxy.serverUrl}/remote.html` })
+
+    assert.equal(result.success, true, JSON.stringify({ result, consoleMessages, pageErrors, trace: proxy.previewProxyDiagnostics?.requestTrace }, null, 2))
+    assert.deepEqual(result.phases, [
+      "a:starting",
+      "replacement-a:client-connected",
+      "replacement-a:blueprint-validated",
+      "a:started",
+      "replacement-b:client-connected",
+      "replacement-b:blueprint-validated",
+      "b:started",
+      "replacement-a-return:client-connected",
+      "replacement-a-return:blueprint-validated",
+      "a-return:started",
+    ])
+    assert.deepEqual(result.firstMarkers, { a: true, b: false })
+    assert.deepEqual(result.secondMarkers, { a: false, b: true })
+    assert.deepEqual(result.thirdMarkers, { a: true, b: false })
+    assert.equal(result.slotReplacedAB, true)
+    assert.equal(result.slotReplacedBA, true)
+    assert.deepEqual(pageErrors, [])
   } finally {
     await browser.close()
     await proxy[Symbol.asyncDispose]()


### PR DESCRIPTION
## Summary
- emit `Service-Worker-Allowed: /` for nested Playground worker responses
- own preview replacement by the iframe slot rather than relying only on Playground scope identifiers
- serialize same-slot disposal and replace the iframe browsing context between runtimes
- consume a packaged `disposePlaygroundClient` adapter when available
- distinguish runtime termination requested from termination confirmed instead of overstating cleanup evidence
- prove A -> B -> A replacement with distinct 1.5 MB, seven-step hosted sites and exact rendered marker isolation

## Current status
This PR remains draft while the pinned self-hosted WP Build runtime gate is unresolved. Codebox's hosted packaged-runtime A -> B -> A test passes. The pinned package now disposes PHP/request-handler state, resets endpoint state, and schedules worker-global closure after replying; A and B pass, but return to A still times out before `playground_client_connected`. The targeted teardown refactor therefore did not clear the third-boot gate.

Linked evidence PR: https://github.a8c.com/chubes4/wp-build/pull/1314

Closes #2329.

## Verification
- `npm run test:browser-sdk-facade`
- `npm run test:service-worker-preview-proxy`
- `npm run build`
- service-worker proxy suite: 4/4 passing
- hosted replacement integration: A marker only -> B marker only -> A marker only
- pinned integration: A marker only -> B marker only -> return to A startup timeout

## AI assistance
GPT-5.6 Sol via OpenCode traced the browser-preview ownership and teardown contract, implemented iframe-slot lifecycle ownership and truthful termination evidence, added the heavy replacement regression, and ran focused and cross-repository verification. Chris Huber directed and reviewed the work.