### PR TITLE
fix(release): pass Node package settings

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -4,7 +4,9 @@
   "changelog_target": "CHANGELOG.md",
   "extensions": {
     "nodejs": {
-      "release_package_script": "release:package"
+      "settings": {
+        "release_package_script": "release:package"
+      }
     }
   },
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -22,7 +22,7 @@ assert.deepEqual(homeboy.release?.package_coverage, [{
   source_roots: [pluginRoot],
   archive_root: "wp-codebox",
 }])
-assert.deepEqual(homeboy.extensions?.nodejs, { release_package_script: "release:package" }, "the Node release provider must consume the project artifact manifest")
+assert.deepEqual(homeboy.extensions?.nodejs, { settings: { release_package_script: "release:package" } }, "the Node release provider must receive the project artifact manifest setting")
 assert.deepEqual(homeboy.scripts?.build, ["npm run package:wordpress-plugin"], "component builds retain singular WordPress deploy-artifact ownership")
 assert.deepEqual(homeboy.scripts?.test, [
   "npm run smoke -- --group package",


### PR DESCRIPTION
## Summary
- move `release_package_script` under the canonical `extensions.nodejs.settings` payload
- ensure Homeboy sends it as `payload.config.release_package_script` to the Node release provider
- retain plugin-only component build ownership

## Verification
- `npm run test:release-package-coverage`
- `npm run build`
- v0.24.4 release evidence showed `payload.config: null` for the prior direct-field shape, proving why the provider took its default npm-only path

Refs #2384