### PR TITLE
fix: detect stale CLI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs",
-    "build:release": "node ./node_modules/typescript/bin/tsc -b --force packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs",
+    "build": "node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs && tsx scripts/write-cli-build-provenance.ts",
+    "build:release": "node ./node_modules/typescript/bin/tsc -b --force packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs && tsx scripts/write-cli-build-provenance.ts",
     "cloudflare:dry-run": "npm exec -- wrangler deploy --dry-run --config packages/runtime-cloudflare/wrangler.jsonc",
     "cloudflare:dry-run:d1": "npm exec -- wrangler deploy --dry-run --config packages/runtime-cloudflare/wrangler.d1.jsonc",
     "cloudflare:dry-run:control": "npm exec -- wrangler deploy --dry-run --config packages/runtime-cloudflare/wrangler.control.jsonc",
@@ -109,6 +109,7 @@
     "test:release-package-coverage": "tsx tests/release-package-coverage.test.ts",
     "test:prepare-declaration-rebuild": "tsx tests/prepare-declaration-rebuild.test.ts",
     "test:release-target": "tsx --test tests/release-target.test.ts",
+    "test:cli-build-freshness": "tsx --test tests/cli-build-freshness.test.ts",
     "test:sharp-release-runtime": "tsx --test tests/sharp-release-runtime.test.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wp-codebox:source": "node bin/wp-codebox-source.mjs",

