### PR TITLE
Fix cross-target bundled CLI startup

### DIFF
--- a/packages/cli/src/cli-build-provenance.ts
+++ b/packages/cli/src/cli-build-provenance.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { spawn } from "node:child_process"
 import { existsSync } from "node:fs"
-import { readFile, readdir, writeFile } from "node:fs/promises"
+import { readFile, readdir, realpath, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 
 export const CLI_BUILD_PROVENANCE_FILE = "cli-build-provenance.json"
@@ -150,6 +150,8 @@ async function readPackageMetadata(packageRoot: string): Promise<{ name: string;
 }
 
 async function sourceIdentity(repositoryRoot: string, packageRoot: string): Promise<FileIdentity> {
+  repositoryRoot = await realpath(repositoryRoot)
+  packageRoot = await realpath(packageRoot)
   const files = [
     ...(await recursiveFiles(join(packageRoot, "src"))),
     join(packageRoot, "package.json"),

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -4,7 +4,6 @@ import type { ExecutionSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-co
 import { errorMessage, now, sha256 } from "@automattic/wp-codebox-core/internals"
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
-import sharp from "sharp"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import type { BrowserArtifact, BrowserProbeViewport } from "./browser-artifacts.js"
 import { launchChromiumBrowser } from "./browser-capture-session.js"
@@ -1904,6 +1903,7 @@ function visualCompareAnimatedMediaCandidate(body: Buffer): boolean {
 // the response first and reuse one static PNG buffer for identical content, so
 // URL, navigation timing, and capture order cannot affect the selected frame.
 async function installVisualCompareAnimatedMediaNormalization(page: Page, policy: "allow" | "first-frame", previewOrigin: string): Promise<VisualCompareAnimatedMediaTracker> {
+  const { default: sharp } = await import("sharp")
   let observed = 0
   let normalized = 0
   let failed = 0

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
-import { cp, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { cp, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises"
 import { createHash } from "node:crypto"
 import { tmpdir } from "node:os"
 import { join, relative, resolve } from "node:path"
@@ -140,6 +140,7 @@ try {
       version = cliVersion.stdout
       assert.match(version, /^\d+\.\d+\.\d+\s*$/)
       await execFileAsync(process.execPath, [cliEntrypoint, "commands"])
+      await assertCliStartsWithoutSharpRuntime(root, cliEntrypoint)
     }
     const descriptorModule = await import(pathToFileURL(join(root, "packages", "runtime-core", "dist", "runtime-contract-manifest.js")).href) as { runtimeDescriptor(): { capabilities: string[]; packageCapabilities: string[]; runtimeServices: { nativeMariaDb: { status: string } }; contractManifest: { capabilities: { runtimeServices: { packageCapabilities: string[] } } } } }
     const descriptor = descriptorModule.runtimeDescriptor()
@@ -212,6 +213,24 @@ try {
 }
 
 console.log("release package coverage passed")
+
+async function assertCliStartsWithoutSharpRuntime(root: string, cliEntrypoint: string): Promise<void> {
+  const nativePackages = sharpRuntimePackageNames(releasePlatform, releaseArch)
+  const disabledPackages: string[] = []
+  try {
+    for (const packageName of nativePackages) {
+      const packagePath = join(root, "node_modules", ...packageName.split("/"))
+      await rename(packagePath, `${packagePath}.disabled`)
+      disabledPackages.push(packagePath)
+    }
+    await execFileAsync(process.execPath, [cliEntrypoint, "--version"])
+    await execFileAsync(process.execPath, [cliEntrypoint, "commands"])
+  } finally {
+    for (const packagePath of disabledPackages.reverse()) {
+      await rename(`${packagePath}.disabled`, packagePath)
+    }
+  }
+}
 
 async function assertPinnedPhpWasmOverlay(root: string, provenancePath: string, allowInternalSymlink = false): Promise<void> {
   const overlay = join(root, "node_modules", "@php-wasm", "node-8-3")


### PR DESCRIPTION
## Summary

- defer loading Sharp until visual comparison actually normalizes animated media
- prove extracted release CLIs can run `--version` and `commands` with native Sharp packages unavailable
- canonicalize provenance source paths so macOS `/var` and `/private/var` aliases hash identically

Refs #1250.

## Testing

Passed:
- `npm run build`
- `npm run test:cli-build-freshness`
- `npm run test:release-target`
- `npm run test:sharp-release-runtime`
- `npm run test:prepare-declaration-rebuild`
- `npm run test:release-package-coverage` (initial complete run)

The full package smoke reaches an unrelated existing failure in `native-mariadb-runtime-service.test.ts`: the loopback collision fixture allocates once instead of twice (`1 !== 2`). A repeated 430+ MB release-package run later timed out after the initial successful run.

## AI Assistance

OpenAI `gpt-5.6-sol` through OpenCode reproduced the packaged CLI failure, implemented the lazy native dependency boundary and macOS provenance normalization, and ran the listed verification. Chris Huber reviewed and remains responsible for the change.