### PR TITLE
fix: align browser fanout no-op status

### DIFF
--- a/packages/runtime-core/src/browser-fanout-aggregation-runtime.js
+++ b/packages/runtime-core/src/browser-fanout-aggregation-runtime.js
@@ -1,5 +1,6 @@
 const fanoutAggregationInputSchema = 'wp-codebox/agent-fanout-aggregation-input/v1';
 const fanoutAggregationOutputSchema = 'wp-codebox/agent-fanout-aggregation-output/v1';
+const fanoutSuccessfulWorkerStatuses = new Set( [ 'succeeded', 'no_op' ] );
 
 const stableJson = ( value ) => {
 	if ( value === null || typeof value !== 'object' ) {
@@ -127,7 +128,7 @@ const fanoutAggregationConflicts = ( input ) => {
 
 	const resultByWorker = new Map( input.workerResultRefs.map( ( result ) => [ result.workerId, result ] ) );
 	for ( const result of input.workerResultRefs ) {
-		if ( result.required && result.status !== 'succeeded' ) {
+		if ( result.required && ! fanoutSuccessfulWorkerStatuses.has( result.status ) ) {
 			conflicts.push( {
 				type: 'failed-worker',
 				severity: 'error',
@@ -149,7 +150,7 @@ const fanoutAggregationConflicts = ( input ) => {
 					workerIds: [ worker.id ],
 					dependencyId,
 				} );
-			} else if ( dependency.status !== 'succeeded' ) {
+			} else if ( ! fanoutSuccessfulWorkerStatuses.has( dependency.status ) ) {
 				conflicts.push( {
 					type: 'failed-worker-dependency',
 					severity: 'error',

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -2775,6 +2775,7 @@ try {
 	// BEGIN generated fanout aggregation runtime. Run `npm run generate:browser-fanout-aggregation-runtime`.
 	const fanoutAggregationInputSchema = 'wp-codebox/agent-fanout-aggregation-input/v1';
 	const fanoutAggregationOutputSchema = 'wp-codebox/agent-fanout-aggregation-output/v1';
+	const fanoutSuccessfulWorkerStatuses = new Set( [ 'succeeded', 'no_op' ] );
 
 	const stableJson = ( value ) => {
 		if ( value === null || typeof value !== 'object' ) {
@@ -2902,7 +2903,7 @@ try {
 
 		const resultByWorker = new Map( input.workerResultRefs.map( ( result ) => [ result.workerId, result ] ) );
 		for ( const result of input.workerResultRefs ) {
-			if ( result.required && result.status !== 'succeeded' ) {
+			if ( result.required && ! fanoutSuccessfulWorkerStatuses.has( result.status ) ) {
 				conflicts.push( {
 					type: 'failed-worker',
 					severity: 'error',
@@ -2924,7 +2925,7 @@ try {
 						workerIds: [ worker.id ],
 						dependencyId,
 					} );
-				} else if ( dependency.status !== 'succeeded' ) {
+				} else if ( ! fanoutSuccessfulWorkerStatuses.has( dependency.status ) ) {
 					conflicts.push( {
 						type: 'failed-worker-dependency',
 						severity: 'error',

--- a/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
@@ -264,11 +264,12 @@ final class WP_Codebox_Fanout_Aggregation {
 
 	/** @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $worker_results Worker results. @return array<int,array<string,mixed>> */
 	private function worker_dependency_conflicts( array $plan, array $worker_results ): array {
+		$successful_statuses = array( 'succeeded', 'no_op' );
 		$conflicts = array();
 		$by_worker = array();
 		foreach ( $worker_results as $result ) {
 			$by_worker[ (string) ( $result['workerId'] ?? '' ) ] = $result;
-			if ( false !== ( $result['required'] ?? true ) && 'succeeded' !== (string) ( $result['status'] ?? '' ) ) {
+			if ( false !== ( $result['required'] ?? true ) && ! in_array( (string) ( $result['status'] ?? '' ), $successful_statuses, true ) ) {
 				$conflicts[] = array_filter(
 					array(
 						'type'         => 'failed-worker',
@@ -297,7 +298,7 @@ final class WP_Codebox_Fanout_Aggregation {
 				}
 
 				$dependency = $by_worker[ $dependency_id ];
-				if ( 'succeeded' !== (string) ( $dependency['status'] ?? '' ) ) {
+				if ( ! in_array( (string) ( $dependency['status'] ?? '' ), $successful_statuses, true ) ) {
 					$conflicts[] = array(
 						'type'         => 'failed-worker-dependency',
 						'severity'     => 'error',

--- a/scripts/generate-fanout-aggregation-contract-fixture.ts
+++ b/scripts/generate-fanout-aggregation-contract-fixture.ts
@@ -44,6 +44,16 @@ const vectors = [
     input: successfulInput,
   },
   {
+    name: "success-with-no-op-required-dependency",
+    input: {
+      ...successfulInput,
+      workerResultRefs: [
+        { workerId: "alpha", status: "no_op", artifactRefs: [{ path: "fanout/workers/alpha/report.json", finalPath: "reports/alpha.json" }] },
+        { workerId: "beta", status: "succeeded", artifactRefs: [{ path: "fanout/workers/beta/report.json", finalPath: "reports/beta.json" }] },
+      ],
+    },
+  },
+  {
     name: "duplicate-final-path-partial-policy",
     input: {
       ...successfulInput,

--- a/tests/fixtures/fanout-aggregation-contract.json
+++ b/tests/fixtures/fanout-aggregation-contract.json
@@ -136,6 +136,128 @@
       }
     },
     {
+      "name": "success-with-no-op-required-dependency",
+      "input": {
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifactNamespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "artifactNamespace": "workers/beta"
+            }
+          ]
+        },
+        "policy": "fail",
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "alpha",
+            "status": "no_op",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/report.json",
+                "finalPath": "reports/alpha.json"
+              }
+            ]
+          },
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/report.json",
+                "finalPath": "reports/beta.json"
+              }
+            ]
+          }
+        ]
+      },
+      "expectedOutput": {
+        "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
+        "status": "succeeded",
+        "policy": "fail",
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifactNamespace": "workers/alpha",
+              "dependsOn": [],
+              "required": true
+            },
+            {
+              "id": "beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "artifactNamespace": "workers/beta",
+              "required": true
+            }
+          ]
+        },
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "alpha",
+            "status": "no_op",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/report.json",
+                "workerId": "alpha",
+                "finalPath": "reports/alpha.json"
+              }
+            ]
+          },
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/report.json",
+                "workerId": "beta",
+                "finalPath": "reports/beta.json"
+              }
+            ]
+          }
+        ],
+        "rawWorkerArtifactRefs": [
+          {
+            "path": "fanout/workers/alpha/report.json",
+            "workerId": "alpha",
+            "finalPath": "reports/alpha.json"
+          },
+          {
+            "path": "fanout/workers/beta/report.json",
+            "workerId": "beta",
+            "finalPath": "reports/beta.json"
+          }
+        ],
+        "finalArtifactRefs": [
+          {
+            "path": "aggregate/final/result.json",
+            "kind": "fanout-aggregate-output",
+            "contentType": "application/json"
+          }
+        ],
+        "conflicts": []
+      }
+    },
+    {
       "name": "duplicate-final-path-partial-policy",
       "input": {
         "plan": {


### PR DESCRIPTION
## Summary

- Treat normalized `no_op` worker results as successful in browser and PHP fanout conflict classification, matching runtime-core's canonical status taxonomy.
- Reuse one local successful-status set per implementation for required workers and dependencies while preserving conflicts for failed, cancelled, incomplete, and other non-success statuses.
- Add and regenerate a cross-runtime parity vector where a required `no_op` worker is also a dependency, then regenerate the checked-in WordPress browser runtime.

## Before/After Parity

Before, the browser runtime preserved the worker status as `no_op` but returned aggregate status `failed`, emitted `failed-worker`, and cleared `finalArtifactRefs`.

After, the generated `success-with-no-op-required-dependency` vector agrees across runtime-core, the WordPress browser runtime, and PHP: aggregate status is `succeeded`, worker status remains `no_op`, conflicts are empty, and the final aggregate artifact is retained.

Generation was run twice. SHA-256 hashes were unchanged on the second pass for the standalone browser source, generated WordPress bundle, and generated parity fixture.

## Verification

- `npm run generate:fanout-aggregation-contract` twice
- `npm run generate:browser-fanout-aggregation-runtime` twice
- `npm run test:fanout-aggregation-contract-parity`
- `npm run test:php-fanout-aggregation-contract`
- `npm run test:browser-runtime-generic-invoker`
- `npm run test:browser-runtime-file-ops`
- `npm run build`
- `npm run smoke -- --group=agent` (18 checks)
- `npm run check` (101 checks; expected Docker-unavailable MySQL E2E skip)

Fixes #2375