### PR TITLE
Test deterministic in-flight Playground timeout

### DIFF
--- a/scripts/playground-command-timeout-smoke.ts
+++ b/scripts/playground-command-timeout-smoke.ts
@@ -2,19 +2,45 @@ import assert from "node:assert/strict"
 import { createRuntime } from "../packages/runtime-core/src/index.js"
 import { createPlaygroundRuntimeBackend, type PlaygroundCliModule } from "../packages/runtime-playground/src/index.js"
 
-let runCalled = false
+const commandTimeoutMs = 25
+let runCalls = 0
+let runtimeDisposed = false
+let timedRunCompleted = false
+let resolveRunEntered!: () => void
+let resolveTimedRun!: () => void
+let resolveTimedRunSettled!: () => void
+const runEntered = new Promise<void>((resolve) => {
+  resolveRunEntered = resolve
+})
+const timedRun = new Promise<{ text: string; exitCode: number }>((resolve) => {
+  resolveTimedRun = () => resolve({ text: "", exitCode: 0 })
+})
+const timedRunSettled = new Promise<void>((resolve) => {
+  resolveTimedRunSettled = resolve
+})
 
 const fakeCliModule: PlaygroundCliModule = {
   runCLI: async () => ({
     serverUrl: "http://127.0.0.1:9400",
     playground: {
       run: async () => {
-        runCalled = true
-        return await new Promise<never>(() => undefined)
+        runCalls += 1
+        if (runCalls === 1) {
+          return { text: "warm", exitCode: 0 }
+        }
+
+        resolveRunEntered()
+        try {
+          return await timedRun
+        } finally {
+          timedRunCompleted = true
+          resolveTimedRunSettled()
+        }
       },
     },
     async [Symbol.asyncDispose]() {
-      return undefined
+      runtimeDisposed = true
+      resolveTimedRun()
     },
   }),
 }
@@ -31,26 +57,50 @@ const runtime = await createRuntime({
   },
 }, createPlaygroundRuntimeBackend({ cliModule: fakeCliModule }))
 
-await assert.rejects(
-  () => runtime.execute({
+try {
+  // Keep runtime startup outside the deliberately tiny in-flight command budget.
+  await runtime.execute({
+    command: "wordpress.run-php",
+    args: ["code=echo 'warm';"],
+  })
+
+  const startedAt = Date.now()
+  const execution = runtime.execute({
     command: "wordpress.run-php",
     args: ["code=echo 'never';"],
-    timeoutMs: 25,
-  }),
-  (error) => {
-    assert.ok(error instanceof Error)
-    assert.match(error.message, /Runtime command wordpress\.run-php exceeded timeoutMs=25/)
-    return true
-  },
-)
+    timeoutMs: commandTimeoutMs,
+  })
 
-assert.equal(runCalled, true)
+  const enteredBeforeSettlement = await Promise.race([
+    runEntered.then(() => true),
+    execution.then(() => false, () => false),
+  ])
+  assert.equal(enteredBeforeSettlement, true, "the timed command must enter Playground run() before settling")
 
-const observation = await runtime.observe({ type: "command-result" })
-const commandResult = observation.data as { exitCode?: number; stderr?: string }
-assert.equal(commandResult.exitCode, 1)
-assert.match(commandResult.stderr ?? "", /timeoutMs=25/)
+  await assert.rejects(
+    () => execution,
+    (error) => {
+      assert.ok(error instanceof Error)
+      assert.match(error.message, /Runtime command wordpress\.run-php exceeded timeoutMs=25/)
+      return true
+    },
+  )
 
-await runtime.destroy()
+  const elapsedMs = Date.now() - startedAt
+  assert.ok(elapsedMs >= commandTimeoutMs, `timeout fired early after ${elapsedMs}ms`)
+  assert.ok(elapsedMs < 1_000, `timeout was not bounded: ${elapsedMs}ms`)
+  assert.equal(timedRunCompleted, false, "timeout must cancel execution without waiting for the backend run to settle")
+
+  const observation = await runtime.observe({ type: "command-result" })
+  const commandResult = observation.data as { exitCode?: number; stderr?: string }
+  assert.equal(commandResult.exitCode, 1)
+  assert.match(commandResult.stderr ?? "", /timeoutMs=25/)
+} finally {
+  await runtime.destroy()
+}
+
+await timedRunSettled
+assert.equal(timedRunCompleted, true)
+assert.equal(runtimeDisposed, true, "runtime teardown must terminate the in-flight fake backend run")
 
 console.log("playground command timeout smoke passed")


### PR DESCRIPTION
## Summary
- warm the fake Playground runtime before applying the intentionally tiny command timeout
- synchronize on the timed backend `run()` entering before asserting the timeout
- verify cancellation does not await backend completion, elapsed time stays bounded, and runtime teardown terminates the pending fake run

## Verification
- `npm run smoke -- --command=playground-command-timeout-smoke`
- `npm run test:host-http-transport`
- `npm run build`
- `npm run check` reaches and passes the updated timeout smoke, then stops on the unrelated Composer activation failure tracked in #2361

Fixes #1904