### PR TITLE
fix(release): route artifacts through Node provider

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,7 +3,9 @@
   "remote_url": "https://github.com/Automattic/wp-codebox.git",
   "changelog_target": "CHANGELOG.md",
   "extensions": {
-    "nodejs": {}
+    "nodejs": {
+      "release_package_script": "release:package"
+    }
   },
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
   "deployment_provider": {
@@ -72,7 +74,7 @@
   ],
   "scripts": {
     "build": [
-      "npm run release:package"
+      "npm run package:wordpress-plugin"
     ],
     "lint": [
       "npm run build"

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -22,7 +22,8 @@ assert.deepEqual(homeboy.release?.package_coverage, [{
   source_roots: [pluginRoot],
   archive_root: "wp-codebox",
 }])
-assert.deepEqual(homeboy.scripts?.build, ["npm run release:package"], "Homeboy releases must consume the release artifact manifest")
+assert.deepEqual(homeboy.extensions?.nodejs, { release_package_script: "release:package" }, "the Node release provider must consume the project artifact manifest")
+assert.deepEqual(homeboy.scripts?.build, ["npm run package:wordpress-plugin"], "component builds retain singular WordPress deploy-artifact ownership")
 assert.deepEqual(homeboy.scripts?.test, [
   "npm run smoke -- --group package",
   "npm run test:release-target",


### PR DESCRIPTION
## Summary
- opt WP Codebox into the Node extension's explicit `release_package_script` contract
- restore `scripts.build` to singular WordPress deploy-artifact ownership
- replace the false build-manifest assertion added in #2386 with the actual extension package-provider contract

## Verification
- `npm run test:release-package-coverage`
- `npm run build`
- cross-repo provider execution with Extra-Chill/homeboy-extensions#2713 emitted one pure three-artifact array:
  - `packages/wordpress-plugin/dist/wp-codebox.zip`
  - `dist/wp-codebox-cli-linux-x64.tar.gz`
  - `wp-codebox-workspace-0.24.3.tgz`

## Dependency
Requires Extra-Chill/homeboy-extensions#2713 to be released and installed before the next WP Codebox release.

Refs #2384