### PR TITLE
test: restore callback metadata contract

### DIFF
--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -242,7 +242,8 @@ try {
   await fetch(`${proxied.serverUrl}/service-worker-redirect?nonce=PRIVATE_ORDINARY_NONCE`, { redirect: "manual" })
   assert.equal(proxied.previewProxyDiagnostics?.requestTrace.total, 0, "ordinary redirects remain outside the service-worker trace")
   await fetch(`${proxied.serverUrl}/sw.js`)
-  assert.deepEqual(proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1), {
+  const serviceWorkerResponse = proxied.previewProxyDiagnostics?.requestTrace.entries.at(-1)
+  assert.deepEqual(serviceWorkerResponse, {
     sequence: 1,
     method: "GET",
     path: "/sw.js",
@@ -250,7 +251,13 @@ try {
     serviceWorker: false,
     outcome: "response",
     status: 200,
+    contentLength: "2",
+    serviceWorkerAllowed: "/",
+    bodyRewritten: false,
   })
+  assert.equal(serviceWorkerResponse?.contentLength, "2", "the trace preserves the normalized response content length")
+  assert.equal(serviceWorkerResponse?.serviceWorkerAllowed, "/", "the trace exposes the worker's allowed root scope")
+  assert.equal(serviceWorkerResponse?.bodyRewritten, false, "the trace reports that an untyped worker body was not rewritten")
   const redirectResponse = await fetch(`${proxied.serverUrl}/service-worker-redirect?nonce=PRIVATE_REQUEST_NONCE`, {
     headers: { "service-worker": "script", "sec-fetch-dest": "serviceworker" },
     redirect: "manual",
@@ -267,6 +274,7 @@ try {
     serviceWorker: true,
     outcome: "response",
     status: 302,
+    bodyRewritten: false,
     upstreamLocation: `${targetServerUrl}/login?token=[redacted]`,
     visibleLocation: `${proxied.serverUrl}/login?token=[redacted]`,
   })
@@ -285,6 +293,7 @@ try {
     serviceWorker: true,
     outcome: "response",
     status: 302,
+    bodyRewritten: false,
     upstreamLocation: `${targetServerUrl}/login?token=[redacted]`,
     visibleLocation: `${proxied.serverUrl}/login?token=[redacted]`,
   })
@@ -298,6 +307,8 @@ try {
     serviceWorker: true,
     outcome: "upstream-error",
     status: 200,
+    contentType: "application/javascript",
+    bodyRewritten: true,
   })
   assert.doesNotMatch(JSON.stringify(proxied.previewProxyDiagnostics), /PRIVATE_TRUNCATED_TOKEN/)
   await Promise.all(Array.from({ length: 64 }, (_, index) => fetch(`${proxied.serverUrl}/bounded-trace/${index}`, { headers: { "service-worker": "script", ...(index === 0 ? { "sec-fetch-dest": "PRIVATE_DESTINATION" } : {}) } })))


### PR DESCRIPTION
## Summary
- restore the exact callback materialization fixtures for bounded preview-proxy response metadata
- assert normalized content length, service-worker root scope, and body rewrite semantics directly
- retain exact object matching for redirect and truncated-response trace records

## Root cause and contract decision
`d4a734f8` intentionally added `contentLength`, `serviceWorkerAllowed`, and `bodyRewritten` to the typed bounded request trace for packaged-worker diagnostics. `b86524a0` subsequently relied on the service-worker scope metadata, while adjacent browser tests assert rewrite behavior. The callback materialization fixture retained the older exact shape, so the fixture rather than the owning contract was stale.

The response metadata remains bounded optional contract output. This PR updates exact expectations rather than weakening them to partial matching.

## Verification
- `npm run test:browser-callback-materialization-contracts` passes
- `npm run test:service-worker-preview-proxy` passes, 4/4
- `npm run test:playground-contained-scope` passes, 1/1
- `npm run build` passes
- `npm run check` passes the repaired callback contract, then stops at the independent pre-existing #1745 `command-registry-smoke` failure: `wordpress.collect-workload-result outputShape should mention outputSchema id`. Fresh reproduction recorded at https://github.com/Automattic/wp-codebox/issues/1745#issuecomment-5400382394

## AI assistance
- AI assistance: Yes
- Tool: OpenCode
- Used for: contract investigation, test fixture updates, verification, and PR preparation

Fixes #2344