### PR TITLE
test: align mounted deletion contract

### DIFF
--- a/scripts/mounted-workspace-diff-smoke.ts
+++ b/scripts/mounted-workspace-diff-smoke.ts
@@ -212,6 +212,7 @@ try {
   await execFileAsync("git", ["-C", vfsBackedRepo, "config", "user.name", "wp-codebox smoke"])
   await writeFile(join(vfsBackedRepo, "committed.php"), "<?php\n// committed\n")
   await writeFile(join(vfsBackedRepo, "remove-me.txt"), "delete this\n")
+  await writeFile(join(vfsBackedRepo, "preserve-me.txt"), "preserve this\n")
   await execFileAsync("git", ["-C", vfsBackedRepo, "add", "."])
   await execFileAsync("git", ["-C", vfsBackedRepo, "commit", "-q", "-m", "baseline"])
 
@@ -277,7 +278,7 @@ try {
         contentsBase64: "",
       },
       {
-        relativePath: "remove-me.txt",
+        relativePath: "preserve-me.txt",
         sha256: "unused",
       },
       {
@@ -293,15 +294,22 @@ try {
     ],
   }])
   assert.equal(emptyAndUnsafePathMaterialized.materialized, 1)
-  assert.equal(emptyAndUnsafePathMaterialized.deleted, 1)
+  assert.equal(emptyAndUnsafePathMaterialized.deleted, 0)
   assert.equal(emptyAndUnsafePathMaterialized.skipped, 2)
   assert.equal(emptyAndUnsafePathMaterialized.phaseResult.schema, "wp-codebox/materialization-phase-result/v1")
   assert.equal(emptyAndUnsafePathMaterialized.phaseResult.phase, "playground-vfs-mount-materialization")
   assert.equal(emptyAndUnsafePathMaterialized.phaseResult.status, "completed")
   assert.equal((await stat(join(vfsBackedRepo, "empty.txt"))).size, 0)
+  assert.equal(await readFile(join(vfsBackedRepo, "committed.php"), "utf8"), "<?php\n// committed\n")
+  assert.equal(await readFile(join(vfsBackedRepo, "remove-me.txt"), "utf8"), "delete this\n")
+  assert.equal(await readFile(join(vfsBackedRepo, "preserve-me.txt"), "utf8"), "preserve this\n")
   await assert.rejects(() => stat(join(root, "escaped.txt")))
 
-  const materialized = await applyVfsMountSnapshots(vfsMounts, [{
+  const deletionMounts: MountSpec[] = [{
+    ...vfsMounts[0],
+    metadata: { ...vfsMounts[0].metadata, materializeDeletes: true },
+  }]
+  const materialized = await applyVfsMountSnapshots(deletionMounts, [{
     mountIndex: 0,
     target: "/workspace/vfs-backed-repo",
     files: [
@@ -315,10 +323,20 @@ try {
         sha256: "unused",
         contentsBase64: Buffer.from("created inside playground\n").toString("base64"),
       },
+      {
+        relativePath: "preserve-me.txt",
+        sha256: "unused",
+      },
     ],
   }])
   assert.equal(materialized.materialized, 2)
   assert.equal(materialized.deleted, 2)
+  assert.equal(materialized.skipped, 0)
+  assert.equal(await readFile(join(vfsBackedRepo, "committed.php"), "utf8"), "<?php\n// edited inside playground\n")
+  assert.equal(await readFile(join(vfsBackedRepo, "AGENT_WROTE_THIS.md"), "utf8"), "created inside playground\n")
+  assert.equal(await readFile(join(vfsBackedRepo, "preserve-me.txt"), "utf8"), "preserve this\n")
+  await assert.rejects(() => stat(join(vfsBackedRepo, "empty.txt")))
+  await assert.rejects(() => stat(join(vfsBackedRepo, "remove-me.txt")))
 
   const vfsResult = await captureMountDiffs(artifactRoot, filesDirectory, vfsMounts, new ArtifactRedactor())
   const vfsChanged = new Map(vfsResult.changedFiles.files.map((file) => [file.relativePath, file]))

--- a/tests/mount-materialization-non-destructive.test.ts
+++ b/tests/mount-materialization-non-destructive.test.ts
@@ -21,22 +21,32 @@ try {
   assert.equal(skippedMaterialization.phaseResult.status, "skipped")
   assert.equal(skippedMaterialization.materialized, 0)
 
-  await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite" }], [{
+  const defaultMaterialization = await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite" }], [{
     mountIndex: 0,
     target: "/workspace/example",
-    files: [{ relativePath: "changed.txt", sha256: "", contentsBase64: Buffer.from("changed").toString("base64") }],
+    files: [
+      { relativePath: "changed.txt", sha256: "", contentsBase64: Buffer.from("changed").toString("base64") },
+      { relativePath: "host-only.txt", sha256: "" },
+    ],
   }])
 
+  assert.equal(defaultMaterialization.materialized, 1)
+  assert.equal(defaultMaterialization.deleted, 0)
+  assert.equal(defaultMaterialization.skipped, 0)
   assert.equal(await readFile(join(root, "host-only.txt"), "utf8"), "keep me", "host-only files are preserved by default")
   assert.equal(await readFile(join(root, "changed.txt"), "utf8"), "changed", "changed VFS files are written back")
 
-  await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite", metadata: { materializeDeletes: true } }], [{
+  const deletionMaterialization = await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite", metadata: { materializeDeletes: true } }], [{
     mountIndex: 0,
     target: "/workspace/example",
     files: [{ relativePath: "changed.txt", sha256: "" }],
   }])
 
+  assert.equal(deletionMaterialization.materialized, 0)
+  assert.equal(deletionMaterialization.deleted, 1)
+  assert.equal(deletionMaterialization.skipped, 0)
   await assert.rejects(readFile(join(root, "host-only.txt"), "utf8"), "explicit delete opt-in removes host-only files")
+  assert.equal(await readFile(join(root, "changed.txt"), "utf8"), "changed", "entries without contents remain present during explicit deletion")
 } finally {
   await rm(root, { recursive: true, force: true })
 }


### PR DESCRIPTION
## Summary
- align the mounted workspace smoke with the opt-in authoritative deletion contract
- prove default snapshots preserve omitted host files and treat missing `contentsBase64` as present-but-unwritten
- prove `materializeDeletes: true` deletes only omitted files while preserving present entries and exact result counters/bytes

## Verification
- `npx tsx tests/mount-materialization-non-destructive.test.ts`
- `npx tsx scripts/mounted-workspace-diff-smoke.ts`
- `npx tsx tests/playground-direct-mount-materialization.test.ts`
- `npx tsx tests/playground-readonly-mounts.test.ts`
- `npx tsx tests/recipe-run-artifacts-mount-guard.test.ts`
- `npm run test:mount-artifact-capture-policy`
- `npm run build`
- artifact smoke commands pass except the pre-existing `executable-browser-dto-smoke` blocker tracked by #2340; all commands after that blocker were run directly and pass
- `npm run check` passes through 58 smoke commands, then stops at the same pre-existing #2340 failure

Fixes #2352