### PR TITLE
fix: preserve redacted artifact integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "test:editor-actions-save-integration": "node --import tsx --test tests/editor-actions-save.integration.test.ts",
     "test:editor-validate-blocks": "tsx tests/editor-validate-blocks.test.ts",
     "test:artifact-result-envelope": "tsx tests/artifact-result-envelope.test.ts",
+    "test:artifact-redaction-integrity": "tsx tests/artifact-redaction-integrity.test.ts",
     "test:async-agent-task-contracts": "tsx tests/async-agent-task-contracts.test.ts",
     "test:artifact-reference-dtos": "tsx tests/artifact-reference-dtos.test.ts",
     "test:artifact-path-primitives": "tsx tests/artifact-path-primitives.test.ts",

--- a/packages/cli/src/commands/recipe-declared-artifacts.ts
+++ b/packages/cli/src/commands/recipe-declared-artifacts.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer"
-import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, materializeStructuredArtifactFiles, redactJsonValue, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type Runtime, type StructuredArtifactPayload, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, materializeStructuredArtifactFiles, redactJsonText, redactJsonValue, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type Runtime, type StructuredArtifactPayload, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { appendRecipeRuntimeEvidenceFiles } from "../recipe-evidence.js"
 import { rewriteInputMountPath, type InputMountPathMapping } from "../input-mount-paths.js"
@@ -128,7 +128,7 @@ export async function materializeTypedRecipeDeclaredArtifacts(artifacts: Artifac
         source: artifact.path,
       },
     })
-    inputs.push({ artifact, ref, contents, contentType: typedArtifact.contentType })
+    inputs.push({ artifact, ref, contents: redactTypedArtifactContents(contents, typedArtifact.contentType), contentType: typedArtifact.contentType })
   }
 
   if (inputs.length === 0) {
@@ -157,6 +157,14 @@ export async function materializeTypedRecipeDeclaredArtifacts(artifacts: Artifac
     maxBytes: DECLARED_ARTIFACT_CAPTURE_MAX_BYTES,
   }))
   await appendRecipeRuntimeEvidenceFiles(artifacts, files)
