### PR TITLE
fix: serialize readonly mount cache retention

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -128,7 +128,7 @@ async function prepareReadonlyDirectory(mount: MountSpec, mountIndex: number, so
   await mkdir(cacheRoot, { recursive: true, mode: 0o700 })
 
   let mode: ReadonlyMountPreparation["mode"] = "cache-hit"
-  await withPlaygroundArchiveCacheLock(cacheRoot, `readonly-mount-${generation.fingerprint}`, async () => {
+  await withPlaygroundArchiveCacheLock(cacheRoot, "readonly-mount-cache", async () => {
     for (let attempt = 0; attempt < 2; attempt++) {
       if (!await directoryExists(cachePath)) {
         mode = "cache-miss"

--- a/tests/playground-readonly-mounts.test.ts
+++ b/tests/playground-readonly-mounts.test.ts
@@ -171,6 +171,16 @@ try {
   assert.ok((await Promise.all(concurrent.map(async (entry) => await readFile(join(entry.mounts[0].source, "value.txt"), "utf8") === "concurrent"))).every(Boolean), "concurrent snapshots are complete")
   await Promise.all(concurrent.map((entry) => entry[Symbol.asyncDispose]()))
 
+  const parallelSources = await Promise.all(Array.from({ length: 12 }, async (_, index) => {
+    const source = join(root, `parallel-source-${index}`)
+    await mkdir(source)
+    await writeFile(join(source, "value.txt"), `parallel-${index}`)
+    return source
+  }))
+  const parallel = await stageReadonlyPlaygroundMounts(parallelSources.map((source, index) => ({ source, target: `/parallel-${index}`, mode: "readonly" })))
+  assert.ok((await Promise.all(parallel.mounts.map(async (mount, index) => await readFile(join(mount.source, "value.txt"), "utf8") === `parallel-${index}`))).every(Boolean), "parallel unique snapshots survive cache retention")
+  await parallel[Symbol.asyncDispose]()
+
   const nestedParent = join(root, "nested-parent")
   const nestedOverlay = join(root, "nested-overlay")
   await mkdir(nestedParent)


### PR DESCRIPTION
## Summary
- use one cache-root lock for readonly snapshot creation, retention, and cloning
- prevent retention for one fingerprint from evicting another parallel mount's active cache entry
- cover twelve unique parallel mounts, exceeding the eight-entry retention limit

## Verification
- `npm exec -- tsx tests/playground-readonly-mounts.test.ts`
- `npm run build`
- full released Gardner recipe completed successfully: run `run_8cc6c2afdd3b43feae01ccd4b5683044`, runtime `runtime-mt8rh00m-p0b89z`

Fixes #2382