### PR TITLE
Support custom database drop-ins in Playground runtimes

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -223,7 +223,7 @@ export async function runRecipe(options: RecipeRunOptions, interruption?: Recipe
       phpVersion: plan.runtime.phpVersion,
       workers: plan.runtime.workers,
       wordpressInstallMode: plan.runtime.wordpressInstallMode,
-      databaseSetup: recipe.inputs?.services?.some(({ kind }) => kind === "mysql") ? "external" as const : undefined,
+      databaseSetup: recipe.inputs?.services?.some(({ kind }) => kind === "mysql") ? "external" as const : plan.runtime.databaseSetup,
       blueprint: plan.runtime.blueprint,
       assets: resolveRecipeRuntimeAssets(recipe, recipeDirectory),
       extensions: resolveRecipeRuntimeExtensionManifests(recipe, recipeDirectory),

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, resolve } from "node:path"
-import { fixtureImportDeterministicIdPlan, normalizeRuntimeBackendKind, validateRuntimePolicy, type FixtureImportDeterministicIdPlan, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeSiteSeedBootstrap, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
+import { fixtureImportDeterministicIdPlan, normalizeRuntimeBackendKind, validateRuntimePolicy, type FixtureImportDeterministicIdPlan, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimeWordPressDatabaseSetup, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeSiteSeedBootstrap, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { serializeError } from "./output.js"
 import { RecipeArtifactsMountConflictError, recipeArtifactsMountConflict } from "./commands/recipe-run-artifacts-mount-guard.js"
@@ -56,6 +56,7 @@ export interface RecipePlan {
     phpVersion?: string
     workers?: number | "auto"
     wordpressInstallMode?: RuntimeWordPressInstallMode
+    databaseSetup?: RuntimeWordPressDatabaseSetup
     assets?: RuntimeAssetSpec
     blueprint: unknown
     extensions?: Array<{ manifest: string }>
@@ -132,6 +133,7 @@ interface RecipeDryRunMount {
   source?: string
   target: string
   mode: "readonly" | "readwrite"
+  phase?: MountSpec["phase"]
   metadata?: Record<string, unknown>
   planned?: "existing" | "generated"
 }
@@ -367,6 +369,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
       source,
       target: mount.target,
       mode: mount.mode ?? "readwrite" as const,
+      ...(mount.phase !== undefined ? { phase: mount.phase } : {}),
       ...(mount.metadata ? { metadata: mount.metadata } : {}),
       planned: "existing" as const,
     }
@@ -469,6 +472,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
       ...(recipe.runtime?.phpVersion ? { phpVersion: recipe.runtime.phpVersion } : {}),
       ...(recipe.runtime?.workers !== undefined ? { workers: recipe.runtime.workers } : {}),
       ...(recipe.runtime?.wordpressInstallMode ? { wordpressInstallMode: recipe.runtime.wordpressInstallMode } : {}),
+      ...(recipe.runtime?.databaseSetup ? { databaseSetup: recipe.runtime.databaseSetup } : {}),
       ...(recipe.runtime?.assets ? { assets: recipe.runtime.assets } : {}),
       ...(recipe.runtime?.extensions ? { extensions: recipe.runtime.extensions } : {}),
       blueprint: recipeBlueprintWithBootActivePlugins(recipe.runtime?.blueprint, extraPlugins),

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -130,6 +130,10 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             enum: enumValues(options.runtimeWordPressInstallModes, defaultRuntimeWordPressInstallModes),
             description: "Controls how Playground prepares a mounted WordPress directory. Use do-not-attempt-installing for custom distributions that own their own boot/readiness probes.",
           },
+          databaseSetup: {
+            enum: ["runtime-managed", "custom-drop-in"],
+            description: "Select custom-drop-in when a recipe-mounted db.php owns the WordPress database boundary.",
+          },
           blueprint: { type: "object" },
           preview: { $ref: "#/$defs/runtimePreview" },
           assets: { $ref: "#/$defs/runtimeAssets" },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -680,6 +680,7 @@ export interface WorkspaceRecipe {
     phpVersion?: string
     workers?: RuntimeWorkerCount
     wordpressInstallMode?: RuntimeWordPressInstallMode
+    databaseSetup?: RuntimeWordPressDatabaseSetup
     blueprint?: unknown
     preview?: RuntimePreviewSpec
     assets?: RuntimeAssetSpec

--- a/packages/runtime-core/src/runtime-neutral-contracts.ts
+++ b/packages/runtime-core/src/runtime-neutral-contracts.ts
@@ -60,7 +60,7 @@ export interface BackendNeutralEnvironmentSpec {
 }
 
 export type RuntimeWordPressInstallModeContract = "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
-export type RuntimeWordPressDatabaseSetupContract = "runtime-managed" | "external"
+export type RuntimeWordPressDatabaseSetupContract = "runtime-managed" | "external" | "custom-drop-in"
 export type RuntimeWorkerCount = number | "auto"
 
 export interface RuntimeWordPressAssetSpec extends BackendNeutralRuntimeAssetSpec {

--- a/packages/runtime-playground/src/blueprint.ts
+++ b/packages/runtime-playground/src/blueprint.ts
@@ -65,6 +65,21 @@ export function playgroundRuntimeBlueprint(spec: RuntimeCreateSpec): unknown {
   }
 }
 
+export function playgroundWpConfigConstants(blueprint: unknown): Record<string, string | number | boolean | null> {
+  const constants: Record<string, string | number | boolean | null> = {}
+  for (const step of normalizeBlueprint(blueprint).steps) {
+    if (!step || typeof step !== "object" || Array.isArray(step)) continue
+    const candidate = step as { step?: unknown; consts?: unknown }
+    if (candidate.step !== "defineWpConfigConsts" || !candidate.consts || typeof candidate.consts !== "object" || Array.isArray(candidate.consts)) continue
+    for (const [name, value] of Object.entries(candidate.consts)) {
+      if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+        constants[name] = value as string | number | boolean | null
+      }
+    }
+  }
+  return constants
+}
+
 export function playgroundRuntimeSiteUrl(spec: RuntimeCreateSpec | undefined): string | undefined {
   const declaredSiteUrl = playgroundSiteSeedPrimaryUrl(spec) ?? spec?.preview?.siteUrl
   if (declaredSiteUrl || !spec || !blueprintNeedsPortlessMultisiteUrl(spec.environment.blueprint)) {

--- a/packages/runtime-playground/src/database-bootstrap.ts
+++ b/packages/runtime-playground/src/database-bootstrap.ts
@@ -1,0 +1,38 @@
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { phpLiteral } from "./php-snippets.js"
+
+export function databaseBootstrapWpConfig(spec: RuntimeCreateSpec): string | undefined {
+  if (spec.environment.databaseSetup === "custom-drop-in") {
+    return `<?php
+define('DB_NAME', 'custom_drop_in');
+define('DB_USER', 'custom_drop_in');
+define('DB_PASSWORD', '');
+define('DB_HOST', 'localhost');
+define('DB_CHARSET', 'utf8mb4');
+define('DB_COLLATE', '');
+$table_prefix = 'wp_';
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/');
+require_once ABSPATH . 'wp-settings.php';
+`
+  }
+  if (spec.environment.databaseSetup !== "external") return undefined
+  const host = spec.runtimeEnv?.DB_HOST
+  if (!host) return undefined
+  const port = spec.runtimeEnv?.DB_PORT
+  const values = {
+    DB_NAME: spec.runtimeEnv?.DB_NAME ?? "runtime",
+    DB_USER: spec.runtimeEnv?.DB_USER ?? "root",
+    DB_HOST: port ? `${host}:${port}` : host,
+  }
+  return `<?php
+define('DB_NAME', ${phpLiteral(values.DB_NAME)});
+define('DB_USER', ${phpLiteral(values.DB_USER)});
+define('DB_PASSWORD', (string) getenv('DB_PASSWORD'));
+define('DB_HOST', ${phpLiteral(values.DB_HOST)});
+define('DB_CHARSET', 'utf8mb4');
+define('DB_COLLATE', '');
+$table_prefix = 'wp_';
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/');
+require_once ABSPATH . 'wp-settings.php';
+`
+}

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -1,4 +1,4 @@
-import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl } from "./blueprint.js"
+import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl, playgroundWpConfigConstants } from "./blueprint.js"
 import { PlaygroundCliExitError, type PlaygroundCliBufferedOutput } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
 import { startProgrammaticPlaygroundServer } from "./programmatic-playground-runner.js"
@@ -14,6 +14,7 @@ import { resolveWordPressRelease } from "@wp-playground/wordpress"
 import { phpEnvAssignments, phpLiteral, phpWpConfigDefineAssignments } from "./php-snippets.js"
 import { stageReadonlyPlaygroundMounts, type ReadonlyMountStaging } from "./mount-materialization.js"
 import { acquirePlaygroundArchiveReference, isCustomPlaygroundWordPressArchive, maintainPlaygroundCustomArchiveCache, playgroundWordPressArchiveCacheDirectory, withPlaygroundArchiveCacheLock, type PlaygroundArchiveReference, type PlaygroundCustomArchiveCacheDiagnostic, type PlaygroundCustomArchiveCacheMaintenance } from "./playground-wordpress-archive-cache.js"
+import { databaseBootstrapWpConfig } from "./database-bootstrap.js"
 
 const DEFAULT_RUNTIME_PHP_INI_ENTRIES = { memory_limit: "512M" }
 
@@ -32,6 +33,9 @@ export interface PlaygroundCliModule {
     workers?: number | "auto"
     wordpressInstallMode?: "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
     skipSqliteSetup?: boolean
+    define?: Record<string, string>
+    "define-bool"?: Record<string, boolean>
+    "define-number"?: Record<string, number>
     "site-url"?: string
     phpIniEntries?: Record<string, string>
     phpEnv?: Record<string, string>
@@ -83,14 +87,9 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       wordpressVersion: spec.environment.version,
     })
     const wordpressDirectory = spec.environment.assets?.wordpressDirectory
