### PR TITLE
fix(fuzz): preserve input-relative runtime sources

### DIFF
--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -438,7 +438,7 @@ function resolveFuzzSuiteRuntimeRequirementPaths(input: Record<string, unknown>,
   const requirements = objectOption(metadata?.runtime_requirements)
   if (!metadata || !requirements) return input
 
-  const resolvePath = (value: unknown): unknown => typeof value === "string" && value.trim() && !/^https?:\/\//i.test(value) ? resolve(inputDirectory, value) : value
+  const resolvePath = (value: unknown): unknown => typeof value === "string" && value.trim() && !/^[a-z][a-z\d+.-]*:\/\//i.test(value) ? resolve(inputDirectory, value) : value
   const resolvePluginPaths = (entries: unknown): unknown => Array.isArray(entries)
     ? entries.map((entry) => {
       const plugin = objectOption(entry)
@@ -446,6 +446,10 @@ function resolveFuzzSuiteRuntimeRequirementPaths(input: Record<string, unknown>,
       const resolved = { ...plugin }
       for (const key of ["source", "path", "sourceRoot", "source_root"]) {
         if (key in plugin) resolved[key] = resolvePath(plugin[key])
+      }
+      const originalSource = stringValue(plugin.source) ?? stringValue(plugin.path)
+      if (originalSource && resolvePath(originalSource) !== originalSource && plugin.originalSource === undefined && plugin.original_source === undefined) {
+        resolved.originalSource = originalSource
       }
       return resolved
     })

--- a/tests/fixtures/fuzz-relative-plugin/fuzz-relative-plugin.php
+++ b/tests/fixtures/fuzz-relative-plugin/fuzz-relative-plugin.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Fuzz Relative Plugin
+ */

--- a/tests/fixtures/fuzz-relative-plugin/tests/fuzz/pipeline-builder-runtime.json
+++ b/tests/fixtures/fuzz-relative-plugin/tests/fuzz/pipeline-builder-runtime.json
@@ -1,0 +1,38 @@
+{
+  "schema": "wp-codebox/fuzz-suite/v1",
+  "id": "data-machine-style-relative-runtime-requirements",
+  "metadata": {
+    "runtime_requirements": {
+      "extra_plugins": [
+        {
+          "slug": "fuzz-relative-plugin",
+          "source": "../..",
+          "path": "../..",
+          "loadAs": "plugin",
+          "activate": true
+        }
+      ],
+      "component_contracts": [
+        {
+          "slug": "fuzz-relative-plugin",
+          "path": "../..",
+          "loadAs": "plugin",
+          "activate": true
+        }
+      ]
+    }
+  },
+  "cases": [
+    {
+      "id": "runtime-command",
+      "target": {
+        "kind": "runtime",
+        "id": "wordpress.rest-route-inventory",
+        "entrypoint": "wordpress.rest-route-inventory"
+      },
+      "input": {
+        "args": []
+      }
+    }
+  ]
+}

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 
 import { runCli } from "../packages/cli/src/cli-entry.js"
 
@@ -145,35 +146,18 @@ return static function ( array $input, array $args ): array {
   const typedWorkloads = JSON.parse(typedWorkloadsJson.replace(/^workloads-json=/, ""))
   assert.deepEqual(typedWorkloads[0].run, [{ type: "php", code: "return array('ok' => true);" }])
 
-  const nestedSuiteDirectory = join(directory, "repository", "tests", "fuzz")
-  const siblingPluginSource = join(directory, "repository", "plugins", "sibling-plugin")
-  await mkdir(nestedSuiteDirectory, { recursive: true })
-  await mkdir(siblingPluginSource, { recursive: true })
-  await writeFile(join(siblingPluginSource, "sibling-plugin.php"), "<?php\n/* Plugin Name: Sibling Plugin */\n", "utf8")
-  const nestedRuntimeFuzzInput = join(nestedSuiteDirectory, "suite.json")
-  await writeFile(nestedRuntimeFuzzInput, JSON.stringify({
-    schema: "wp-codebox/fuzz-suite/v1",
-    id: "portable-relative-runtime-requirements",
-    metadata: {
-      runtime_requirements: {
-        extra_plugins: [{ slug: "sibling-plugin", source: "../../plugins/sibling-plugin", originalSource: "../../plugins/sibling-plugin", loadAs: "plugin", activate: true }],
-        component_contracts: [{ slug: "sibling-plugin", path: "../../plugins/sibling-plugin", original_source: "../../plugins/sibling-plugin", loadAs: "plugin", activate: true }],
-      },
-    },
-    cases: [{
-      id: "portable-relative-plugin",
-      target: { kind: "runtime", id: "wordpress.rest-route-inventory", entrypoint: "wordpress.rest-route-inventory" },
-      input: { args: [] },
-    }],
-  }), "utf8")
+  const nestedRuntimeFuzzInput = fileURLToPath(new URL("./fixtures/fuzz-relative-plugin/tests/fuzz/pipeline-builder-runtime.json", import.meta.url))
+  const nestedPluginSource = fileURLToPath(new URL("./fixtures/fuzz-relative-plugin", import.meta.url))
   const nestedRuntimeFuzzOutput = await captureStdout(async () => {
     assert.equal(await runCli(["run-fuzz-suite", "--input-file", nestedRuntimeFuzzInput, "--format=json", "--dry-run"]), 0)
   })
   const nestedRuntimeFuzzJson = JSON.parse(nestedRuntimeFuzzOutput)
   const nestedRuntimePlan = nestedRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan
-  assert.deepEqual(nestedRuntimePlan.extra_plugins.map((plugin: { source: string; slug: string; activate: boolean }) => ({ source: plugin.source, slug: plugin.slug, activate: plugin.activate })), [{ source: siblingPluginSource, slug: "sibling-plugin", activate: true }])
-  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.extra_plugins[0].originalSource, "../../plugins/sibling-plugin")
-  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.component_contracts[0].original_source, "../../plugins/sibling-plugin")
+  assert.deepEqual(nestedRuntimePlan.extra_plugins.map((plugin: { source: string; slug: string; activate: boolean }) => ({ source: plugin.source, slug: plugin.slug, activate: plugin.activate })), [{ source: nestedPluginSource, slug: "fuzz-relative-plugin", activate: true }])
+  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.extra_plugins[0].originalSource, "../..")
+  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.component_contracts[0].originalSource, "../..")
+  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.extra_plugins[0].source, nestedPluginSource)
+  assert.equal(nestedRuntimePlan.metadata.runtime_requirements.component_contracts[0].path, nestedPluginSource)
   const nestedRuntimeExecutionOutput = await captureStdout(async () => {
     assert.equal(await runCli(["run-fuzz-suite", "--input-file", nestedRuntimeFuzzInput, "--format=json", "--runner-mode=runtime-backed"]), 0)
   })
