### PR TITLE
test: align Playground worker default coverage

### DIFF
--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -33,7 +33,7 @@ try {
     environment: {
       version: "mounted-wordpress-source",
       phpVersion: "8.4",
-      workers: 1,
+      workers: 6,
       wordpressInstallMode: "do-not-attempt-installing",
       databaseSetup: "external",
       assets: { wordpressDirectory: wordpressDevelopDirectory },
@@ -86,7 +86,7 @@ try {
   assert.equal(calls[0]["mount-before-install"]?.[4]?.vfsPath, "/wordpress/wp-config.php")
   assert.deepEqual(calls[0]["mount-before-install"]?.[5], { hostPath: wordpressDevelopDirectory, vfsPath: "/wordpress" })
   assert.deepEqual(calls[0].mount, [])
-  assert.equal(calls[0].workers, 1)
+  assert.equal(calls[0].workers, 6)
   assert.equal("internalCookieStore" in calls[0], false, "browser cookies must remain outside the CLI-global cookie store")
   assert.equal(calls[0].wordpressInstallMode, "do-not-attempt-installing")
   assert.equal(calls[0].skipSqliteSetup, true)
@@ -168,7 +168,7 @@ try {
   await defaultRuntimeIniServer[Symbol.asyncDispose]()
 
   assert.equal(calls.length, 1)
-  assert.equal(calls[0].workers, 1)
+  assert.equal(calls[0].workers, 6)
   assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
   assert.equal(calls[0].skipSqliteSetup, false)
   assert.equal(shouldUseProgrammaticPlaygroundRunner(defaultRuntimeIniSpec), true)
@@ -193,7 +193,7 @@ try {
   assert.equal(calls[0]["mount-before-install"]?.[0]?.vfsPath, "/internal/wp-codebox")
   assert.match(calls[0]["mount-before-install"]?.[1]?.vfsPath ?? "", /^\/wordpress\/wp-codebox-execute-[a-f0-9]{24}\.php$/)
   assert.equal(calls[0].wordpressInstallMode, undefined)
-  assert.equal(calls[0].workers, 6)
+  assert.equal(calls[0].workers, 1)
   assert.equal(shouldUseProgrammaticPlaygroundRunner(downloadedWordPressSpec), false)
 
   calls.length = 0


### PR DESCRIPTION
## Summary
- update the Playground CLI fixture to assert the intentional omitted-worker default of one
- preserve explicit concurrency coverage by verifying a configured six-worker value is forwarded
- leave the production worker default unchanged

Fixes #2350

## Verification
- `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts` passed
- `npm run test:runtime-workers` passed
- `npm run test:playground-checkpoint-maintenance-integration` passed
- `npm run build --workspace @automattic/wp-codebox-playground` passed
- `npm run build` passed
- `npm run check` passed all gates until the independently reproducible `artifact-patch-git-apply-smoke` failure tracked in #2064

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 via OpenCode
- **Used for:** implementation history review, fixture update, verification, and PR preparation