-    const wordpressInstallMode = spec.environment.wordpressInstallMode ?? "install-from-existing-files"
+    const wordpressInstallMode = spec.environment.wordpressInstallMode
+      ?? (spec.environment.databaseSetup === "custom-drop-in" ? "do-not-attempt-installing" : "install-from-existing-files")
     const bootstrapIniEntries = runtimeBootstrapPhpIniEntries(spec)
-    const useProgrammaticRunner = shouldUseProgrammaticPlaygroundRunner(spec, options)
-    const requestWorkerEndpoint = useProgrammaticRunner ? undefined : {
-      route: `/wp-codebox-execute-${randomBytes(12).toString("hex")}.php`,
-      token: randomBytes(32).toString("base64url"),
-      payloadDirectory: join(spec.artifactsDirectory ?? "artifacts", "playground-internal-shared"),
-    }
     usesArchiveCache = !wordpressDirectory && !spec.environment.assets?.wordpressZip
     readonlyMountStaging = await stageReadonlyPlaygroundMounts(mounts)
     emitProgress("preview:materializing-mounts", "complete", "Prepared mounted inputs", {
@@ -105,6 +104,12 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       cacheMaintenanceDiagnostics = maintenance.diagnostics
     }
     const wordpressStartupAsset = wordpressDirectory ? undefined : await resolvePlaygroundWordPressStartupAsset(spec.environment.version, spec.environment.assets?.wordpressZip)
+    const useProgrammaticRunner = shouldUseProgrammaticPlaygroundRunner(spec, options, Boolean(wordpressStartupAsset?.localPath || wordpressStartupAsset?.wp))
+    const requestWorkerEndpoint = useProgrammaticRunner ? undefined : {
+      route: `/wp-codebox-execute-${randomBytes(12).toString("hex")}.php`,
+      token: randomBytes(32).toString("base64url"),
+      payloadDirectory: join(spec.artifactsDirectory ?? "artifacts", "playground-internal-shared"),
+    }
     archiveReference = wordpressStartupAsset?.archiveReference
     const cacheValidation = wordpressStartupAsset?.cacheValidation ?? {
       version: spec.environment.version ?? "mounted-wordpress-source",
@@ -137,16 +142,19 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           port,
         },
       }, stagedMounts, {
-        bootstrapIniEntries: bootstrapIniEntries!,
+        bootstrapIniEntries: bootstrapIniEntries ?? {},
         phpIniEntries: pluginRuntimePhpIniEntries(spec),
-        wordpressDirectory: wordpressDirectory!,
+        wordpressDirectory,
+        wordpressArchivePath: wordpressStartupAsset?.localPath,
+        wordpressArchiveUrl: wordpressStartupAsset?.wp,
         wordpressInstallMode,
-        sharedPhpIniContent: phpIniContent(bootstrapIniEntries!, "/internal/wp-codebox/auto_prepend_file.php"),
+        sharedPhpIniContent: phpIniContent(bootstrapIniEntries ?? {}, "/internal/wp-codebox/auto_prepend_file.php"),
       })
     }, Boolean(spec.preview?.port)) : await startPlaygroundCliWithDynamicPortRetry(async (port) => {
       const { runCLI } = options.cliModule ?? (await import("@wp-playground/cli")) as unknown as PlaygroundCliModule
       const localAssetServer = wordpressStartupAsset?.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
       const bootstrapSharedMounts = await pluginRuntimeBootstrapSharedMounts(spec, requestWorkerEndpoint)
+      const customDropInDefines = customDropInBootstrapDefines(spec)
       try {
         return await runCLI({
           command: "server",
@@ -169,10 +177,11 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
               ...(wordpressDirectory ? [{ hostPath: wordpressDirectory, vfsPath: "/wordpress" }] : []),
             ],
           } : {}),
-          ...(wordpressDirectory ? { wordpressInstallMode } : {}),
+          ...(wordpressDirectory || spec.environment.databaseSetup === "custom-drop-in" ? { wordpressInstallMode } : {}),
           wp: localAssetServer?.url ?? wordpressStartupAsset?.wp,
           php: spec.environment.phpVersion,
-          skipSqliteSetup: spec.environment.databaseSetup === "external",
+          skipSqliteSetup: spec.environment.databaseSetup === "external" || spec.environment.databaseSetup === "custom-drop-in",
+          ...customDropInDefines,
           ...(spec.environment.extensions?.length ? { phpExtension: spec.environment.extensions.map((extension) => extension.manifest) } : {}),
           ...playgroundBundledExtensionOptions(spec),
           phpIniEntries: pluginRuntimePhpIniEntries(spec),
@@ -229,6 +238,28 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     }
 
     throw error
+  }
+}
+
+function customDropInBootstrapDefines(spec: RuntimeCreateSpec): Pick<Parameters<PlaygroundCliModule["runCLI"]>[0], "define" | "define-bool" | "define-number"> {
+  if (spec.environment.databaseSetup !== "custom-drop-in") {
+    return {}
+  }
+
+  const constants = playgroundWpConfigConstants(spec.environment.blueprint)
+  const define: Record<string, string> = {}
+  const defineBool: Record<string, boolean> = {}
+  const defineNumber: Record<string, number> = {}
+  for (const [name, value] of Object.entries(constants ?? {})) {
+    if (typeof value === "boolean") defineBool[name] = value
+    else if (typeof value === "number") defineNumber[name] = value
+    else if (typeof value === "string") define[name] = value
+  }
+
+  return {
+    ...(Object.keys(define).length > 0 ? { define } : {}),
+    ...(Object.keys(defineBool).length > 0 ? { "define-bool": defineBool } : {}),
+    ...(Object.keys(defineNumber).length > 0 ? { "define-number": defineNumber } : {}),
   }
 }
 
