### PR TITLE
test: restore runtime PHP snippet fixtures

### DIFF
--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { mkdtempSync } from "node:fs"
 import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
-import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
+import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction, type RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
 import { bootstrapPhpCode, phpCodeFromArgs } from "../packages/runtime-playground/src/php-bootstrap.js"
 import { phpEnvAssignmentFunction, phpEnvAssignments } from "../packages/runtime-playground/src/php-snippets.js"
 
@@ -116,7 +116,29 @@ assert.deepEqual(JSON.parse(actionOutput), {
   contained_runtime_abilities_ready: 1,
 })
 
+const runtimeSpec: RuntimeCreateSpec = {
+  backend: "wordpress-playground",
+  environment: {
+    kind: "wordpress",
+    version: "latest",
+    blueprint: {},
+  },
+  policy: {
+    network: "deny",
+    filesystem: "readwrite-mounts",
+    commands: ["wordpress.run-php"],
+    secrets: "none",
+    approvals: "never",
+  },
+}
+
 const bootstrappedRunPhp = bootstrapPhpCode({
+  ...runtimeSpec,
+  environment: { ...runtimeSpec.environment, databaseSetup: "external" },
+  policy: { ...runtimeSpec.policy, secrets: "connector-scoped" },
+  runtimeEnv: { EXAMPLE_RUNTIME_ENV: "runtime-value" },
+  secretEnv: { EXAMPLE_SECRET_ENV: "secret-value", MYSQL_PASSWORD: "connector-secret" },
+  secretEnvTargets: { DB_PASSWORD: "MYSQL_PASSWORD" },
   metadata: {
     recipe: {
       inputs: {
@@ -125,10 +147,13 @@ const bootstrappedRunPhp = bootstrapPhpCode({
       },
     },
   },
-} as never, "<?php echo 'ok';", [])
+}, "<?php echo 'ok';", [])
 assert.match(bootstrappedRunPhp, /contained_runtime_run_php_component_lifecycle_replay_prepare/)
 assert.match(bootstrappedRunPhp, /CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON/)
 assert.match(bootstrappedRunPhp, /define\('STDOUT', fopen\('php:\/\/stdout', 'wb'\)\)/)
+assert.match(bootstrappedRunPhp, /putenv\("EXAMPLE_RUNTIME_ENV=runtime-value"\);/)
+assert.match(bootstrappedRunPhp, /putenv\("EXAMPLE_SECRET_ENV=secret-value"\);/)
+assert.doesNotMatch(bootstrappedRunPhp, /connector-secret|MYSQL_PASSWORD|DB_PASSWORD/)
 assert.ok(bootstrappedRunPhp.indexOf("define('STDOUT'") < bootstrappedRunPhp.indexOf("require_once '/wordpress/wp-load.php';"), "CLI streams must exist before WordPress and test dependencies load")
 assert.doesNotMatch(bootstrappedRunPhp, /wp_codebox_run_php|wp_codebox_component_manifest|WP_CODEBOX_COMPONENT_MANIFEST_JSON/)
 
@@ -136,7 +161,7 @@ const strictTypesCodeFileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-run-php-s
 const strictTypesCodeFile = join(strictTypesCodeFileRoot, "strict-types.php")
 writeFileSync(strictTypesCodeFile, "<?php declare(strict_types=1);\necho 'strict';")
 const strictTypesCode = await phpCodeFromArgs([`code-file=${strictTypesCodeFile}`])
-const bootstrappedStrictTypesCodeFile = bootstrapPhpCode({} as never, strictTypesCode, [])
+const bootstrappedStrictTypesCodeFile = bootstrapPhpCode(runtimeSpec, strictTypesCode, [])
 assert.match(bootstrappedStrictTypesCodeFile, /^<\?php\ndeclare\(strict_types=1\);\nregister_shutdown_function/)
 assert.equal((bootstrappedStrictTypesCodeFile.match(/declare\(strict_types=1\);/g) ?? []).length, 1)
 assert.match(bootstrappedStrictTypesCodeFile, /echo 'strict';/)


### PR DESCRIPTION
## Summary
- replace partial `as never` PHP bootstrap fixtures with a typed, contract-valid `RuntimeCreateSpec`
- reuse the minimal spec for strict-types coverage and derive the external-database fixture through object spreads
- strengthen bootstrap assertions for runtime environment values, ordinary secrets, and connector-secret exclusion

## Fixture contract

The minimal fixture now explicitly provides:

- `backend: wordpress-playground`
- `environment.kind: wordpress`, `environment.version: latest`, and an empty blueprint
- a deny-network, readwrite-mounts runtime policy allowing `wordpress.run-php`

The secret behavior fixture derives from that base, selects `environment.databaseSetup: external`, uses `connector-scoped` secrets, maps `DB_PASSWORD` to `MYSQL_PASSWORD`, and verifies that runtime environment plus ordinary secret values are emitted while the mapped connector secret and names remain absent from generated PHP.

## Verification
- `npm run test:runtime-php-snippets` (pass)
- `npx tsx tests/external-mysql-runtime-service.test.ts` (pass)
- `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts` (independent stale worker-default assertion, tracked in #2350)
- `npm run build --workspace=@automattic/wp-codebox-playground` (pass)
- `npm run build` (pass)
- `npm run check` (passes build and preceding smoke gates, then reaches independent artifact patch path assertion tracked in #2064)
- `git diff --check` (pass)

Fixes #2349

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 via OpenCode
- **Used for:** fixture analysis, test update, verification, and PR preparation