--- a/packages/cli/src/cli-build-provenance.ts
+++ b/packages/cli/src/cli-build-provenance.ts
@@ -1,0 +1,233 @@
+import { createHash } from "node:crypto"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { readFile, readdir, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
+
+export const CLI_BUILD_PROVENANCE_FILE = "cli-build-provenance.json"
+
+export interface CliBuildProvenance {
+  schema: "wp-codebox/cli-build-provenance/v1"
+  package: { name: string; version: string }
+  source: FileIdentity
+  dist: FileIdentity
+  git: { commit?: string; ref?: string }
+}
+
+interface FileIdentity {
+  sha256: string
+  files: number
+}
+
+interface GitRelationship {
+  head: string
+  ref?: string
+  upstream?: string
+  upstreamHead?: string
+  ahead?: number
+  behind?: number
+  evidence: "local-tracking-ref" | "unavailable"
+  reason?: string
+  remoteFetch: "not-attempted"
+}
+
+export interface CliFreshnessCheck {
+  id: "wp-codebox.source"
+  status: "ok" | "warning" | "error"
+  message: string
+  details: Record<string, unknown>
+}
+
+export async function writeCliBuildProvenance(repositoryRoot: string, packageRoot: string): Promise<CliBuildProvenance> {
+  const packageMetadata = await readPackageMetadata(packageRoot)
+  const relationship = await gitRelationship(repositoryRoot)
+  const expectedCommit = process.env.WP_CODEBOX_SOURCE_SHA
+  if (expectedCommit && relationship && expectedCommit !== relationship.head) {
+    throw new Error(`WP_CODEBOX_SOURCE_SHA ${expectedCommit} does not match source checkout HEAD ${relationship.head}`)
+  }
+
+  const provenance: CliBuildProvenance = {
+    schema: "wp-codebox/cli-build-provenance/v1",
+    package: packageMetadata,
+    source: await sourceIdentity(repositoryRoot, packageRoot),
+    dist: await distIdentity(packageRoot),
+    git: { commit: relationship?.head ?? expectedCommit, ref: process.env.WP_CODEBOX_SOURCE_REF ?? relationship?.ref },
+  }
+  await writeFile(join(packageRoot, "dist", CLI_BUILD_PROVENANCE_FILE), `${JSON.stringify(provenance, null, 2)}\n`)
+  return provenance
+}
+
+export async function inspectCliFreshness(packageRoot: string, binaryPath: string): Promise<CliFreshnessCheck> {
+  const provenancePath = join(packageRoot, "dist", CLI_BUILD_PROVENANCE_FILE)
+  const details: Record<string, unknown> = { packageRoot, binaryPath, provenancePath }
+  if (!existsSync(provenancePath)) {
+    return {
+      id: "wp-codebox.source",
+      status: "warning",
+      message: "CLI build provenance is missing; reinstall a release artifact or run npm run build in the source checkout",
+      details,
+    }
+  }
+
+  let parsedProvenance: unknown
+  try {
+    parsedProvenance = JSON.parse(await readFile(provenancePath, "utf8"))
+  } catch (error) {
+    return { id: "wp-codebox.source", status: "error", message: "CLI build provenance is unreadable; rebuild or reinstall WP Codebox", details: { ...details, error: errorMessage(error) } }
+  }
+  if (!parsedProvenance || typeof parsedProvenance !== "object") {
+    return { id: "wp-codebox.source", status: "error", message: "CLI build provenance schema is invalid; rebuild or reinstall WP Codebox", details: { ...details, provenance: parsedProvenance } }
+  }
+  const provenance = parsedProvenance as CliBuildProvenance
+  details.provenance = provenance
+  if (provenance.schema !== "wp-codebox/cli-build-provenance/v1") {
+    return { id: "wp-codebox.source", status: "error", message: "CLI build provenance schema is invalid; rebuild or reinstall WP Codebox", details }
+  }
+
+  const packageMetadata = await readPackageMetadata(packageRoot)
+  details.package = packageMetadata
+  if (packageMetadata.name !== provenance.package?.name || packageMetadata.version !== provenance.package?.version) {
+    return { id: "wp-codebox.source", status: "error", message: "CLI package metadata does not match its immutable build provenance; rebuild or reinstall WP Codebox", details }
+  }
+
+  const currentDist = await distIdentity(packageRoot)
+  details.dist = currentDist
+  if (currentDist.sha256 !== provenance.dist?.sha256) {
+    return { id: "wp-codebox.source", status: "error", message: "CLI dist differs from its immutable build provenance; run npm run build or reinstall WP Codebox", details }
+  }
+
+  const repositoryRoot = await gitTopLevel(packageRoot)
+  if (!repositoryRoot) {
+    return { id: "wp-codebox.source", status: "ok", message: "packaged CLI build provenance verified (not running from a Git checkout)", details }
+  }
+
+  details.repositoryRoot = repositoryRoot
+  const currentSource = await sourceIdentity(repositoryRoot, packageRoot)
+  details.source = currentSource
+  if (currentSource.sha256 !== provenance.source?.sha256) {
+    return { id: "wp-codebox.source", status: "error", message: "CLI source differs from the source identity used to build dist; run npm run build", details }
+  }
+
+  const relationship = await gitRelationship(repositoryRoot)
+  details.git = relationship ?? { evidence: "unavailable", reason: "Git HEAD could not be read", remoteFetch: "not-attempted" }
+  if (!relationship) {
+    return { id: "wp-codebox.source", status: "warning", message: "CLI source and dist match, but Git freshness evidence is unavailable", details }
+  }
+  if (provenance.git?.commit && provenance.git.commit !== relationship.head) {
+    return { id: "wp-codebox.source", status: "error", message: "CLI dist was built from a different Git commit; run npm run build", details }
+  }
+  if (relationship.evidence === "unavailable" && relationship.upstream) {
+    return { id: "wp-codebox.source", status: "warning", message: `CLI source and dist match, but configured upstream ${relationship.upstream} is unavailable locally; remote fetch was not attempted`, details }
+  }
+  if ((relationship.ahead ?? 0) > 0 && (relationship.behind ?? 0) > 0) {
+    return { id: "wp-codebox.source", status: "warning", message: `CLI checkout has diverged from locally available upstream ${relationship.upstream}`, details }
+  }
+  if ((relationship.behind ?? 0) > 0) {
+    return { id: "wp-codebox.source", status: "warning", message: `CLI checkout is ${relationship.behind} commit(s) behind locally available upstream ${relationship.upstream}; refresh the checkout, then run npm run build`, details }
+  }
+  if ((relationship.ahead ?? 0) > 0) {
+    return { id: "wp-codebox.source", status: "ok", message: `CLI source/dist provenance verified; checkout is ${relationship.ahead} commit(s) ahead of locally available upstream ${relationship.upstream}`, details }
+  }
+  if (relationship.upstream) {
+    return { id: "wp-codebox.source", status: "ok", message: `CLI source/dist provenance verified against locally available upstream ${relationship.upstream}; remote fetch was not attempted`, details }
+  }
+  return { id: "wp-codebox.source", status: "ok", message: "CLI source/dist provenance verified; no configured upstream is available and remote fetch was not attempted", details }
+}
+
+export async function findPackageRoot(start: string): Promise<string | undefined> {
+  let directory = dirname(start)
+  while (directory && directory !== dirname(directory)) {
+    if (existsSync(join(directory, "package.json"))) return directory
+    directory = dirname(directory)
+  }
+  return undefined
+}
+
+async function readPackageMetadata(packageRoot: string): Promise<{ name: string; version: string }> {
+  const metadata = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as { name?: string; version?: string }
+  if (!metadata.name || !metadata.version) throw new Error(`CLI package metadata is incomplete at ${packageRoot}`)
+  return { name: metadata.name, version: metadata.version }
+}
+
+async function sourceIdentity(repositoryRoot: string, packageRoot: string): Promise<FileIdentity> {
+  const files = [
+    ...(await recursiveFiles(join(packageRoot, "src"))),
+    join(packageRoot, "package.json"),
+    join(packageRoot, "tsconfig.json"),
+    join(repositoryRoot, "tsconfig.base.json"),
+  ].filter(existsSync)
+  return hashFiles(repositoryRoot, files)
+}
+
+async function distIdentity(packageRoot: string): Promise<FileIdentity> {
+  const distRoot = join(packageRoot, "dist")
+  const files = (await recursiveFiles(distRoot)).filter((path) => path !== join(distRoot, CLI_BUILD_PROVENANCE_FILE) && !path.endsWith(".tsbuildinfo"))
+  return hashFiles(packageRoot, files)
+}
+
+async function recursiveFiles(root: string): Promise<string[]> {
+  if (!existsSync(root)) return []
+  const files: string[] = []
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) files.push(...await recursiveFiles(path))
+    else if (entry.isFile()) files.push(path)
+  }
+  return files
+}
+
+async function hashFiles(root: string, files: string[]): Promise<FileIdentity> {
+  const hash = createHash("sha256")
+  for (const path of files.sort()) {
+    hash.update(relative(root, path).split("\\").join("/"))
+    hash.update("\0")
+    hash.update(await readFile(path))
+    hash.update("\0")
+  }
+  return { sha256: hash.digest("hex"), files: files.length }
+}
+
+async function gitTopLevel(cwd: string): Promise<string | undefined> {
+  const result = await git(cwd, ["rev-parse", "--show-toplevel"])
+  return result?.stdout ? resolve(result.stdout) : undefined
+}
+
+async function gitRelationship(cwd: string): Promise<GitRelationship | undefined> {
+  const head = await git(cwd, ["rev-parse", "HEAD"])
+  if (!head?.stdout) return undefined
+  const ref = (await git(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]))?.stdout
+  const upstream = (await git(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]))?.stdout ?? await configuredUpstream(cwd, ref)
+  if (!upstream) {
+    return { head: head.stdout, ref, evidence: "unavailable", reason: "no configured upstream", remoteFetch: "not-attempted" }
+  }
+  const upstreamHead = (await git(cwd, ["rev-parse", upstream]))?.stdout
+  const counts = await git(cwd, ["rev-list", "--left-right", "--count", `HEAD...${upstream}`])
+  if (!upstreamHead || !counts?.stdout) {
+    return { head: head.stdout, ref, upstream, evidence: "unavailable", reason: "configured upstream ref is unavailable locally", remoteFetch: "not-attempted" }
+  }
+  const [ahead, behind] = counts.stdout.split(/\s+/).map((value) => Number.parseInt(value, 10))
+  return { head: head.stdout, ref, upstream, upstreamHead, ahead, behind, evidence: "local-tracking-ref", remoteFetch: "not-attempted" }
+}
+
+async function configuredUpstream(cwd: string, ref?: string): Promise<string | undefined> {
+  if (!ref) return undefined
+  const remote = (await git(cwd, ["config", "--get", `branch.${ref}.remote`]))?.stdout
+  const merge = (await git(cwd, ["config", "--get", `branch.${ref}.merge`]))?.stdout
+  if (!remote || !merge) return undefined
+  const branch = merge.replace(/^refs\/heads\//, "")
+  return remote === "." ? branch : `${remote}/${branch}`
+}
+
+function git(cwd: string, args: string[]): Promise<{ stdout: string } | undefined> {
+  return new Promise((resolveGit) => {
+    const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "ignore"] })
+    const stdout: Buffer[] = []
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)))
+    child.once("error", () => resolveGit(undefined))
+    child.once("close", (code) => resolveGit(code === 0 ? { stdout: Buffer.concat(stdout).toString().trim() } : undefined))
+  })
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -3,8 +3,9 @@ import { spawn } from "node:child_process"
 import { existsSync } from "node:fs"
 import { opendir, readFile, realpath, stat, unlink } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, join, resolve } from "node:path"
