### PR TITLE
Fix ordinary prose redaction

### DIFF
--- a/packages/runtime-core/src/redaction.ts
+++ b/packages/runtime-core/src/redaction.ts
@@ -107,7 +107,8 @@ export function redactString(value: string, options: RedactStringOptions = {}): 
     .replace(/https?:\/\/[^\s"'<>]+/gi, (match) => redactUrl(match, options))
     .replace(SECRET_LIKE_VALUE_GLOBAL_PATTERN, REDACTED_VALUE)
     .replace(/([?&][^=&#\s"'<>]+)=([^&#\s"'<>]+)/g, options.redactQueryAssignments ? `$1=${REDACTED_VALUE}` : "$&")
-    .replace(/((?:[A-Za-z0-9_-]*)(?:access[_-]?token|auth|bearer|code|cookie|credential|key|login|nonce|pass|password|secret|session|state|token)(?:[A-Za-z0-9_-]*)(?:["'\s:=]+))[^&#\s"'<>]+/gi, `$1${REDACTED_VALUE}`)
+    .replace(/\b(Bearer[ \t]+)[^&#\s"'<>]+/gi, `$1${REDACTED_VALUE}`)
+    .replace(/((?:[A-Za-z0-9_-]*)(?:access[_-]?token|auth|bearer|code|cookie|credential|key|login|nonce|pass|password|secret|session|state|token)(?:[A-Za-z0-9_-]*)(?:["'\s]*[:=]["'\s]*))[^&#\s"'<>]+/gi, `$1${REDACTED_VALUE}`)
 }
 
 export function redactError(error: unknown, options: RedactStringOptions = {}): Error {

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -29,6 +29,30 @@ assert.equal(containsSecretLikeValue("token sk-abcdefghijklmnopqrstuvwxyz"), tru
 assert.equal(containsSecretLikeValue("token [redacted]"), false)
 assert.equal(redactString("token sk-abcdefghijklmnopqrstuvwxyz"), "token [redacted]")
 
+const proseCases: Array<[string, string]> = [
+  ["Local wp-admin auth fixture user could not be loaded.", "Local wp-admin auth fixture user could not be loaded."],
+  ["The token validation fixture passed.", "The token validation fixture passed."],
+  ["Apply the cookie policy to this session state.", "Apply the cookie policy to this session state."],
+  ["    at <anonymous> (/workspace/auth-fixture.ts:7:21)", "    at <anonymous> (/workspace/auth-fixture.ts:7:21)"],
+]
+
+for (const [input, expected] of proseCases) {
+  assert.equal(redactString(input), expected, `ordinary prose should survive: ${input}`)
+}
+
+const secretContextCases: Array<[string, string]> = [
+  ["Local wp-admin auth: fixture-password user could not be loaded.", "Local wp-admin auth: [redacted] user could not be loaded."],
+  ["The token=fixture-token validation failed.", "The token=[redacted] validation failed."],
+  ["Authorization: Bearer fixture-auth-token", "Authorization: [redacted]"],
+  ["Bearer fixture-auth-token", "Bearer [redacted]"],
+  ["Cookie: wordpress_logged_in=fixture-cookie", "Cookie: [redacted]"],
+  ['{"username":"fixture","password":"fixture-password"}', '{"username":"fixture","password":"[redacted]"}'],
+]
+
+for (const [input, expected] of secretContextCases) {
+  assert.equal(redactString(input), expected, `secret context should redact: ${input}`)
+}
+
 assert.deepEqual(
   redactJsonValue({ token: "abc", nested: { api_key: "def", visible: "ok" }, list: [{ password: "secret" }] }, { redactStrings: false }),
   { token: "[redacted]", nested: { api_key: "[redacted]", visible: "ok" }, list: [{ password: "[redacted]" }] },


### PR DESCRIPTION
## Summary

- require explicit `:` or `=` delimiters before treating sensitive-looking prose terms as key/value assignments
- preserve explicit bearer-token redaction while leaving ordinary words such as `auth fixture`, `token validation`, and stack-frame `at` text intact
- add table-driven regressions pairing harmless prose with real credentials in equivalent assignment, header, bearer, cookie, and JSON contexts

Fixes #2137

## Threat model

The previous heuristic accepted whitespace alone as proof that any word containing `auth`, `token`, `cookie`, `session`, and related fragments introduced a secret. That over-redacted ordinary diagnostics and stack text without adding reliable secrecy: whitespace in prose does not establish a key/value boundary.

This change narrows only that ambiguous fallback. Structured sensitive keys still redact through `redactJsonValue`; header lines still redact by sensitive header name; query and URL policies remain unchanged; known provider-token shapes remain redacted; explicit sensitive assignments still require redaction; standalone `Bearer <credential>` remains protected; and artifact redaction still replaces configured secret names and values literally. Output truncation and deterministic ordering are unchanged.

## Gates

- `npm run test:redaction` passes
- `npx tsx scripts/playground-command-errors-smoke.ts` passes every command-error/redaction assertion, then reaches the independent fixture-shape failure tracked in #2358
- `npm run test:artifact-redaction-integrity` passes
- `npx tsx scripts/artifact-redaction-smoke.ts` passes
- `npm run test:browser-routed-command-security` passes
- `npm run test:production-boundary-enforcement` passes
- `npm run build` passes
- `npm run check` passes 70 commands through the repaired `playground-command-errors-smoke` assertions, then stops at #2358 (`bootstrapPhpCode` smoke fixture lacks the current runtime-spec shape)
- `git diff --check` passes
- worktree is clean after commit