### PR TITLE
Restore command error runtime fixture

### DIFF
--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { createRuntime } from "../packages/runtime-core/src/index.js"
+import { createRuntime, type RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
 import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
 import { PlaygroundCommandCrashError, PlaygroundCommandError } from "../packages/runtime-playground/src/playground-command-errors.js"
 import { createPlaygroundRuntimeBackend, type PlaygroundCliModule } from "../packages/runtime-playground/src/index.js"
@@ -258,7 +258,41 @@ await assert.rejects(
 )
 await workerFailureRuntime.destroy()
 
-const bootstrappedRunPhp = bootstrapPhpCode({ kind: "wordpress", name: "fatal-diagnostic", version: "7.0", blueprint: { steps: [] } }, "throw new RuntimeException('boom');", [])
+const fatalDiagnosticRuntimeSpec: RuntimeCreateSpec = {
+  backend: "wordpress-playground",
+  environment: {
+    kind: "wordpress",
+    name: "fatal-diagnostic",
+    version: "7.0",
+    blueprint: { steps: [] },
+  },
+  policy: {
+    network: "deny",
+    filesystem: "sandbox",
+    commands: ["wordpress.run-php"],
+    secrets: "none",
+    approvals: "never",
+  },
+}
+
+assert.deepEqual(fatalDiagnosticRuntimeSpec, {
+  backend: "wordpress-playground",
+  environment: {
+    kind: "wordpress",
+    name: "fatal-diagnostic",
+    version: "7.0",
+    blueprint: { steps: [] },
+  },
+  policy: {
+    network: "deny",
+    filesystem: "sandbox",
+    commands: ["wordpress.run-php"],
+    secrets: "none",
+    approvals: "never",
+  },
+})
+
+const bootstrappedRunPhp = bootstrapPhpCode(fatalDiagnosticRuntimeSpec, "throw new RuntimeException('boom');", [])
 assert.match(bootstrappedRunPhp, /register_shutdown_function/)
 assert.match(bootstrappedRunPhp, /WP_CODEBOX_PHP_FATAL_DIAGNOSTIC/)
 assert.match(bootstrappedRunPhp, /wp-codebox\/php-fatal-diagnostic\/v1/)


### PR DESCRIPTION
## Summary

- replace the environment-shaped bootstrap fixture with a typed minimal `RuntimeCreateSpec`
- assert the exact required backend, environment, and policy shape
- preserve the command-error, redaction, and PHP fatal bootstrap assertions without production fallback behavior

Fixes #2358

## Gates

- `npx tsx scripts/playground-command-errors-smoke.ts` passes
- `npm run test:runtime-php-snippets` passes
- `npx tsx scripts/runtime-component-lifecycle-replay-smoke.ts` passes
- `npm run build` passes
- `npm run test:playground-phpunit-bootstrap-failure-integration` reaches the independent open fixture-mount failure in #2139
- `npm run check` clears `playground-command-errors-smoke`, then reaches the independent open timeout-smoke failure in #1904
- `git diff --check` passes
- worktree is clean after commit