+import { join, resolve } from "node:path"
 import { DEFAULT_TEMP_RUNTIME_SCAN_LIMIT, DEFAULT_TEMP_RUNTIME_USAGE_ENTRY_LIMIT, inventoryTempRuntimeDirectories } from "./temp-runtime-cleanup.js"
+import { findPackageRoot, inspectCliFreshness } from "../cli-build-provenance.js"
 
 type HealthStatus = "ok" | "warning" | "error"
 
@@ -179,12 +180,7 @@ async function sourceCheck(): Promise<HealthCheck> {
   if (!root) {
     return { id: "wp-codebox.source", status: "warning", message: "package root not found for wp-codebox binary", details: { binaryPath } }
   }
-  return {
-    id: "wp-codebox.source",
-    status: "ok",
-    message: "wp-codebox source resolved",
-    details: { packageRoot: root, packageJsonSha256: await sha256File(join(root, "package.json")).catch(() => undefined), gitHead: await gitHead(root) },
-  }
+  return inspectCliFreshness(root, binaryPath)
 }
 
 async function staleRecipeRunCheck(options: DoctorOptions): Promise<HealthCheck> {
@@ -282,30 +278,10 @@ function defaultArchiveRoots(): string[] {
   return [join(homedir(), ".cache", "wp-codebox"), join(homedir(), ".wp-codebox"), join(homedir(), ".cache", "wordpress-playground"), join(homedir(), ".wordpress-playground")]
 }
 
-async function findPackageRoot(start: string): Promise<string | undefined> {
-  let directory = dirname(start)
-  while (directory && directory !== dirname(directory)) {
-    if (existsSync(join(directory, "package.json"))) {
-      return directory
-    }
-    directory = dirname(directory)
-  }
-  return undefined
-}
-
 async function sha256File(path: string): Promise<string> {
   const hash = createHash("sha256")
   hash.update(await readFile(path))
   return hash.digest("hex")
-}
-
-async function gitHead(cwd: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFile("git", ["rev-parse", "HEAD"], { cwd })
-    return stdout.trim() || undefined
-  } catch {
-    return undefined
-  }
 }
 
 interface ProcessRow { pid: number; ageSeconds: number; command: string }

