### PR TITLE
refactor: consolidate WordPress runtime test fixtures

### DIFF
--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict"
-import { createRuntime, type RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+import { createRuntime } from "../packages/runtime-core/src/index.js"
 import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
 import { PlaygroundCommandCrashError, PlaygroundCommandError } from "../packages/runtime-playground/src/playground-command-errors.js"
 import { createPlaygroundRuntimeBackend, type PlaygroundCliModule } from "../packages/runtime-playground/src/index.js"
+import { wordpressRuntimeSpec } from "./test-kit.js"
 
 const hiddenFatal = new Error("PHP.run() failed with exit code 255") as Error & {
   httpStatusCode?: number
@@ -157,17 +158,7 @@ const fakeCliModule: PlaygroundCliModule = {
   }),
 }
 
-const runtime = await createRuntime({
-  backend: "wordpress-playground",
-  environment: { kind: "wordpress", name: "hidden-fatal-smoke", version: "7.0", blueprint: { steps: [] } },
-  policy: {
-    network: "deny",
-    filesystem: "sandbox",
-    commands: ["wordpress.run-php"],
-    secrets: "none",
-    approvals: "never",
-  },
-}, createPlaygroundRuntimeBackend({ cliModule: fakeCliModule }))
+const runtime = await createRuntime(wordpressRuntimeSpec({ commands: ["wordpress.run-php"], environment: { name: "hidden-fatal-smoke", version: "7.0", blueprint: { steps: [] } } }), createPlaygroundRuntimeBackend({ cliModule: fakeCliModule }))
 
 await assert.rejects(
   () => runtime.execute({
@@ -202,11 +193,7 @@ const phpunitFailureCliModule: PlaygroundCliModule = {
   }),
 }
 
-const phpunitFailureRuntime = await createRuntime({
-  backend: "wordpress-playground",
-  environment: { kind: "wordpress", name: "phpunit-bootstrap-failure", version: "7.0", blueprint: { steps: [] } },
-  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.phpunit"], secrets: "none", approvals: "never" },
-}, createPlaygroundRuntimeBackend({ cliModule: phpunitFailureCliModule }))
+const phpunitFailureRuntime = await createRuntime(wordpressRuntimeSpec({ commands: ["wordpress.phpunit"], environment: { name: "phpunit-bootstrap-failure", version: "7.0", blueprint: { steps: [] } } }), createPlaygroundRuntimeBackend({ cliModule: phpunitFailureCliModule }))
 
 await assert.rejects(
   () => phpunitFailureRuntime.execute({ command: "wordpress.phpunit", args: ["plugin-slug=demo"] }),
@@ -234,11 +221,7 @@ const workerFailureCliModule: PlaygroundCliModule = {
   }),
 }
 