+}
+
+function redactTypedArtifactContents(contents: Buffer, contentType: string): Buffer {
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase()
+  if (mediaType !== "application/json" && !mediaType?.endsWith("+json")) {
+    return contents
+  }
+  return Buffer.from(redactJsonText(contents.toString("utf8"), { profile: "browser_event" }), "utf8")
 }
 
 function recipeRunTypedArtifactDeclaration(artifact: RecipeRunDeclaredArtifact): { name: string; type: string; contentType: string; payloadSchema?: string | Record<string, unknown> } | undefined {

--- a/packages/runtime-core/src/artifact-capture-policy.ts
+++ b/packages/runtime-core/src/artifact-capture-policy.ts
@@ -3,7 +3,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path"
 
 import { artifactFileDigest, artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions } from "./artifact-manifest.js"
 import { resolveArtifactPath, safeArtifactRelativePath } from "./artifact-paths.js"
-import { containsSecretLikeValue, redactString } from "./redaction.js"
+import { containsSecretLikeValue, redactJsonText, redactString } from "./redaction.js"
 
 export interface ArtifactPartInput {
   root: string
@@ -98,7 +98,11 @@ export async function captureArtifactFile(input: CapturedArtifactFileInput): Pro
       return captureSkipped(input, relativePath, "sensitive", "secret-like-value", { originalBytes: contents.byteLength, maxBytes, allowedRoots })
     }
 
-    const capturedContents = binary ? contents : Buffer.from(input.redact ? input.redact(relativePath, text) : redactString(text), "utf8")
+    const capturedContents = binary ? contents : Buffer.from(input.redact
+      ? input.redact(relativePath, text)
+      : isJsonContentType(input.contentType)
+        ? redactJsonText(text, { profile: "browser_event" })
+        : redactString(text), "utf8")
     await mkdir(dirname(absolutePath), { recursive: true })
     await writeFile(absolutePath, capturedContents)
     const manifestFile = artifactManifestFile(relativePath, input.kind, input.contentType ?? (binary ? "application/octet-stream" : "text/plain; charset=utf-8"), artifactFileDigest(capturedContents), {
@@ -126,6 +130,11 @@ export async function captureArtifactFile(input: CapturedArtifactFileInput): Pro
     }
     return captureSkipped(input, relativePath, "failed", "capture-failed", { maxBytes, allowedRoots, error: error instanceof Error ? error.message : String(error) })
   }
+}
+
+function isJsonContentType(contentType: string | undefined): boolean {
+  const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase()
+  return mediaType === "application/json" || Boolean(mediaType?.endsWith("+json"))
 }
 
 export function normalizeArtifactPartPath(path: string): string {

--- a/packages/runtime-core/src/redaction.ts
+++ b/packages/runtime-core/src/redaction.ts
@@ -94,6 +94,11 @@ export function redactJsonValue(value: unknown, options: RedactJsonOptions = {},
   return value
 }
 
+export function redactJsonText(value: string, options: RedactJsonOptions = {}): string {
+  const redacted = redactJsonValue(JSON.parse(value), options)
+  return `${JSON.stringify(redacted, null, 2)}\n`
+}
+
 export function redactString(value: string, options: RedactStringOptions = {}): string {
   return value
     .replace(/(^|\r?\n)([ \t]*([A-Za-z0-9_-]+)[ \t]*:[ \t]*)[^\r\n]*/g, (line, prefix: string, assignment: string, key: string) => (

--- a/tests/artifact-redaction-integrity.test.ts
+++ b/tests/artifact-redaction-integrity.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { artifactFileDigest, type ArtifactManifest, type Runtime, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { verifyArtifactBundle } from "../packages/runtime-core/src/artifact-bundle-verifier.js"
+import { collectRecipeDeclaredArtifacts, materializeTypedRecipeDeclaredArtifacts } from "../packages/cli/src/commands/recipe-declared-artifacts.js"
+import { collectPlaygroundArtifacts } from "../packages/runtime-playground/src/runtime-artifact-helpers.js"
+import type { BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-redaction-integrity-"))
+const artifactRoot = join(root, "artifacts")
+const screenshots = [
+  "files/browser/screenshot-gardner-granted-social-operator.png",
+  "files/browser/screenshot-ordinary-team-social-denial.png",
+]
+const secretToken = "sk-abcdefghijklmnopqrstuvwxyz"
+interface TypedArtifactIndexFixture {
+  artifacts: Array<{
+    name: string
+    type: string
+    payload: { oracleIds: string[] }
+    artifact: { path: string; sha256: string }
+  }>
+}
+const typedPayload = {
+  schema: "fixture/state-transition-ledger/v1",
+  oracleIds: ["state-loss", "authorization-bypass"],
+  authorization: "Bearer fixture-authorization-secret",
+  api_token: secretToken,
+}
+
+try {
+  await mkdir(join(artifactRoot, "files/browser"), { recursive: true })
+  await Promise.all(screenshots.map((path, index) => writeFile(join(artifactRoot, path), Buffer.from([index + 1]))))
+  await writeFile(join(artifactRoot, "files/browser/action-summary.json"), `${JSON.stringify({ schema: "wp-codebox/browser-actions/v1", files: { screenshots } }, null, 2)}\n`)
+
+  const browserArtifact: BrowserArtifact = {
+    artifactType: "actions",
+    requestedUrl: "https://example.test/",
+    url: "https://example.test/",
+    preview: { requestedMode: "local", effectiveMode: "local", localOrigin: "https://example.test", effectiveOrigin: "https://example.test", diagnostics: [] },
+    files: { screenshots, summary: "files/browser/action-summary.json" },
+    summary: { actions: 2, steps: 2, consoleMessages: 0, errors: 0, finalUrl: "https://example.test/", htmlSnapshot: false, networkEvents: 0, replayability: "partial", screenshot: false, viewport: null },
+  }
+  const artifacts = await collectPlaygroundArtifacts({
+    artifactRoot,
+    browserProbes: [browserArtifact],
+    commands: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    events: [],
+    info: async () => ({ id: "artifact-redaction-integrity", backend: "wordpress-playground", status: "ready", createdAt: "2026-01-01T00:00:00.000Z", environment: { kind: "wordpress" } }),
+    mounts: [],
+    observations: [],
+    pluginChecks: [],
+    previewInfo: async () => undefined,
+    recordArtifactsCollected: () => {},
+    runtimeId: "artifact-redaction-integrity",
+    snapshots: [],
+    spec: { environment: { blueprint: {} } },
+    themeChecks: [],
+  })
+
+  const recipe = {
+    schema: "wp-codebox/recipe/v1",
+    runtime: { kind: "wordpress-playground" },
+    workflow: { steps: [] },
+    artifacts: {
+      verify: { enabled: true, strict: true },
+      typed: [{ name: "state-transition-ledger", type: "fixture/state-transition-ledger/v1", path: "/tmp/state-transition-ledger.json", contentType: "application/json", parseJson: true }],
+    },
+  } as unknown as WorkspaceRecipe
+  const payloadContents = Buffer.from(JSON.stringify(typedPayload))
+  const runtime = {
+    execute: async () => ({
+      id: "collect-typed-artifact",
+      command: "wordpress.run-php",
+      args: [],
+      exitCode: 0,
+      stdout: `${JSON.stringify({ exists: true, type: "file", size: payloadContents.byteLength, sha256: artifactFileDigest(payloadContents).value, parsedJson: typedPayload, contentBase64: payloadContents.toString("base64") })}\n`,
+      stderr: "",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:00.000Z",
+    }),
+  } as unknown as Runtime
+  const declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, runtime)
+  await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
+
+  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
+  for (const screenshot of screenshots) {
+    assert.equal(manifest.files.filter((file) => file.path === screenshot).length, 1)
+  }
+  const index = JSON.parse(await readFile(join(artifactRoot, "files/runtime-evidence/typed-artifacts/index.json"), "utf8")) as TypedArtifactIndexFixture
+  assert.equal(index.artifacts[0].name, "state-transition-ledger")
+  assert.equal(index.artifacts[0].type, "fixture/state-transition-ledger/v1")
+  assert.deepEqual(index.artifacts[0].payload.oracleIds, ["state-loss", "authorization-bypass"])
+  const materializedPath = index.artifacts[0].artifact.path as string
+  const materializedContents = await readFile(join(artifactRoot, materializedPath), "utf8")
+  const materializedPayload = JSON.parse(materializedContents)
+  assert.deepEqual(materializedPayload.oracleIds, ["state-loss", "authorization-bypass"])
+  assert.equal(materializedPayload.authorization, "[redacted]")
+  assert.equal(materializedPayload.api_token, "[redacted]")
+  assert.doesNotMatch(`${JSON.stringify(index)}\n${materializedContents}`, new RegExp(secretToken))
+  assert.equal(artifactFileDigest(materializedContents).value, index.artifacts[0].artifact.sha256)
+
+  const verification = await verifyArtifactBundle(artifactRoot, { strict: true })
+  assert.equal(verification.valid, true, JSON.stringify(verification.violations, null, 2))
+  assert.deepEqual(verification.violations, [])
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("artifact redaction integrity ok")


### PR DESCRIPTION
## Summary

- structurally redact JSON artifact content so sensitive-looking domain vocabulary cannot consume JSON delimiters
- redact typed JSON payloads before materialization records payload/index hashes, keeping final bundle bytes and embedded SHA-256 references aligned
- verify the original strict consumer shape end to end: named browser screenshots plus a `state-transition-ledger` typed artifact containing `state-loss` and `authorization-bypass`

## Root Causes

1. Named `wordpress.browser-actions` screenshot steps wrote PNGs under `files/browser/`, but older browser action results did not expose those paths through `BrowserArtifact.files.screenshots`, so final manifest assembly could not include them and strict orphan detection rejected the bundle. Main already contains the production registration fix from `a6067fca` (`fix: manifest all browser screenshots`); this PR adds strict end-to-end coverage proving every named screenshot is manifested exactly once.
2. Typed JSON payloads and `typed-artifacts/index.json` passed through text-oriented `redactString()`. Its assignment heuristic could interpret values such as `state-transition-ledger` as secret assignments and replace the following comma, changing valid JSON like `\"name\": \"state-transition-ledger\",` into malformed `\"name\": \"state-transition-ledger\"[redacted]`. Typed payload refs were also hashed before that later capture-time mutation, leaving embedded hashes pointed at pre-redaction bytes.

## Redaction And Digest Ordering

JSON capture now parses the document, redacts by key/value policy, and serializes valid JSON instead of applying assignment regexes to serialized syntax. Typed JSON bytes are structurally redacted before `materializeStructuredArtifactFiles()` computes payload hashes and builds the typed index; capture then hashes the final persisted bytes.

Before:

```json
{
  "name": "state-transition-ledger"[redacted]
  "type": "fixture/state-transition-ledger/v1"
}
```

After:

```json
{
  "name": "state-transition-ledger",
  "type": "fixture/state-transition-ledger/v1",
  "payload": {
    "oracleIds": ["state-loss", "authorization-bypass"],
    "authorization": "[redacted]",
    "api_token": "[redacted]"
  }
}
```

## Secret Safety

The strict integration fixture includes an authorization value and an OpenAI-shaped token. It asserts both are redacted, the token is absent from payload and index bytes, oracle IDs remain exact, the typed payload SHA-256 equals the index reference, both screenshots occur once in `manifest.json`, and strict verification returns no violations.

## Verification

- `npm run test:artifact-redaction-integrity`
- `npm run test:browser-artifact-session`
- `npm run test:redaction`
- `npx tsx tests/structured-artifact-materializer.test.ts`
- `npx tsx scripts/artifact-bundle-verifier-smoke.ts`
- `npx tsx scripts/artifact-redaction-smoke.ts`
- `npx tsx scripts/typed-artifacts-smoke.ts`
- `npx tsx tests/adversarial-campaign.test.ts` (11 passed)
- `npx tsx tests/recipe-browser-evidence.test.ts`
- `npm run test:browser-actions-environment` (10 passed)
- `npm run test:browser-transport-faults` (5 passed)
- `npm run build:release`
- `npm run smoke -- --group=package` (passed; Docker-only MySQL E2E skipped because Docker is unavailable)
- `npm run test:release-package-coverage`
- `npm run test:cli-build-freshness` (7 passed)

The broader artifact smoke group reaches two unrelated existing failures: patch-path expectation #2064 and executable browser DTO fixture #2340. All artifact smoke commands relevant to this change pass.

## Consumer Relation

Studio PR #184 remains a valid consumer mitigation for WP Codebox 0.23.3: it removed explicit named screenshot steps and collected ledgers as parsed declared artifacts while keeping strict verification enabled. This PR fixes the typed JSON redaction/hash ordering underneath that mitigation and locks in the already-landed named screenshot registration so consumers can safely restore the original shape.

Closes #2339