### PR TITLE
fix(release): publish platform CLI archives

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -72,7 +72,7 @@
   ],
   "scripts": {
     "build": [
-      "npm run package:wordpress-plugin"
+      "npm run release:package"
     ],
     "lint": [
       "npm run build"

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -22,6 +22,7 @@ assert.deepEqual(homeboy.release?.package_coverage, [{
   source_roots: [pluginRoot],
   archive_root: "wp-codebox",
 }])
+assert.deepEqual(homeboy.scripts?.build, ["npm run release:package"], "Homeboy releases must consume the release artifact manifest")
 assert.deepEqual(homeboy.scripts?.test, [
   "npm run smoke -- --group package",
   "npm run test:release-target",


### PR DESCRIPTION
## Summary
- route Homeboy's canonical build hook through the existing `release:package` manifest instead of plugin-only packaging
- publish installer-compatible platform CLI archives alongside `wp-codebox.zip`
- lock the Homeboy build contract into release package coverage

## Verification
- `npm run test:release-package-coverage`
- `npm run build`
- Cook run: `agent-task-effc69bd-a189-497a-9fa0-16ecac26f9c1-transport-retry`

## Compatibility
Low risk. Existing WordPress ZIP and CLI packaging remain owned by their current scripts; this only makes canonical Homeboy releases consume the complete artifact manifest. No installer, changelog, version, release, or deployment changes.

Fixes #2384