-const workerFailureRuntime = await createRuntime({
-  backend: "wordpress-playground",
-  environment: { kind: "wordpress", name: "phpunit-worker-failure", version: "7.0", blueprint: { steps: [] } },
-  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.phpunit"], secrets: "none", approvals: "never" },
-}, createPlaygroundRuntimeBackend({ cliModule: workerFailureCliModule }))
+const workerFailureRuntime = await createRuntime(wordpressRuntimeSpec({ commands: ["wordpress.phpunit"], environment: { name: "phpunit-worker-failure", version: "7.0", blueprint: { steps: [] } } }), createPlaygroundRuntimeBackend({ cliModule: workerFailureCliModule }))
 
 await assert.rejects(
   () => workerFailureRuntime.execute({ command: "wordpress.phpunit", args: ["plugin-slug=demo"] }),
@@ -258,39 +241,7 @@ await assert.rejects(
 )
 await workerFailureRuntime.destroy()
 
-const fatalDiagnosticRuntimeSpec: RuntimeCreateSpec = {
-  backend: "wordpress-playground",
-  environment: {
-    kind: "wordpress",
-    name: "fatal-diagnostic",
-    version: "7.0",
-    blueprint: { steps: [] },
-  },
-  policy: {
-    network: "deny",
-    filesystem: "sandbox",
-    commands: ["wordpress.run-php"],
-    secrets: "none",
-    approvals: "never",
-  },
-}
-
-assert.deepEqual(fatalDiagnosticRuntimeSpec, {
-  backend: "wordpress-playground",
-  environment: {
-    kind: "wordpress",
-    name: "fatal-diagnostic",
-    version: "7.0",
-    blueprint: { steps: [] },
-  },
-  policy: {
-    network: "deny",
-    filesystem: "sandbox",
-    commands: ["wordpress.run-php"],
-    secrets: "none",
-    approvals: "never",
-  },
-})
+const fatalDiagnosticRuntimeSpec = wordpressRuntimeSpec({ commands: ["wordpress.run-php"], environment: { name: "fatal-diagnostic", version: "7.0", blueprint: { steps: [] } } })
 
 const bootstrappedRunPhp = bootstrapPhpCode(fatalDiagnosticRuntimeSpec, "throw new RuntimeException('boom');", [])
 assert.match(bootstrappedRunPhp, /register_shutdown_function/)

--- a/scripts/test-kit.ts
+++ b/scripts/test-kit.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
+import type { RuntimeCreateSpec } from "../packages/runtime-core/src/runtime-contracts.js"
 
 const execFileAsync = promisify(execFile)
 
@@ -14,6 +15,27 @@ export const cliPath = resolve(repoRoot, "packages/cli/dist/index.js")
 export interface CommandOptions {
   cwd?: string
   env?: NodeJS.ProcessEnv
+}
+
+export interface WordPressRuntimeSpecOptions {
+  commands: string[]
+  environment?: Partial<RuntimeCreateSpec["environment"]>
+  policy?: Partial<Omit<RuntimeCreateSpec["policy"], "commands">>
+  runtimeEnv?: Record<string, string>
+  metadata?: Record<string, unknown>
+  artifactsDirectory?: string
+}
+
+export function wordpressRuntimeSpec(options: WordPressRuntimeSpecOptions): RuntimeCreateSpec {
+  const { commands, environment, policy, runtimeEnv, metadata, artifactsDirectory } = options
+  return {
+    backend: "wordpress-playground",
+    environment: { kind: "wordpress", name: "test", version: "latest", blueprint: {}, ...environment },
+    policy: { network: "deny", filesystem: "sandbox", commands, secrets: "none", approvals: "never", ...policy },
+    ...(runtimeEnv ? { runtimeEnv } : {}),
+    ...(metadata ? { metadata } : {}),
+    ...(artifactsDirectory ? { artifactsDirectory } : {}),
+  }
 }
 
 export async function runCliJson<T>(args: string[]): Promise<T> {

--- a/tests/browser-actions-environment.browser.test.ts
+++ b/tests/browser-actions-environment.browser.test.ts
@@ -5,18 +5,14 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import test from "node:test"
 
-import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
 import { runBrowserActionsCommand, runBrowserScenarioCommand } from "../packages/runtime-playground/src/browser-actions-runner.js"
 import { runBrowserProbeCommand } from "../packages/runtime-playground/src/browser-probe-runner.js"
 import type { BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
 import { isBrowserCommandArtifactError } from "../packages/runtime-playground/src/browser-command-artifact-error.js"
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
-const runtimeSpec: RuntimeCreateSpec = {
-  backend: "wordpress-playground",
-  environment: {},
-  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.browser-actions", "wordpress.browser-actions.evaluate", "wordpress.browser-probe", "wordpress.browser-scenario"], secrets: "none", approvals: "never" },
-}
+const runtimeSpec = wordpressRuntimeSpec({ commands: ["wordpress.browser-actions", "wordpress.browser-actions.evaluate", "wordpress.browser-probe", "wordpress.browser-scenario"] })
 
 test("standalone probes use the shared environment context adapter", async () => {
   const fixture = await browserFixture()

--- a/tests/browser-actions-navigation-capture.browser.test.ts
+++ b/tests/browser-actions-navigation-capture.browser.test.ts
@@ -5,17 +5,14 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import test from "node:test"
 
-import { browserAdaptiveExplorationContract, type RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+import { browserAdaptiveExplorationContract } from "../packages/runtime-core/src/index.js"
 import { runBrowserActionsCommand } from "../packages/runtime-playground/src/browser-actions-runner.js"
 import { captureBrowserPageHtml, trackBrowserNavigation, type BrowserNavigationTracker } from "../packages/runtime-playground/src/browser-capture-session.js"
 import { browserEnvironmentCell, resolvePlaywrightBrowserEnvironment } from "../packages/runtime-playground/src/browser-environment-matrix.js"
 import { chromium } from "playwright"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
-const runtimeSpec: RuntimeCreateSpec = {
-  backend: "wordpress-playground",
-  environment: {},
-  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.browser-actions"], secrets: "none", approvals: "never" },
-}
+const runtimeSpec = wordpressRuntimeSpec({ commands: ["wordpress.browser-actions"] })
 
 test("HTML capture remains unchanged when no navigation is active", async () => {
   const browser = await chromium.launch({ headless: true })

--- a/tests/browser-transport-fault-scenarios.browser.test.ts
+++ b/tests/browser-transport-fault-scenarios.browser.test.ts
@@ -6,17 +6,14 @@ import { join } from "node:path"
 import test from "node:test"
 import { chromium } from "playwright"
 
-import type { RuntimeCreateSpec, TransportFaultModel } from "../packages/runtime-core/src/index.js"
+import type { TransportFaultModel } from "../packages/runtime-core/src/index.js"
 import { runBrowserActionsCommand, runBrowserScenarioCommand } from "../packages/runtime-playground/src/browser-actions-runner.js"
 import { isBrowserCommandArtifactError } from "../packages/runtime-playground/src/browser-command-artifact-error.js"
 import { installBrowserTransportFaults } from "../packages/runtime-playground/src/browser-transport-faults.js"
 import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
-const runtimeSpec: RuntimeCreateSpec = {
-  backend: "wordpress-playground",
-  environment: {},
-  policy: { network: "deny", filesystem: "sandbox", commands: ["wordpress.browser-actions", "wordpress.browser-actions.evaluate", "wordpress.browser-scenario"], secrets: "none", approvals: "never" },
-}
+const runtimeSpec = wordpressRuntimeSpec({ commands: ["wordpress.browser-actions", "wordpress.browser-actions.evaluate", "wordpress.browser-scenario"] })
 
 test("real browser faults cover delay, timeout, refusal, reset, malformed, truncation, recovery, and unmatched rules", async () => {
   const fixture = await browserFixture()

--- a/tests/phpunit-discovery-only.test.ts
+++ b/tests/phpunit-discovery-only.test.ts
@@ -4,6 +4,7 @@ import { buildWordPressPhpunitRecipe } from "../packages/runtime-core/src/recipe
 import { phpunitRunCode } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
 import { runPhpunitCommand } from "../packages/runtime-playground/src/wordpress-command-runners.js"
 import { recipeHasPhpunitDiscoveryOnly } from "../packages/cli/src/commands/recipe-runtime-setup.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
 test("wordpress.phpunit discovery-only returns canonical files before execution", () => {
   const recipe = buildWordPressPhpunitRecipe({
@@ -55,7 +56,7 @@ test("discovery-only rejects selectors before starting a runtime", async () => {
       invoked = true
       return { exitCode: 0, errors: "", text: "" }
     },
-    runtimeSpec: { environment: { kind: "wordpress", name: "test", version: "latest" }, policy: { commands: ["wordpress.phpunit"] } } as never,
+    runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.phpunit"] }),
     server: {} as never,
     spec: { command: "wordpress.phpunit", args: ["plugin-slug=fixture", "discovery-only=1", "test-file=tests/FixtureTest.php"] },
   }), /discovery-only cannot be combined/)
@@ -75,7 +76,7 @@ test("discovery-only returns its schema-bound result directly", async () => {
     artifactRoot: "/tmp/artifacts",
     mounts: [],
     runPlaygroundCommand: async () => ({ exitCode: 0, errors: "", text: "private runtime output" }),
-    runtimeSpec: { environment: { kind: "wordpress", name: "test", version: "latest" }, policy: { commands: ["wordpress.phpunit"] } } as never,
+    runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.phpunit"] }),
     server: { playground: { readFileAsText: async () => `DISCOVERY_RESULT_JSON:${JSON.stringify(payload)}\n` } } as never,
     spec: { command: "wordpress.phpunit", args: ["plugin-slug=fixture", "discovery-only=1"] },
   })

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -11,12 +11,10 @@ import { phpunitExecutionSemantics, requiresManagedMysqlMultisitePreinstall } fr
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
 import { recipeExtraPluginSourceSubpath } from "../packages/cli/src/recipe-sources.js"
 import { recipeInputMountPathMap, rewriteInputMountPathArgs } from "../packages/cli/src/commands/recipe-runtime-setup.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
 const woocommerceAutoload = "/wordpress/wp-content/plugins/woocommerce/vendor/autoload_packages.php"
-const phpunitRuntimeSpec = {
-  environment: { kind: "wordpress", name: "test", version: "latest" },
-  runtimeEnv: { TC_MYSQL_PORT: "3306" },
-} as never
+const phpunitRuntimeSpec = wordpressRuntimeSpec({ commands: ["wordpress.phpunit"], runtimeEnv: { TC_MYSQL_PORT: "3306" } })
 
 function phpunitRecipeArgs(options: Omit<Parameters<typeof buildWordPressPhpunitRecipe>[0], "pluginSlug">): string[] {
   return buildWordPressPhpunitRecipe({ pluginSlug: "demo-plugin", ...options }).workflow.steps[0].args
@@ -708,11 +706,11 @@ await runPhpunitCommand({
     capturedMysqlCode = input.code
     return { text: "ok", exitCode: 0 }
   },
-  runtimeSpec: {
-    environment: { kind: "wordpress", name: "test", version: "latest", databaseSetup: "external" },
+  runtimeSpec: wordpressRuntimeSpec({
+    commands: ["wordpress.phpunit"],
+    environment: { databaseSetup: "external" },
     runtimeEnv: { DB_HOST: "127.0.0.1", DB_PORT: "3307", DB_NAME: "runtime", DB_USER: "runtime", DB_PASSWORD: "secret" },
-    policy: { commands: ["wordpress.phpunit"] },
-  } as never,
+  }),
   server: { playground: {} } as never,
   spec: { command: "wordpress.phpunit", args: ["plugin-slug=demo-plugin", "database-type=mysql"] },
 })
@@ -755,12 +753,12 @@ await runPhpunitCommand({
     mysqlMultisiteInvocations.push(decodedBootstrapWrapper(input.code))
     return { text: "ok", exitCode: 0 }
   },
-  runtimeSpec: {
-    environment: { kind: "wordpress", name: "test", version: "latest", databaseSetup: "external" },
+  runtimeSpec: wordpressRuntimeSpec({
+    commands: ["wordpress.phpunit"],
+    environment: { databaseSetup: "external" },
     runtimeEnv: { DB_HOST: "127.0.0.1", DB_PORT: "3307", DB_NAME: "runtime", DB_USER: "runtime", DB_PASSWORD: "secret" },
-    policy: { commands: ["wordpress.phpunit"] },
     metadata: { recipe: { inputs: { extra_plugins: [{ slug: "preinstall-sensitive", pluginFile: "preinstall-sensitive/bootstrap.php", target: "/wordpress/wp-content/plugins/preinstall-sensitive", activate: true, loadAs: "plugin" }] } } },
-  } as never,
+  }),
   server: { playground: {} } as never,
   spec: { command: "wordpress.phpunit", args: ["plugin-slug=demo-plugin", "database-type=mysql", "multisite=1"] },
 })
@@ -780,11 +778,11 @@ await assert.rejects(
       failedPreinstallInvocations.push(decodedBootstrapWrapper(input.code))
       return { text: "preinstall failed", exitCode: 1 }
     },
-    runtimeSpec: {
-      environment: { kind: "wordpress", name: "test", version: "latest", databaseSetup: "external" },
+    runtimeSpec: wordpressRuntimeSpec({
+      commands: ["wordpress.phpunit"],
+      environment: { databaseSetup: "external" },
       runtimeEnv: { DB_HOST: "127.0.0.1", DB_PORT: "3307", DB_NAME: "runtime", DB_USER: "runtime", DB_PASSWORD: "secret" },
-      policy: { commands: ["wordpress.phpunit"] },
-    } as never,
+    }),
     server: {
       playground: {
         readFileAsText: async () => "STAGE_FAIL:preinstall:RuntimeException: network install failed",
@@ -804,7 +802,7 @@ await assert.rejects(runPhpunitCommand({
   artifactRoot: mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-mysql-reject-")),
   mounts: [],
   runPlaygroundCommand: async () => { throw new Error("workload must not execute") },
-  runtimeSpec: { environment: { kind: "wordpress", name: "test", version: "latest" }, policy: { commands: ["wordpress.phpunit"] } } as never,
+  runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.phpunit"] }),
   server: { playground: {} } as never,
   spec: { command: "wordpress.phpunit", args: ["plugin-slug=demo-plugin", "database-type=mysql"] },
 }), /requires a managed external database service.*refusing to substitute SQLite/)

--- a/tests/phpunit-runtime-failure-diagnostics.test.ts
+++ b/tests/phpunit-runtime-failure-diagnostics.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { PLUGIN_PHPUNIT_RESULT_FILE } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
 import { runPhpunitCommand } from "../packages/runtime-playground/src/wordpress-command-runners.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
 const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-phpunit-runtime-diagnostics-"))
 const secret = "sk-abcdefghijklmnopqrstuvwxyz"
@@ -17,7 +18,7 @@ await assert.rejects(
       submittedCode = input.code
       return { exitCode: 1, errors: "", text: "" }
     },
-    runtimeSpec: { environment: { kind: "wordpress", name: "test", version: "latest" }, policy: { commands: ["wordpress.phpunit"] } } as never,
+    runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.phpunit"] }),
     server: {
       playground: {
         readFileAsText: async (path: string) => {

--- a/tests/phpunit-structured-evidence.test.ts
+++ b/tests/phpunit-structured-evidence.test.ts
@@ -7,6 +7,7 @@ import { PlaygroundCommandCrashError } from "../packages/runtime-playground/src/
 import { PLUGIN_PHPUNIT_RESULT_FILE } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
 import { buildPhpunitTestResults, parsePhpunitCompletedResult } from "../packages/runtime-playground/src/phpunit-test-results.js"
 import { runPhpunitCommand } from "../packages/runtime-playground/src/wordpress-command-runners.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
 const passedLog = completedLog({ status: "passed", total: 3, passed: 3, failed: 0, skipped: 0, assertions: 3, failures: 0, errors: 0 })
 const failedLog = completedLog({ status: "failed", total: 4, passed: 1, failed: 2, skipped: 1, assertions: 2, failures: 1, errors: 1 })
@@ -59,7 +60,7 @@ function runPhpunitWith(error: Error, log: string, artifactRoot: string): Promis
     artifactRoot,
     mounts: [],
     runPlaygroundCommand: async () => { throw error },
-    runtimeSpec: { environment: { kind: "wordpress", name: "test", version: "latest" }, policy: { commands: ["wordpress.phpunit"] } } as never,
+    runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.phpunit"] }),
     server: { playground: { readFileAsText: async (path: string) => {
       assert.equal(path, PLUGIN_PHPUNIT_RESULT_FILE)
       return log

--- a/tests/plugin-state-command.test.ts
+++ b/tests/plugin-state-command.test.ts
@@ -3,6 +3,7 @@ import { commandRegistry } from "../packages/runtime-core/src/command-registry.j
 import { pluginStateInputFromArgs, pluginStatePhpCode } from "../packages/runtime-playground/src/plugin-state-command-handlers.js"
 import { materializePlaygroundRunResponse } from "../packages/runtime-playground/src/playground-runtime.js"
 import { runPluginStateCommand } from "../packages/runtime-playground/src/wordpress-command-runners.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
 const command = commandRegistry.find((definition) => definition.id === "wordpress.plugin-state")
 const ensureCommand = commandRegistry.find((definition) => definition.id === "wordpress.ensure-plugin-active")
@@ -53,7 +54,7 @@ assert.deepEqual(JSON.parse(materializedResponse.text), JSON.parse(pluginStateJs
 
 const pluginStateOutput = await runPluginStateCommand({
   runPlaygroundCommand: async () => materializedResponse,
-  runtimeSpec: { environment: { kind: "wordpress" } } as never,
+  runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.plugin-state"] }),
   server: {} as never,
   spec: { command: "wordpress.plugin-state", args: ["plugin=example"] } as never,
 })

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -5,9 +5,10 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { mkdtempSync } from "node:fs"
 import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
-import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction, type RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
 import { bootstrapPhpCode, phpCodeFromArgs } from "../packages/runtime-playground/src/php-bootstrap.js"
 import { phpEnvAssignmentFunction, phpEnvAssignments } from "../packages/runtime-playground/src/php-snippets.js"
+import { wordpressRuntimeSpec } from "../scripts/test-kit.js"
 
 const environmentSnippet = phpEnvAssignments({ EXAMPLE_RUNTIME_ENV: "available" })
 const environmentOutput = execFileSync(
@@ -116,21 +117,7 @@ assert.deepEqual(JSON.parse(actionOutput), {
   contained_runtime_abilities_ready: 1,
 })
 
-const runtimeSpec: RuntimeCreateSpec = {
-  backend: "wordpress-playground",
-  environment: {
-    kind: "wordpress",
-    version: "latest",
-    blueprint: {},
-  },
-  policy: {
-    network: "deny",
-    filesystem: "readwrite-mounts",
-    commands: ["wordpress.run-php"],
-    secrets: "none",
-    approvals: "never",
-  },
-}
+const runtimeSpec = wordpressRuntimeSpec({ commands: ["wordpress.run-php"], policy: { filesystem: "readwrite-mounts" } })
 
 const bootstrappedRunPhp = bootstrapPhpCode({
   ...runtimeSpec,


### PR DESCRIPTION
## Summary
- add one test-only `wordpressRuntimeSpec()` helper with explicit commands and shallow environment, policy, runtime environment, metadata, and artifact-directory overrides
- replace invalid partial PHPUnit/plugin-state fixtures and repeated complete runtime baselines while preserving external-database and omitted-worker behavior
- remove the duplicate command-error deep-equality fixture copy; leave the specialized bootstrap-failure recipes unchanged because converting their custom mount layouts would not simplify them

## Before / After
- targeted runtime-spec `as never` casts: 10 -> 0
- direct WordPress backend baselines across migrated consumers: 9 -> 0
- helper consumers: 0 -> 18
- diff: 63 lines added, 111 lines deleted (net -48)

## Tests
- `npm exec -- tsx --test tests/phpunit-runtime-failure-diagnostics.test.ts tests/phpunit-discovery-only.test.ts tests/phpunit-structured-evidence.test.ts tests/plugin-state-command.test.ts tests/phpunit-project-autoload.test.ts tests/runtime-php-snippets.test.ts`
- `npm exec -- tsx scripts/playground-command-errors-smoke.ts`
- `npm exec -- tsx --test tests/browser-actions-environment.browser.test.ts tests/browser-actions-navigation-capture.browser.test.ts tests/browser-transport-fault-scenarios.browser.test.ts`
- `npm run build`
- `npm run check` (passes all 101 check-group commands; existing Docker-backed MySQL E2E reports its standard skip because Docker is unavailable)

Fixes #2372