### PR TITLE
fix: refresh explicit Composer plugin sources

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -325,18 +325,13 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
     return prepared
   }
 
-  try {
-    const autoload = await stat(join(prepared.source, "vendor", "autoload.php"))
-    if (autoload.isFile()) {
-      return prepared
-    }
-  } catch {
-    // Prepare a temporary copy below.
-  }
-
   const stagingRoot = await mkdtemp(join(tmpdir(), `wp-codebox-plugin-${slug}-`))
-  const stagedRoot = join(stagingRoot, slug)
-  await cp(copyRoot, stagedRoot, { recursive: true })
+  const stagedRoot = prepareLocalSourceStageSync({
+    source: copyRoot,
+    targetRoot: stagingRoot,
+    targetName: slug,
+    cleanupRoot: false,
+  }).source
   const sourceSubpath = relative(copyRoot, prepared.source).replace(/\\/g, "/")
   const stagedSource = sourceSubpath ? join(stagedRoot, sourceSubpath) : stagedRoot
   try {

--- a/tests/recipe-extra-plugin-composer-preparation.test.ts
+++ b/tests/recipe-extra-plugin-composer-preparation.test.ts
@@ -53,6 +53,9 @@ await withTempDir("wp-codebox-explicit-composer-plugin-", async (recipeDirectory
     config: { "allow-plugins": { "example/malicious-plugin": true } },
     extra: { "installer-paths": { "packages/{$name}": ["example/runtime-package"] } },
   }, null, 2)}\n`)
+  await mkdir(join(source, "vendor", "composer"), { recursive: true })
+  await writeFile(join(source, "vendor", "autoload.php"), "<?php require __DIR__ . '/composer/autoload_files.php';\n")
+  await writeFile(join(source, "vendor", "composer", "autoload_files.php"), "<?php require __DIR__ . '/../../removed-fixture.php';\n")
   await writeFile(join(source, "source-plugin.php"), "<?php\n/* Plugin Name: Source Plugin */\n")
   await writeFile(join(pathPackage, "composer.json"), `${JSON.stringify({ name: "example/runtime-package", type: "wordpress-plugin" })}\n`)
   await writeFile(join(pathPackage, "src", "Package.php"), "<?php namespace Example\\RuntimePackage; final class Package {}\n")
@@ -92,13 +95,14 @@ printf '<?php return array();\n' > vendor/composer/autoload_classmap.php
   }
 
   assert.ok(plugin)
-  assert.notEqual(plugin.source, source, "explicit Composer preparation must use a staged copy")
+  assert.notEqual(plugin.source, source, "explicit Composer preparation must replace an existing stale vendor tree in a staged copy")
   assert.equal(await pathExists(join(plugin.source, "vendor", "autoload.php")), true)
+  assert.equal(await pathExists(join(plugin.source, "vendor", "composer", "autoload_files.php")), false, "stale generated autoload files must not survive preparation")
   assert.match(await readFile(join(plugin.source, "vendor", "autoload_packages.php"), "utf8"), /require_once __DIR__ \. '\/autoload\.php';/)
   assert.equal(await pathExists(join(plugin.source, "packages", "runtime-package", "src", "Package.php")), true, "Composer must install the WordPress package at its declared runtime path")
   await execFile("php", ["-r", `define('ABSPATH', ${JSON.stringify(`${plugin.source}/`)}); require ${JSON.stringify(join(plugin.source, "vendor", "autoload_packages.php"))}; if (!class_exists('Example\\\\RuntimePackage\\\\Package')) { exit(1); }`])
   assert.equal(await pathExists(pluginExecuted), false, "recipe-authorized Composer plugins must remain disabled during host hydration")
-  assert.equal(await pathExists(join(source, "vendor")), false, "explicit preparation must not mutate the caller source")
+  assert.match(await readFile(join(source, "vendor", "composer", "autoload_files.php"), "utf8"), /removed-fixture/, "explicit preparation must not mutate the caller source")
   assert.equal(plugin.provenance.localPathCategory, "temporary-composer-autoload")
   await cleanupRecipePreparedSources([], [plugin])
 })


### PR DESCRIPTION
## Summary
- always stage explicitly Composer-prepared local plugin sources through the canonical filtered copier
- discard ignored/stale `vendor` trees before contained Composer hydration
- preserve caller checkout state and existing `--no-dev --no-scripts --no-plugins` execution policy

## Verification
- `npm exec -- tsx tests/recipe-extra-plugin-composer-preparation.test.ts`
- `npm run test:recipe-extra-plugin-composer-autoloaders`
- `npm run build`
- exact Data Machine Socials reproduction progressed from zero executions to 247 PHPUnit tests (236 passed, 1 downstream compatibility failure, 10 skipped)

Fixes #2380