### PR TITLE
test: restore PHP environment snippet contract

### DIFF
--- a/scripts/php-snippets-smoke.ts
+++ b/scripts/php-snippets-smoke.ts
@@ -20,7 +20,14 @@ assert.equal(phpLiteral(false), "false")
 assert.equal(phpLiteral(12.5), "12.5")
 assert.equal(phpLiteral(null), "null")
 
-assert.equal(phpEnvAssignments({ VALID_ENV: "secret\nvalue", "INVALID-NAME": "nope" }), 'putenv("VALID_ENV=secret\\nvalue");\n')
+const escapedEnvValue = "quote' double\" newline\nbackslash\\value"
+const environmentSnippet = phpEnvAssignments({ VALID_ENV: escapedEnvValue, "INVALID-NAME": "nope" })
+assert.equal(
+  environmentSnippet,
+  'putenv("VALID_ENV=quote\' double\\" newline\\nbackslash\\\\value");\n'
+    + '$_ENV["VALID_ENV"] = "quote\' double\\" newline\\nbackslash\\\\value";\n'
+    + '$_SERVER["VALID_ENV"] = "quote\' double\\" newline\\nbackslash\\\\value";\n',
+)
 assert.equal(
   phpWpConfigDefineAssignments({ VALID_DEFINE: "value", FLAG: true, COUNT: 3, NULL_VALUE: null, "INVALID-NAME": "nope", ARRAY_VALUE: [] }),
   'if (!defined("VALID_DEFINE")) { define("VALID_DEFINE", "value"); }\n'
@@ -34,9 +41,18 @@ const dir = mkdtempSync(join(tmpdir(), "wp-codebox-php-snippets-"))
 
 const staticPhp = join(dir, "static.php")
 writeFileSync(staticPhp, `<?php
-${phpEnvAssignments({ VALID_ENV: "value" })}
-${phpWpConfigDefineAssignments({ VALID_DEFINE: "value", FLAG: true, COUNT: 3, NULL_VALUE: null })}`)
+${environmentSnippet}
+${phpWpConfigDefineAssignments({ VALID_DEFINE: "value", FLAG: true, COUNT: 3, NULL_VALUE: null })}
+echo json_encode(array(
+    'accepted' => array(getenv('VALID_ENV'), $_ENV['VALID_ENV'], $_SERVER['VALID_ENV']),
+    'invalid' => array(getenv('INVALID-NAME'), array_key_exists('INVALID-NAME', $_ENV), array_key_exists('INVALID-NAME', $_SERVER)),
+));`)
 execFileSync("php", ["-l", staticPhp], { stdio: "pipe" })
+const staticEnvironmentOutput = JSON.parse(execFileSync("php", [staticPhp], { encoding: "utf8" }))
+assert.deepEqual(staticEnvironmentOutput, {
+  accepted: [escapedEnvValue, escapedEnvValue, escapedEnvValue],
+  invalid: [false, false, false],
+})
 
 const runtimePhp = join(dir, "runtime.php")
 writeFileSync(runtimePhp, `<?php
@@ -44,7 +60,7 @@ ${phpEnvAssignmentFunction("apply_env", "json_encode", "$GLOBALS['invalid_env'][
 ${phpWpConfigDefineAppenderFunction("append_defines", "$GLOBALS['invalid_define'][] = $name;")}
 
 $invalid_env = array();
-apply_env(array('SCALAR_INT' => 12, 'SCALAR_BOOL' => true, 'ARRAY_VALUE' => array('a' => 1), 'INVALID-NAME' => 'nope'));
+apply_env(array('VALID_ENV' => ${JSON.stringify(escapedEnvValue)}, 'SCALAR_INT' => 12, 'SCALAR_BOOL' => true, 'ARRAY_VALUE' => array('a' => 1), 'INVALID-NAME' => 'nope'));
 assert(getenv('SCALAR_INT') === '12');
 assert($_ENV['SCALAR_BOOL'] === '1');
 assert(getenv('ARRAY_VALUE') === '{"a":1}');
@@ -55,9 +71,19 @@ $config = "<?php\n";
 append_defines($config, array('VALID_DEFINE' => "quote' value", 'INVALID-NAME' => 'nope'));
 assert(strpos($config, "define('VALID_DEFINE', 'quote\\' value')") !== false);
 assert($invalid_define === array('INVALID-NAME'));
+
+echo json_encode(array(
+    'environment' => array(
+        'accepted' => array(getenv('VALID_ENV'), $_ENV['VALID_ENV'], $_SERVER['VALID_ENV']),
+        'invalid' => array(getenv('INVALID-NAME'), array_key_exists('INVALID-NAME', $_ENV), array_key_exists('INVALID-NAME', $_SERVER)),
+    ),
+    'invalid_names' => $invalid_env,
+));
 `)
 execFileSync("php", ["-l", runtimePhp], { stdio: "pipe" })
-execFileSync("php", [runtimePhp], { stdio: "pipe" })
+const runtimeEnvironmentOutput = JSON.parse(execFileSync("php", [runtimePhp], { encoding: "utf8" }))
+assert.deepEqual(runtimeEnvironmentOutput.environment, staticEnvironmentOutput)
+assert.deepEqual(runtimeEnvironmentOutput.invalid_names, ["INVALID-NAME"])
 
 const lifecyclePhp = join(dir, "lifecycle.php")
 writeFileSync(lifecyclePhp, `<?php


### PR DESCRIPTION
## Summary

- restore the exact `phpEnvAssignments()` smoke contract for `putenv()`, `$_ENV`, and `$_SERVER`
- exercise quote, newline, and backslash escaping through generated PHP
- prove invalid-name rejection and output parity between static snippet generation and `phpEnvAssignmentFunction()`

## Root cause

#1912 / `13ccafb5` intentionally expanded static PHP environment assignment from `putenv()` alone to all three PHP environment surfaces, matching the runtime helper. The smoke fixture retained the old one-line expectation, so `npm run check` failed even though the implementation contract was correct.

## Contract

For every accepted environment name and stringified value, both generation paths populate:

1. `getenv()` through `putenv()`
2. `$_ENV`
3. `$_SERVER`

Invalid names remain rejected. The test uses an escaped value containing quotes, a newline, and a backslash and compares the executable static/runtime results.

## Tests

- `npx tsx scripts/php-snippets-smoke.ts` passes
- `npx tsx tests/external-mysql-runtime-service.test.ts` passes
- `npm run build` passes
- `npm run check` passes the repaired `php-snippets-smoke` gate and later stops at the independent `artifact-patch-git-apply-smoke` failure tracked by #2064
- adjacent independent stale fixtures discovered during verification are tracked by #2349 and #2350; they are intentionally out of scope

Fixes #2347