--- a/scripts/doctor-command-smoke.ts
+++ b/scripts/doctor-command-smoke.ts
@@ -26,6 +26,9 @@ try {
   assert.equal(doctor.cleanup, false)
   assert.equal(doctor.status, "warning")
   assert.ok(doctor.checks.some((check: { id: string }) => check.id === "wp-codebox.binary"))
+  const sourceCheck = doctor.checks.find((check: { id: string }) => check.id === "wp-codebox.source")
+  assert.equal(sourceCheck.status, "ok")
+  assert.equal(sourceCheck.details.provenance.schema, "wp-codebox/cli-build-provenance/v1")
   const runtimeCheck = doctor.checks.find((check: { id: string }) => check.id === "wp-codebox.temp-runtime")
   const processEvidenceAvailable = runtimeCheck.details.candidateCount === 1
   if (processEvidenceAvailable) {

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -136,6 +136,7 @@ export const smokeGroups = {
     description: "Package build contract smoke checks.",
     commands: [
       npmScript("build"),
+      npmScript("test:cli-build-freshness"),
       npmScript("test:runtime-services"),
       npmScript("test:runtime-services-lifecycle"),
       npmScript("test:disposable-mysql-mysqli-e2e"),

--- a/scripts/write-cli-build-provenance.ts
+++ b/scripts/write-cli-build-provenance.ts
@@ -1,0 +1,10 @@
+import { resolve } from "node:path"
+
+import { inspectCliFreshness, writeCliBuildProvenance } from "../packages/cli/src/cli-build-provenance.ts"
+
+const repositoryRoot = resolve(import.meta.dirname, "..")
+const packageRoot = resolve(repositoryRoot, "packages", "cli")
+const provenance = await writeCliBuildProvenance(repositoryRoot, packageRoot)
+const check = await inspectCliFreshness(packageRoot, resolve(packageRoot, "dist", "index.js"))
+if (check.status === "error") throw new Error(check.message)
+process.stdout.write(`WP Codebox CLI build provenance: ${provenance.package.version} ${provenance.git.commit ?? "no-git-commit"} ${provenance.source.sha256}\n`)

--- a/tests/cli-build-freshness.test.ts
+++ b/tests/cli-build-freshness.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { test } from "node:test"
+import { promisify } from "node:util"
+
+import { inspectCliFreshness, writeCliBuildProvenance } from "../packages/cli/src/cli-build-provenance.ts"
+
+const execFileAsync = promisify(execFile)
+
+test("reports fresh source/dist and locally available upstream state", async () => {
+  await withCheckout(async ({ root, packageRoot, binaryPath }) => {
+    const check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "ok")
+    assert.match(check.message, /locally available upstream origin\/main/)
+    assert.deepEqual(check.details.git, {
+      head: await git(root, "rev-parse", "HEAD"),
+      ref: "main",
+      upstream: "origin/main",
+      upstreamHead: await git(root, "rev-parse", "HEAD"),
+      ahead: 0,
+      behind: 0,
+      evidence: "local-tracking-ref",
+      remoteFetch: "not-attempted",
+    })
+  })
+})
+
+test("rejects dist that differs from build provenance", async () => {
+  await withCheckout(async ({ packageRoot, binaryPath }) => {
+    await writeFile(binaryPath, "stale dist\n")
+    const check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "error")
+    assert.match(check.message, /dist differs/)
+  })
+})
+
+test("rejects source changed after dist was built", async () => {
+  await withCheckout(async ({ packageRoot, binaryPath }) => {
+    await writeFile(join(packageRoot, "src", "index.ts"), "export const source = 'new'\n")
+    const check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "error")
+    assert.match(check.message, /source differs/)
+  })
+})
+
+test("reports checkout ahead of and behind its local upstream", async () => {
+  await withCheckout(async ({ root, packageRoot, binaryPath }) => {
+    await writeFile(join(packageRoot, "src", "ahead.ts"), "export const ahead = true\n")
+    await git(root, "add", ".")
+    await git(root, "commit", "-m", "ahead")
+    await writeCliBuildProvenance(root, packageRoot)
+    let check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "ok")
+    assert.match(check.message, /1 commit\(s\) ahead/)
+
+    const upstreamCommit = await git(root, "commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "upstream")
+    await git(root, "update-ref", "refs/remotes/origin/main", upstreamCommit)
+    check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "warning")
+    assert.match(check.message, /1 commit\(s\) behind/)
+  })
+})
+
+test("makes unavailable upstream evidence explicit", async () => {
+  await withCheckout(async ({ root, packageRoot, binaryPath }) => {
+    await git(root, "branch", "--unset-upstream")
+    const check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "ok")
+    assert.match(check.message, /no configured upstream.*remote fetch was not attempted/)
+    assert.equal((check.details.git as { evidence: string }).evidence, "unavailable")
+  })
+})
+
+test("warns when a configured upstream ref is unavailable locally", async () => {
+  await withCheckout(async ({ root, packageRoot, binaryPath }) => {
+    await git(root, "branch", "--unset-upstream")
+    await git(root, "config", "branch.main.remote", "origin")
+    await git(root, "config", "branch.main.merge", "refs/heads/missing")
+    const check = await inspectCliFreshness(packageRoot, binaryPath)
+    assert.equal(check.status, "warning")
+    assert.match(check.message, /configured upstream origin\/missing is unavailable locally.*remote fetch was not attempted/)
+  })
+})
+
+test("verifies packaged provenance without a Git checkout or source tree", async () => {
+  await withCheckout(async ({ packageRoot, binaryPath }) => {
+    const packagedRoot = await mkdtemp(join(tmpdir(), "wp-codebox-packaged-cli-"))
+    try {
+      await cp(join(packageRoot, "package.json"), join(packagedRoot, "package.json"))
+      await cp(join(packageRoot, "dist"), join(packagedRoot, "dist"), { recursive: true })
+      const check = await inspectCliFreshness(packagedRoot, join(packagedRoot, "dist", "index.js"))
+      assert.equal(check.status, "ok")
+      assert.match(check.message, /not running from a Git checkout/)
+    } finally {
+      await rm(packagedRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+async function withCheckout(run: (fixture: { root: string; packageRoot: string; binaryPath: string }) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "wp-codebox-cli-freshness-"))
+  const packageRoot = join(root, "packages", "cli")
+  const binaryPath = join(packageRoot, "dist", "index.js")
+  try {
+    await mkdir(join(packageRoot, "src"), { recursive: true })
+    await mkdir(join(packageRoot, "dist"), { recursive: true })
+    await writeFile(join(packageRoot, "src", "index.ts"), "export const source = 'fresh'\n")
+    await writeFile(binaryPath, "export const dist = 'fresh'\n")
+    await writeFile(join(packageRoot, "package.json"), `${JSON.stringify({ name: "@automattic/wp-codebox-cli", version: "1.2.3" })}\n`)
+    await writeFile(join(packageRoot, "tsconfig.json"), "{}\n")
+    await writeFile(join(root, "tsconfig.base.json"), "{}\n")
+    await git(root, "init", "-b", "main")
+    await git(root, "config", "user.name", "WP Codebox Test")
+    await git(root, "config", "user.email", "test@wp-codebox.invalid")
+    await git(root, "add", ".")
+    await git(root, "commit", "-m", "fixture")
+    await git(root, "remote", "add", "origin", root)
+    await git(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+    await git(root, "branch", "--set-upstream-to", "origin/main", "main")
+    await writeCliBuildProvenance(root, packageRoot)
+    await run({ root, packageRoot, binaryPath })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd })
+  return stdout.trim()
+}

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -105,6 +105,11 @@ try {
   const pluginCliRoot = join(pluginExtraction, "wp-codebox", "vendor", "wp-codebox-cli")
   const tarCliRoot = join(cliExtraction, "wp-codebox-cli")
   for (const root of [pluginCliRoot, tarCliRoot]) {
+    const cliBuildProvenance = JSON.parse(await readFile(join(root, "packages", "cli", "dist", "cli-build-provenance.json"), "utf8"))
+    assert.equal(cliBuildProvenance.schema, "wp-codebox/cli-build-provenance/v1")
+    assert.equal(cliBuildProvenance.package.version, JSON.parse(await readFile(join(root, "packages", "cli", "package.json"), "utf8")).version)
+    assert.match(cliBuildProvenance.source.sha256, /^[a-f0-9]{64}$/)
+    assert.match(cliBuildProvenance.dist.sha256, /^[a-f0-9]{64}$/)
     const browserProvenance = JSON.parse(await readFile(join(root, "browser-provenance.json"), "utf8"))
     assert.equal(browserProvenance.schema, "wp-codebox/playwright-browser-provenance/v1")
     assert.equal(browserProvenance.playwrightVersion, "1.61.1")


### PR DESCRIPTION
## Summary

- generate immutable `wp-codebox/cli-build-provenance/v1` evidence after normal and release builds, binding package version, Git commit/ref, source identity, and compiled dist identity
- make `wp-codebox doctor` fail or warn actionably when source/dist/package provenance differs or the checkout is behind/diverged from its locally available upstream
- preserve packaged non-Git behavior and keep doctor non-mutating: it does not fetch, rebuild, or modify checkouts

Refs #1222
Related owner gap: Extra-Chill/homeboy-extensions#2677

## Root Cause

The CLI previously reported only a package JSON hash and current Git HEAD. Compiled `dist` carried no immutable record of the source/version/commit that produced it, so doctor could not distinguish a fresh build from stale generated output. Release/deploy also correctly treated the private root npm package separately from the WordPress plugin artifact, leaving independently installed global copies untouched.

## Ownership Boundary

WP Codebox owns its CLI source, build artifacts, package metadata, provenance, and diagnostics. This PR adds only that contract.

The WordPress Homeboy extension owns managed WP Codebox installation/refresh. Its setup currently accepts runnable ambient/global `wp-codebox-workspace` candidates based on runtime and minimum-version probes, including the production `~/.opencode` install. Extra-Chill/homeboy-extensions#2677 tracks consuming this provenance contract and converging ambient stale installs without adding WP Codebox literals to generic Homeboy or Data Machine Code layers.

## Provenance And Freshness Contract

- `packages/cli/dist/cli-build-provenance.json` records package name/version, source SHA-256 identity, dist SHA-256 identity, and build Git commit/ref.
- Build and release-build regenerate provenance after TypeScript compilation, then immediately verify it. A configured `WP_CODEBOX_SOURCE_SHA` that differs from checkout HEAD fails loudly.
- Doctor verifies package metadata and dist bytes for every installation.
- In a Git checkout, doctor also verifies tracked CLI source identity and build commit, then reports ahead/behind/diverged state against the configured locally available upstream.
- Doctor explicitly reports that it does not fetch. Missing configured upstream refs warn rather than being treated as fresh; no configured upstream is reported explicitly.
- Packaged CLIs outside Git verify immutable package/dist provenance without false positives.

## Remediation Behavior

Doctor reports `npm run build` for stale source/dist checkouts and reinstalling a release artifact for stale packaged installs. Normal CLI commands never fetch, rebuild, or mutate Git. The existing explicit `npm run wp-codebox:source -- ...` launcher remains the safe source-checkout rebuild path.

## Tests

Passed:

- `npm run build`
- `npm run test:cli-build-freshness`
- `npm run smoke -- --command=doctor-command-smoke`
- `npm run smoke -- --command=source-checkout-entrypoint-smoke`
- `npm run smoke:cli-version`
- `npm run package:wordpress-plugin`
- `npm run smoke -- --group package`
- `npm run test:release-target`
- `npm run test:sharp-release-runtime`
- `npm run test:prepare-declaration-rebuild`
- `npm run test:release-package-coverage`
- built `wp-codebox doctor --json` returned `ok` with matching source/dist/commit and explicit local-upstream/no-fetch evidence

The package-group Docker-backed disposable MySQL E2E reported its existing skip because `docker info` is unavailable; all other declared gates passed.

No secrets, generated version changes, `CHANGELOG.md` edits, release, deploy, or production source modification occurred.