### PR TITLE
test: remove stale workload normalizer smoke entry

### DIFF
--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -145,7 +145,6 @@ export const smokeGroups = {
   agent: {
     description: "Agent task, fanout, and delegation contract smoke checks.",
     commands: [
-      tsxSmoke("agent-runtime-workload-normalizer-smoke"),
       tsxSmoke("agent-runtime-signal-smoke"),
       tsxSmoke("agent-runtime-ability-lifecycle-smoke"),
       tsxSmoke("agent-runtime-ability-tools-smoke"),


### PR DESCRIPTION
## Summary
- remove the stale manifest command for a standalone workload-normalizer smoke deleted during legacy compatibility cleanup
- keep canonical normalizer behavior consolidated in `tests/agent-task-contracts.test.ts`
- keep public export ownership consolidated in `tests/public-api-contract.test.ts`

## Verification
- `npm exec -- tsx tests/agent-task-contracts.test.ts`
- `npm run test:public-api-contract`
- `npm run check` (passes the corrected manifest path and all preceding commands, then reaches the independent `component-contracts-agent-task-smoke` failure tracked in #2369)

Fixes #2368