@@ -181,6 +165,11 @@ return static function ( array $input, array $args ): array {
   assert.equal(nestedRuntimeExecution.status, "passed")
   assert.equal(nestedRuntimeExecution.cases[0].status, "passed")
 
+  const nestedSuiteDirectory = join(directory, "repository", "tests", "fuzz")
+  const siblingPluginSource = join(directory, "repository", "plugins", "sibling-plugin")
+  await mkdir(nestedSuiteDirectory, { recursive: true })
+  await mkdir(siblingPluginSource, { recursive: true })
+  await writeFile(join(siblingPluginSource, "sibling-plugin.php"), "<?php\n/* Plugin Name: Sibling Plugin */\n", "utf8")
   const componentOnlyFuzzInput = join(nestedSuiteDirectory, "component-suite.json")
   await writeFile(componentOnlyFuzzInput, JSON.stringify({
     schema: "wp-codebox/fuzz-suite/v1",


### PR DESCRIPTION
## Summary

- normalize local fuzz runtime requirement references once when public `--input-file` input is read, while retaining the original reference in the existing `originalSource` field
- preserve URL, absolute-path, source-root/subpath, `--input-json`, and nested recipe-command semantics
- replace the synthetic relative-path coverage with a committed minimal plugin fixture matching the reported `tests/fuzz` plus `../..` Data Machine shape

## Resolution Call Chains

Observed failing public artifact path:

```text
parsePublicRuntimeCommandOptions
  -> readInput (parsed --input-file suite retained ../..)
  -> normalizePublicFuzzSuite
  -> runWordPressFuzzCommand / runWordPressWorkloadFuzzCase
  -> applyFuzzSuiteRuntimeRequirements
  -> write temporary recipe.json
  -> runRecipeRunCommand
  -> validateWorkspaceRecipeSemantics / prepareRecipeSource
  -> resolve(temporary recipe or process root, ../..)
```

Fixed path:

```text
parsePublicRuntimeCommandOptions
  -> readInput
  -> resolveFuzzSuiteRuntimeRequirementPaths(parsed, dirname(resolvedInputFile))
     -> normalize wordpress_directory
     -> normalize extra_plugins source/path/sourceRoot
     -> normalize component_contracts path/sourceRoot
     -> retain original local source/path as originalSource
  -> normalizePublicFuzzSuite
  -> shared options.input consumed by dry-run and runtime-backed execution
  -> applyFuzzSuiteRuntimeRequirements
  -> temporary recipe materialization and normal recipe validation
```

The public file-input boundary owns the fix because it is the last layer that knows the suite file location and the first layer shared by dry-run and runtime-backed execution. Recipe validation and source preparation should remain recipe-relative and should not infer a caller's input-file directory.

## Preserved Semantics

- `--input-json` still returns parsed input directly and receives no file-relative normalization.
- Nested `wp-codebox/run-fuzz-suite` recipe commands still resolve their `input-file` against `recipeDirectory` in `fuzzSuiteFromRecipeCommandArgs()`.
- Absolute paths remain unchanged through `path.resolve()`.
- URL-shaped references remain URLs for normal source-policy validation rather than becoming host paths.
- `sourceSubpath` / `sourceSubdir` are not normalized at this boundary and remain bounded plugin-internal paths.
- Existing caller-provided `originalSource` / `original_source` values are preserved.

## Evidence

The committed fixture is a minimal real plugin root at `tests/fixtures/fuzz-relative-plugin`; its nested suite is at `tests/fuzz/pipeline-builder-runtime.json` and declares both `extra_plugins[].source/path = ../..` and `component_contracts[].path = ../..`.

Built public CLI evidence:

```text
dry-run: 1/1 passed, normalized=<worktree>/tests/fixtures/fuzz-relative-plugin, original=../..
runtime-backed: 1/1 passed
```

Dry-run asserts the normalized source/path for both requirement lists and the retained original references. Runtime-backed execution mounts and activates the fixture plugin, boots WordPress, and executes `wordpress.rest-route-inventory`.

## Tests And Gates

- `npm exec -- tsx tests/public-fuzz-workload-cli.test.ts`: passed, including 1 dry-run and 1 runtime-backed nested-fixture case
- `npm run test:nested-fuzz-suite-recipe-command`: passed
- `npm run test:fuzz-suite-runner`: passed
- `npm run test:fuzz-run-recipe`: passed
- `npm run test:public-api-contract`: passed
- `npm run build`: passed across runtime-core, runtime-playground, and CLI
- built `packages/cli/dist/index.js` exact fixture check: 2/2 modes passed, 1/1 case each
- Homeboy PR audit: 0 introduced findings; 1 known contextual info finding
- Homeboy changed-scope lint: 4 files, 0 findings
- Homeboy release package build: passed, 2 artifacts produced (WordPress plugin ZIP and Linux x64 CLI tarball)
- Homeboy selected and Node passed 1/1 changed test, but Homeboy misparsed the TAP summary as zero tests; tracked in Extra-Chill/homeboy#13497
- Homeboy full audit also treated an unchanged source literal as introduced only after scanning ignored generated `dist/`; the required PR-profile audit passed and the full-profile false positive is tracked in Extra-Chill/homeboy#13502

Fixes #2385

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the public CLI and recipe materialization paths, implemented the focused change and fixture, ran the runtime-backed verification and gates, and drafted this PR. Chris Huber directed the work and acceptance criteria.