### PR TITLE
fix: restore workload result registry contract

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -777,7 +777,7 @@ export const commandRegistry = [
       { name: "artifact", description: "Logical workload artifact or coverage name requested by the phase.", format: "string" },
       { name: "schema", description: "Optional expected artifact schema id for runtimes that materialize a concrete artifact.", format: "string" },
     ],
-    outputShape: "The requested typed artifact payload, for example wp-codebox/wordpress-rest-db-query-profile/v1.",
+    outputShape: "wp-codebox/typed-workload-artifact/v1 JSON object containing one requested typed artifact payload and preserving its concrete schema id, for example wp-codebox/wordpress-rest-db-query-profile/v1; collection fails when the artifact is missing or ambiguous.",
     outputSchema: objectEnvelopeSchema("wp-codebox/typed-workload-artifact/v1", {
       schema: { type: "string" },
     }),

--- a/scripts/command-registry-smoke.ts
+++ b/scripts/command-registry-smoke.ts
@@ -31,6 +31,14 @@ async function main(): Promise<void> {
     assert(Array.isArray(command.acceptedArgs), `${command.id} acceptedArgs must be an array`)
   }
 
+  const collectWorkloadResult = commandRegistry.find((command) => command.id === "wordpress.collect-workload-result")
+  assert(collectWorkloadResult, "wordpress.collect-workload-result must be registered")
+  assert(collectWorkloadResult.outputShape === "wp-codebox/typed-workload-artifact/v1 JSON object containing one requested typed artifact payload and preserving its concrete schema id, for example wp-codebox/wordpress-rest-db-query-profile/v1; collection fails when the artifact is missing or ambiguous.", "wordpress.collect-workload-result outputShape must describe the bounded typed artifact contract")
+  assert(collectWorkloadResult.outputSchema?.id === "wp-codebox/typed-workload-artifact/v1", "wordpress.collect-workload-result must declare the typed workload artifact output schema")
+  assert(collectWorkloadResult.outputSchema.jsonSchema?.type === "object", "wordpress.collect-workload-result output must be a JSON object")
+  const collectWorkloadResultSchemaProperty = (collectWorkloadResult.outputSchema.jsonSchema.properties as Record<string, Record<string, unknown>>).schema
+  assert(collectWorkloadResultSchemaProperty?.type === "string", "wordpress.collect-workload-result output must preserve the concrete artifact schema id")
+
   const metadataRuntimeIds = new Set(runtimeCommandDefinitions().map((command) => command.id))
   const handlerRuntimeIds = new Set(playgroundRuntimeCommandIds())
   const metadataWithoutHandler = sorted([...metadataRuntimeIds].filter((id) => !handlerRuntimeIds.has(id)))


### PR DESCRIPTION
## Summary

- align `wordpress.collect-workload-result` discovery metadata with its declared typed workload artifact contract
- describe the real bounded behavior: one selected typed artifact object, concrete schema preservation, and failure for missing or ambiguous matches
- add exact registry smoke coverage for the descriptor text, meta-schema ID, object output type, and concrete string `schema` field

## Root cause

The typed workload artifact change replaced the old synthetic collection envelope with the selected artifact payload and changed `outputSchema.id` to `wp-codebox/typed-workload-artifact/v1`. Its `outputShape` only named `wp-codebox/wordpress-rest-db-query-profile/v1` as an example, so the registry's general schema/shape consistency rule correctly rejected the descriptor because it omitted the declared schema ID.

This keeps the validator unchanged and fixes the owner-layer metadata instead.

## Descriptor/schema contract

- `outputSchema.id` and JSON Schema `$id`: `wp-codebox/typed-workload-artifact/v1`
- output JSON type: object
- concrete payload `schema` property: string
- output: one requested typed artifact payload preserving its concrete schema, such as `wp-codebox/wordpress-rest-db-query-profile/v1`
- failure semantics: missing and ambiguous artifact resolution fail rather than returning a synthetic marker

## Testing

- `npx tsx scripts/command-registry-smoke.ts` passes
- `npm run build --prefix packages/runtime-core` passes
- `npm run build` passes
- `npm run check` passes the repaired `command-registry-smoke` and continues until the independent stale `php-snippets-smoke` expectation tracked in #2347

Fixes #1745

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 via OpenCode
- **Used for:** Repository investigation, minimal implementation, contract coverage, verification, and PR drafting.