@@ -318,10 +349,10 @@ class PreviewLeaseProbeError extends Error {
   }
 }
 
-export function shouldUseProgrammaticPlaygroundRunner(spec: RuntimeCreateSpec, options: PlaygroundCliStartupOptions = {}): boolean {
-  return !options.cliModule
-    && spec.environment.databaseSetup !== "external"
-    && Boolean(spec.environment.assets?.wordpressDirectory)
+export function shouldUseProgrammaticPlaygroundRunner(spec: RuntimeCreateSpec, options: PlaygroundCliStartupOptions = {}, hasWordPressArchive = false): boolean {
+  if (options.cliModule || spec.environment.databaseSetup === "external") return false
+  if (spec.environment.databaseSetup === "custom-drop-in") return hasWordPressArchive
+  return Boolean(spec.environment.assets?.wordpressDirectory)
     && (Boolean(runtimeBootstrapPhpIniEntries(spec)) || Boolean(spec.environment.extensions?.length))
 }
 
@@ -338,8 +369,8 @@ async function pluginRuntimeBootstrapSharedMounts(spec: RuntimeCreateSpec, reque
     await writeFile(join(directory, "wp-codebox-auto-prepend.php"), runtimeAutoPrependPhp(spec), "utf8")
   }
   if (requestWorkerEndpoint) await writeFile(join(directory, "request-worker.php"), requestWorkerPhp(requestWorkerEndpoint.token), "utf8")
-  const externalWpConfig = externalDatabaseWpConfig(spec)
-  if (externalWpConfig) await writeFile(join(directory, "wp-config.php"), externalWpConfig, "utf8")
+  const wpConfig = databaseBootstrapWpConfig(spec)
+  if (wpConfig) await writeFile(join(directory, "wp-config.php"), wpConfig, "utf8")
 
   return [
     ...(iniEntries ? [
@@ -350,7 +381,7 @@ async function pluginRuntimeBootstrapSharedMounts(spec: RuntimeCreateSpec, reque
       { hostPath: directory, vfsPath: "/internal/wp-codebox" },
       { hostPath: join(directory, "request-worker.php"), vfsPath: `/wordpress${requestWorkerEndpoint.route}` },
     ] : []),
-    ...(externalWpConfig ? [{ hostPath: join(directory, "wp-config.php"), vfsPath: "/wordpress/wp-config.php" }] : []),
+    ...(wpConfig ? [{ hostPath: join(directory, "wp-config.php"), vfsPath: "/wordpress/wp-config.php" }] : []),
   ]
 }
 
@@ -514,29 +545,6 @@ if (!$wpcb_db_diagnostic['transport']['stream_socket_client'] || !$wpcb_db_diagn
 $wpcb_db_target = strpos($wpcb_db_host, ':') !== false ? 'tcp://[' . $wpcb_db_host . ']:' . $wpcb_db_port : 'tcp://' . $wpcb_db_host . ':' . $wpcb_db_port;
 $wpcb_db_diagnostic['tcp']['attempted'] = true; $wpcb_db_socket = @stream_socket_client($wpcb_db_target, $wpcb_db_tcp_errno, $wpcb_db_tcp_error, 2, STREAM_CLIENT_CONNECT); if (!$wpcb_db_socket) { $wpcb_db_diagnostic['tcp']['error_code'] = (int) $wpcb_db_tcp_errno; $wpcb_db_fail('endpoint_unreachable', 'Verify runtime network access to the managed database endpoint.'); } fclose($wpcb_db_socket); $wpcb_db_diagnostic['tcp']['connected'] = true;
 $wpcb_db_diagnostic['mysqli']['attempted'] = true; $wpcb_db = @mysqli_init(); if (!$wpcb_db) $wpcb_db_fail('transport_unavailable', 'The mysqli client could not initialize in this runtime.'); @mysqli_options($wpcb_db, MYSQLI_OPT_CONNECT_TIMEOUT, 2); $wpcb_db_user = getenv('DB_USER') ?: 'root'; $wpcb_db_name = getenv('DB_NAME') ?: 'runtime'; $wpcb_db_connected = @mysqli_real_connect($wpcb_db, $wpcb_db_host, $wpcb_db_user, getenv('DB_PASSWORD'), $wpcb_db_name, (int) $wpcb_db_port); if (!$wpcb_db_connected) { $wpcb_db_errno = (int) mysqli_connect_errno(); $wpcb_db_diagnostic['mysqli']['error_code'] = $wpcb_db_errno; $wpcb_db_fail($wpcb_db_errno === 1045 ? 'authentication_failed' : ($wpcb_db_errno === 1049 ? 'database_missing' : 'endpoint_unreachable'), 'Verify the managed database credentials and selected database.'); } mysqli_close($wpcb_db); $wpcb_db_diagnostic['mysqli']['connected'] = true;
-`
-}
-
-function externalDatabaseWpConfig(spec: RuntimeCreateSpec): string | undefined {
-  if (spec.environment.databaseSetup !== "external") return undefined
-  const host = spec.runtimeEnv?.DB_HOST
-  if (!host) return undefined
-  const port = spec.runtimeEnv?.DB_PORT
-  const values = {
-    DB_NAME: spec.runtimeEnv?.DB_NAME ?? "runtime",
-    DB_USER: spec.runtimeEnv?.DB_USER ?? "root",
-    DB_HOST: port ? `${host}:${port}` : host,
-  }
-  return `<?php
-define('DB_NAME', ${phpLiteral(values.DB_NAME)});
-define('DB_USER', ${phpLiteral(values.DB_USER)});
-define('DB_PASSWORD', (string) getenv('DB_PASSWORD'));
-define('DB_HOST', ${phpLiteral(values.DB_HOST)});
-define('DB_CHARSET', 'utf8mb4');
-define('DB_COLLATE', '');
-$table_prefix = 'wp_';
-if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/');
-require_once ABSPATH . 'wp-settings.php';
 `
 }
 

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -3,11 +3,13 @@ import { compileBlueprint } from "@wp-playground/blueprints"
 import { bootWordPressAndRequestHandler } from "@wp-playground/wordpress"
 import type { MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { createServer as createHttpServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http"
-import { dirname } from "node:path"
-import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl } from "./blueprint.js"
+import { readFile } from "node:fs/promises"
+import { basename, dirname } from "node:path"
+import { playgroundRuntimeBlueprint, playgroundRuntimeSiteUrl, playgroundWpConfigConstants } from "./blueprint.js"
 import { assertPhpWasmExternalExtensionsSupported } from "./php-wasm-preflight.js"
 import { phpEnvAssignments } from "./php-snippets.js"
 import type { PlaygroundCliServer, PlaygroundServerRunResponse } from "./preview-server.js"
+import { databaseBootstrapWpConfig } from "./database-bootstrap.js"
 
 const { createNodeFsMountHandler, loadNodeRuntime } = PHPWasmNode as unknown as {
   createNodeFsMountHandler(localPath: string): unknown
@@ -36,7 +38,9 @@ interface ProgrammaticPHPResponse {
 export interface ProgrammaticPlaygroundStartupOptions {
   bootstrapIniEntries: Record<string, string>
   phpIniEntries?: Record<string, string>
-  wordpressDirectory: string
+  wordpressDirectory?: string
+  wordpressArchivePath?: string
+  wordpressArchiveUrl?: string
   wordpressInstallMode?: "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
   sharedPhpIniContent: string
 }
@@ -51,6 +55,8 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
   }
   const preinstallMounts = mounts.filter((mount) => mount.phase === "pre-install")
   const postinstallMounts = mounts.filter((mount) => mount.phase !== "pre-install")
+  const wpConfig = databaseBootstrapWpConfig(spec)
+  const wordPressZip = await wordpressArchiveFile(options)
   const requestHandler = await bootWordPressAndRequestHandler({
     createPhpRuntime: () => loadNodeRuntime(phpVersion, programmaticNodeRuntimeOptions(spec, nextProcessId++)),
     maxPhpInstances: 1,
@@ -59,16 +65,21 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
     documentRoot: "/wordpress",
     sapiName: "cli",
     wordpressInstallMode: options.wordpressInstallMode ?? "install-from-existing-files",
+    ...(wordPressZip ? { wordPressZip } : {}),
+    constants: playgroundWpConfigConstants(spec.environment.blueprint),
     phpIniEntries,
     createFiles: {
       "/internal/shared/php.ini": options.sharedPhpIniContent,
       "/internal/wp-codebox/auto_prepend_file.php": autoPrependPhp(spec),
       "/internal/shared/mu-plugins/.keep": "",
       "/internal/shared/preload/.keep": "",
+      ...(wpConfig ? { "/wordpress/wp-config.php": wpConfig } : {}),
     },
     async onPHPInstanceCreated(php: unknown) {
       const programmaticPhp = php as ProgrammaticPHP
-      await mountHostDirectory(programmaticPhp, "/wordpress", options.wordpressDirectory)
+      if (options.wordpressDirectory) {
+        await mountHostDirectory(programmaticPhp, "/wordpress", options.wordpressDirectory)
+      }
       for (const mount of preinstallMounts) {
         await mountHostDirectory(programmaticPhp, mount.target, mount.source)
       }
@@ -109,6 +120,16 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
       await requestHandler[Symbol.asyncDispose]()
     },
   }
+}
+
+async function wordpressArchiveFile(options: ProgrammaticPlaygroundStartupOptions): Promise<File | undefined> {
+  if (options.wordpressArchivePath) {
+    return new File([await readFile(options.wordpressArchivePath)], basename(options.wordpressArchivePath))
+  }
+  if (!options.wordpressArchiveUrl) return undefined
+  const response = await fetch(options.wordpressArchiveUrl)
+  if (!response.ok) throw new Error(`Failed to fetch WordPress archive: HTTP ${response.status} ${response.statusText}`.trim())
+  return new File([await response.arrayBuffer()], basename(new URL(options.wordpressArchiveUrl).pathname) || "wordpress.zip")
 }
 
 export function programmaticNodeRuntimeOptions(spec: RuntimeCreateSpec, processId: number): { followSymlinks: true; emscriptenOptions: { processId: number }; extensions?: Array<string | { source: { format: "manifest"; manifestUrl: string } }> } {

--- a/tests/custom-database-drop-in.integration.test.ts
+++ b/tests/custom-database-drop-in.integration.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { startPlaygroundCliServer } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-custom-drop-in-"))
+const content = join(root, "wp-content")
+const artifacts = join(root, "artifacts")
+await mkdir(content)
+await writeFile(join(content, "db.php"), "<?php echo 'WP_CODEBOX_CUSTOM_DROP_IN_SENTINEL'; exit;\n")
+
+const spec: RuntimeCreateSpec = {
+  backend: "wordpress-playground",
+  environment: {
+    version: "7.1",
+    phpVersion: "8.3",
+    databaseSetup: "custom-drop-in",
+    blueprint: {},
+  },
+  policy: {
+    network: "deny",
+    filesystem: "readwrite-mounts",
+    commands: ["wordpress.run-php"],
+    secrets: "none",
+    approvals: "never",
+  },
+  artifactsDirectory: artifacts,
+}
+
+try {
+  const server = await startPlaygroundCliServer(spec, [
+    { type: "directory", source: content, target: "/wordpress/wp-content", mode: "readwrite", phase: "pre-install" },
+  ])
+  try {
+    const mounted = await server.playground.run({ code: "<?php echo json_encode( array( 'dropin' => is_file( '/wordpress/wp-content/db.php' ), 'config' => is_file( '/wordpress/wp-config.php' ) ) );" })
+    assert.deepEqual(JSON.parse(mounted.text), { dropin: true, config: true }, "the custom drop-in and WordPress configuration remain available to workload PHP instances")
+    const bootstrap = await server.playground.run({ code: "<?php require '/wordpress/wp-load.php';" })
+    assert.equal(bootstrap.text, "WP_CODEBOX_CUSTOM_DROP_IN_SENTINEL", "the custom db.php executes when the workload boots WordPress")
+  } finally {
+    await server[Symbol.asyncDispose]()
+  }
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("custom database drop-in integration ok")

--- a/tests/custom-database-drop-in.test.ts
+++ b/tests/custom-database-drop-in.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+
+import { planWorkspaceRecipe } from "../packages/cli/src/recipe-dry-run.js"
+import { validateWorkspaceRecipeJsonSchema } from "../packages/runtime-core/src/recipe-schema.js"
+import type { WorkspaceRecipe } from "../packages/runtime-core/src/runtime-contracts.js"
+
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: { databaseSetup: "custom-drop-in" },
+  inputs: {
+    mounts: [{ type: "file", source: "db.php", target: "/wordpress/wp-content/db.php", mode: "readonly", phase: "pre-install" }],
+  },
+  workflow: { steps: [{ command: "wordpress.run-php", args: ["code=<?php echo get_class($wpdb);"] }] },
+}
+
+assert.equal(validateWorkspaceRecipeJsonSchema(recipe).valid, true)
+assert.equal(validateWorkspaceRecipeJsonSchema({ ...recipe, runtime: { databaseSetup: "external" } }).valid, false)
+
+const plan = await planWorkspaceRecipe(
+  recipe,
+  "/tmp",
+  { recipePath: "/tmp/custom-db-recipe.json" },
+  {
+    defaultWordPressVersion: "latest",
+    async resolveExecutionSpec(step) {
+      return { command: step.command, args: step.args ?? [] }
+    },
+  },
+)
+assert.equal(plan.runtime.databaseSetup, "custom-drop-in")
+assert.equal(plan.mounts.find((mount) => mount.target === "/wordpress/wp-content/db.php")?.phase, "pre-install")

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -174,6 +174,34 @@ try {
   assert.equal(shouldUseProgrammaticPlaygroundRunner(defaultRuntimeIniSpec), true)
 
   calls.length = 0
+  const customDropInServer = await startPlaygroundCliServer({
+    ...defaultRuntimeIniSpec,
+    environment: {
+      ...defaultRuntimeIniSpec.environment,
+      databaseSetup: "custom-drop-in",
+      blueprint: { steps: [{ step: "defineWpConfigConsts", consts: { MARKDOWN_DB_BACKEND: "mdi-native", WP_DEBUG: true, RETRY_LIMIT: 3 } }] },
+    },
+  }, [
+    { type: "directory", source: wordpressDevelopDirectory, target: "/wordpress/wp-content/custom-db", mode: "readonly", phase: "pre-install" },
+    { type: "directory", source: wordpressDevelopDirectory, target: "/wordpress/wp-content/post-install", mode: "readonly" },
+  ], { cliModule })
+  await customDropInServer[Symbol.asyncDispose]()
+  assert.equal(calls[0]?.skipSqliteSetup, true)
+  assert.equal(calls[0]?.phpEnv, undefined, "custom drop-ins do not inherit external database bindings")
+  const customDropInWpConfigPath = calls[0]?.["mount-before-install"]?.find((mount) => mount.vfsPath === "/wordpress/wp-config.php")?.hostPath
+  assert.equal(typeof customDropInWpConfigPath, "string")
+  assert.match(await readFile(customDropInWpConfigPath as string, "utf8"), /define\('DB_NAME', 'custom_drop_in'\)/)
+  assert.equal(calls[0]?.["mount-before-install"]?.some((mount) => mount.vfsPath === "/wordpress/wp-content/custom-db"), true)
+  assert.equal(calls[0]?.mount?.some((mount) => mount.vfsPath === "/wordpress/wp-content/post-install"), true)
+  assert.deepEqual(calls[0]?.define, { MARKDOWN_DB_BACKEND: "mdi-native" })
+  assert.deepEqual(calls[0]?.["define-bool"], { WP_DEBUG: true })
+  assert.deepEqual(calls[0]?.["define-number"], { RETRY_LIMIT: 3 })
+  assert.equal(shouldUseProgrammaticPlaygroundRunner({
+    ...defaultRuntimeIniSpec,
+    environment: { ...defaultRuntimeIniSpec.environment, databaseSetup: "custom-drop-in" },
+  }), false)
+
+  calls.length = 0
   const downloadedWordPressSpec: RuntimeCreateSpec = {
     ...defaultRuntimeIniSpec,
     environment: {
@@ -195,6 +223,14 @@ try {
   assert.equal(calls[0].wordpressInstallMode, undefined)
   assert.equal(calls[0].workers, 1)
   assert.equal(shouldUseProgrammaticPlaygroundRunner(downloadedWordPressSpec), false)
+
+  calls.length = 0
+  const unmanagedInstallServer = await startPlaygroundCliServer({
+    ...downloadedWordPressSpec,
+    environment: { ...downloadedWordPressSpec.environment, databaseSetup: "custom-drop-in" },
+  }, [], { cliModule })
+  await unmanagedInstallServer[Symbol.asyncDispose]()
+  assert.equal(calls[0]?.wordpressInstallMode, "do-not-attempt-installing")
 
   calls.length = 0
   const distributionOnlySpec: RuntimeCreateSpec = {


### PR DESCRIPTION
## Summary

- add an explicit `custom-drop-in` recipe/runtime database setup contract
- preserve pre-install mount phases and bootstrap `defineWpConfigConsts` values before WordPress loads `db.php`
- route current cached WordPress archives through Playground's programmatic `wordPressZip` path with managed database installation disabled
- synthesize a database-neutral `wp-config.php` so the custom drop-in owns first WordPress boot
- retain existing runtime-managed SQLite and external MySQL behavior

Closes #2391.

## Verification

- `npm run build`
- `npx tsx tests/custom-database-drop-in.integration.test.ts`
- `npx tsx tests/custom-database-drop-in.test.ts`
- `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts`
- `npx tsx tests/programmatic-playground-runner.test.ts`
- `npx tsx tests/runtime-neutral-contracts.test.ts`
- downstream lifecycle proof: WordPress 7.1 booted from the current archive cache as `WP_Markdown_Native_WPDB` with no managed database process and reached WooCommerce activation

## AI Assistance

OpenAI gpt-5.6-sol was used through OpenCode to reproduce the custom-drop-in lifecycle failure, inspect WP Codebox and WordPress Playground boot sequencing, implement the runtime contract, and run the verification suite.