### PR TITLE
fix: tolerate vanished process group members

### DIFF
--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -1087,16 +1087,26 @@ async function ownedProcessGroupExists(state: OwnedNativeProcess): Promise<boole
 async function ownedProcessGroupHasLiveMembers(state: OwnedNativeProcess): Promise<boolean> {
   if (process.platform !== "linux" || !state.groupId) return await ownedProcessGroupExists(state)
   if (!await ownedProcessGroupExists(state)) return false
+  return await linuxProcessGroupHasLiveMembers(state.groupId)
+}
+
+export async function linuxProcessGroupHasLiveMembers(groupId: number, probe: { entries(): Promise<string[]>; readStat(pid: string): Promise<string> } = {
+  entries: async () => await readdir("/proc"),
+  readStat: async (pid) => await readFile(`/proc/${pid}/stat`, "utf8"),
+}): Promise<boolean> {
   // Capturing parents can retain killed descendants as zombies; they cannot execute
   // and only the adopting parent, not this process, can reap them.
-  for (const entry of await readdir("/proc")) {
+  for (const entry of await probe.entries()) {
     if (!/^\d+$/.test(entry)) continue
     try {
-      const fields = linuxProcessStatFields(await readFile(`/proc/${entry}/stat`, "utf8"))
-      if (Number(fields[2]) === state.groupId && !["Z", "X", "x"].includes(fields[0] ?? "")) return true
+      const fields = linuxProcessStatFields(await probe.readStat(entry))
+      const state = fields[0]
+      const processGroup = fields[2]
+      if (!state || !processGroup || !/^\d+$/.test(processGroup)) throw new Error(`Malformed Linux process stat for PID ${entry}`)
+      if (Number(processGroup) === groupId && !["Z", "X", "x"].includes(state)) return true
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code
-      if (code !== "ENOENT" && code !== "EACCES" && code !== "EPERM") throw error
+      if (code !== "ENOENT" && code !== "ESRCH") throw error
     }
   }
   return false

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -5,7 +5,7 @@ import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { runRecipeBuildCommand } from "../packages/cli/src/commands/recipe-build.ts"
-import { executeRuntimeServiceProcess, parseLoopbackPort, provisionRuntimeServices, provisionRuntimeServicesForRecipe, RuntimeServiceProvisionError, runtimeServiceEvidenceFromError, runtimeServicePlan, waitForMysqlProtocol, type RuntimeServiceDependencies } from "../packages/cli/src/runtime-services.ts"
+import { executeRuntimeServiceProcess, linuxProcessGroupHasLiveMembers, parseLoopbackPort, provisionRuntimeServices, provisionRuntimeServicesForRecipe, RuntimeServiceProvisionError, runtimeServiceEvidenceFromError, runtimeServicePlan, waitForMysqlProtocol, type RuntimeServiceDependencies } from "../packages/cli/src/runtime-services.ts"
 import { planWorkspaceRecipe } from "../packages/cli/src/recipe-dry-run.ts"
 import { executeSmtpSinkRecipeOperation } from "../packages/cli/src/smtp-sink-recipe-operations.ts"
 import { recipePolicy, validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.ts"
@@ -17,6 +17,16 @@ const plan = runtimeServicePlan([service])
 assert.deepEqual(plan, [{ id: "test-db", kind: "mysql", provider: "docker", version: "mysql:8.4", bind: "loopback", port: "ephemeral", persistentVolume: false, storage: "tmpfs", outputs: service.outputs }])
 assert.equal(parseLoopbackPort("127.0.0.1:44001\n"), 44001)
 assert.throws(() => parseLoopbackPort("0.0.0.0:3306"), /loopback/)
+for (const code of ["ENOENT", "ESRCH"]) {
+  const vanished = Object.assign(new Error(`${code}: vanished process entry`), { code })
+  assert.equal(await linuxProcessGroupHasLiveMembers(42, { entries: async () => ["100"], readStat: async () => { throw vanished } }), false, `${code} after /proc enumeration is a completed process exit`)
+}
+assert.equal(await linuxProcessGroupHasLiveMembers(42, { entries: async () => ["100", "101"], readStat: async (pid) => pid === "100" ? "100 (zombie) Z 1 42" : "101 (live) S 1 42" }), true, "the bounded probe continues past exited members")
+for (const code of ["EACCES", "EPERM", "EIO"]) {
+  const failure = Object.assign(new Error(`${code}: process stat unavailable`), { code })
+  await assert.rejects(linuxProcessGroupHasLiveMembers(42, { entries: async () => ["100"], readStat: async () => { throw failure } }), (error: unknown) => error === failure, `${code} remains fatal`)
+}
+await assert.rejects(linuxProcessGroupHasLiveMembers(42, { entries: async () => ["100"], readStat: async () => "malformed" }), /Malformed Linux process stat/, "malformed process stat remains fatal")
 const auxiliaryServices = [
   { id: "cache", kind: "redis", outputs: { host: "REDIS_HOST", port: "REDIS_PORT", url: "REDIS_URL" } },
   { id: "mail", kind: "smtp", outputs: { host: "SMTP_HOST", port: "SMTP_PORT", httpPort: "SMTP_HTTP_PORT" } },


### PR DESCRIPTION
## Summary

- Handle the `/proc` process-group enumeration/read TOCTOU race by treating only vanished process entries as completed exits.
- Add deterministic coverage for `ENOENT` and `ESRCH`, continued probing after an exited member, and fatal permission, malformed-data, and unexpected I/O failures.
- Keep the process-group helper generic and preserve the existing bounded lifecycle teardown behavior.

## Root cause

`ownedProcessGroupHasLiveMembers()` first enumerated numeric entries under `/proc`, then read each `/proc/<pid>/stat`. A short-lived initializer descendant could exit after its PID was returned by `readdir()` but before `readFile()` completed. Node reported that disappearance as `ESRCH: no such process, read`, which the probe did not classify as a completed exit, so teardown surfaced a `RuntimeServiceProvisionError` even though the descendant had already terminated.

## Error handling

`ENOENT` and `ESRCH` are benign only while reading an already-enumerated process stat entry: both mean that member disappeared during the probe, so iteration continues within the existing bounded wait.

`EACCES`, `EPERM`, unexpected I/O errors such as `EIO`, malformed stat fields, and all other errors remain fatal. The previous suppression of permission errors was removed so the probe cannot mistake an unreadable process group for an exited one.

## Lifecycle behavior

Before: an initializer descendant exiting between `/proc` enumeration and stat read could turn otherwise-complete native MariaDB teardown into a provisioning failure.

After: the vanished member is treated as exited, remaining process-group entries are still checked, and teardown completes when no live members remain. Genuine probe failures still abort teardown visibly.

## Verification

- `npm ci` - passed; postinstall patches applied and forced release TypeScript build passed.
- `npm run test:runtime-services` - passed runtime services, external MySQL, and native MariaDB fake suites, including the initializer-descendant lifecycle fixture.
- `npm run test:runtime-services-lifecycle` - passed.
- `npm run build` - passed.
- `npm run test:release-package-coverage` - passed.
- `npm run smoke -- --group=package` - passed build, runtime-service, and lifecycle commands; disposable MySQL/mysqli E2E reported its expected skip because Docker is unavailable.
- `git diff --check` - passed.

Closes #2331.