### PR TITLE
Fix custom database preview page loads

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -66,7 +66,7 @@ export class PlaygroundPreviewPortUnavailableError extends Error {
 export async function withPreviewProxy(server: PlaygroundCliServer, port: number, bind = "127.0.0.1"): Promise<PlaygroundCliServer> {
   let proxy: PlaygroundPreviewProxy | undefined
   try {
-    proxy = await startPreviewProxy(server.serverUrl, port, bind)
+    proxy = await startPreviewProxy(server.serverUrl, port, bind, server.wordpressUrl)
   } catch (error) {
     await server[Symbol.asyncDispose]()
     throw error
@@ -87,12 +87,16 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
   }
 }
 
-async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
+async function startPreviewProxy(targetUrl: string, port: number, bind: string, wordpressUrl?: string): Promise<PlaygroundPreviewProxy> {
   const target = new URL(targetUrl)
+  const wordpressOrigin = {
+    declared: Boolean(wordpressUrl),
+    value: wordpressUrl ? new URL(wordpressUrl).origin : target.origin,
+  }
   const routes = createPreviewRouteRegistry()
   const requestTrace = createPreviewProxyRequestTrace()
   const upstreamQueue = createPreviewProxyQueue()
-  const proxy = previewProxyServer(target, routes, requestTrace, upstreamQueue)
+  const proxy = previewProxyServer(target, wordpressOrigin, routes, requestTrace, upstreamQueue)
   const servers = [proxy]
 
   await listenPreviewProxy(proxy, port, bind)
@@ -100,7 +104,7 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   const resolvedPort = address && typeof address === "object" ? address.port : port
 
   if (bind === "127.0.0.1") {
-    const ipv6Proxy = previewProxyServer(target, routes, requestTrace, upstreamQueue)
+    const ipv6Proxy = previewProxyServer(target, wordpressOrigin, routes, requestTrace, upstreamQueue)
     try {
       await listenPreviewProxy(ipv6Proxy, resolvedPort, "::1")
       servers.push(ipv6Proxy)
@@ -134,7 +138,12 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   }
 }
 
-function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry, requestTrace: PlaygroundPreviewProxyRequestTrace, upstreamQueue: ReturnType<typeof createPreviewProxyQueue>): PreviewProxyServer {
+interface PlaygroundWordPressOrigin {
+  declared: boolean
+  value: string
+}
+
+function previewProxyServer(target: URL, wordpressOrigin: PlaygroundWordPressOrigin, routes: InternalPreviewRouteRegistry, requestTrace: PlaygroundPreviewProxyRequestTrace, upstreamQueue: ReturnType<typeof createPreviewProxyQueue>): PreviewProxyServer {
   return createHttpServer(async (incoming, outgoing) => {
     try {
       if (await routes.handle(incoming, outgoing)) {
@@ -146,7 +155,7 @@ function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry, r
     }
 
     upstreamQueue(
-      () => proxyPreviewRequest(target, incoming, outgoing, requestTrace),
+      () => proxyPreviewRequest(target, wordpressOrigin, incoming, outgoing, requestTrace),
       () => incoming.aborted || incoming.destroyed || outgoing.destroyed,
       (cancel) => {
         incoming.once("aborted", cancel)
@@ -183,7 +192,7 @@ function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
   }
 }
 
-function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse, requestTrace: PlaygroundPreviewProxyRequestTrace): Promise<void> {
+function proxyPreviewRequest(target: URL, wordpressOrigin: PlaygroundWordPressOrigin, incoming: IncomingMessage, outgoing: ServerResponse, requestTrace: PlaygroundPreviewProxyRequestTrace): Promise<void> {
   return new Promise((resolve) => {
     const requestTarget = previewProxyRequestTarget(incoming, target)
     const serviceWorkerRegistration = isPreviewProxyServiceWorkerRegistrationRequest(incoming)
@@ -221,11 +230,12 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
         port: target.port,
         method: incoming.method,
         path: requestTarget.path,
-        headers: proxyRequestHeaders(incoming.headers, requestTarget),
+        headers: proxyRequestHeaders(incoming.headers, requestTarget, new URL(wordpressOrigin.value).host),
       }, (response) => {
         targetResponse = response
-        const headers = proxyResponseHeaders(response.headers, requestTarget, target)
-        const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target)
+        learnWordPressOrigin(response.headers.location, target, wordpressOrigin)
+        const headers = proxyResponseHeaders(response.headers, requestTarget, target, wordpressOrigin.value)
+        const bodyTransform = previewProxyResponseBodyTransform(headers, requestTarget, target, wordpressOrigin.value)
         const responseOutcome: PlaygroundPreviewProxyRequestOutcome = {
           outcome: "response",
           status: response.statusCode ?? 502,
@@ -452,7 +462,7 @@ function formatPreviewHost(host: string): string {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
 }
 
-function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget): IncomingHttpHeaders {
+function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, wordpressHost: string): IncomingHttpHeaders {
   const forwarded = { ...headers }
   delete forwarded.connection
   delete forwarded["transfer-encoding"]
@@ -477,7 +487,7 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: Previe
 
   return {
     ...forwarded,
-    host: requestTarget.upstreamHost,
+    host: wordpressHost,
     "x-forwarded-host": requestTarget.visibleHost,
     "x-forwarded-port": requestTarget.port,
     "x-forwarded-proto": requestTarget.protocol.slice(0, -1),
@@ -499,7 +509,7 @@ function isCredentiallessPlaygroundWorkerAssetRequest(headers: IncomingHttpHeade
   return path.endsWith("/sw.js") || /(?:^|\/)assets\/[^/]+\.(?:m?js|wasm)$/i.test(path)
 }
 
-function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, target: URL): IncomingHttpHeaders {
+function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, target: URL, wordpressOrigin: string): IncomingHttpHeaders {
   const forwarded = { ...headers }
   delete forwarded.connection
   delete forwarded["transfer-encoding"]
@@ -511,7 +521,7 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: Previ
   if (typeof forwarded.location === "string") {
     try {
       const location = new URL(forwarded.location, target)
-      if (location.origin === target.origin) {
+      if (location.origin === target.origin || location.origin === wordpressOrigin) {
         location.protocol = requestTarget.protocol
         const visible = new URL(`${requestTarget.protocol}//${requestTarget.visibleHost}`)
         location.hostname = visible.hostname
@@ -526,7 +536,7 @@ function proxyResponseHeaders(headers: IncomingHttpHeaders, requestTarget: Previ
   return forwarded
 }
 
-function previewProxyResponseBodyTransform(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, target: URL): Transform | undefined {
+function previewProxyResponseBodyTransform(headers: IncomingHttpHeaders, requestTarget: PreviewProxyRequestTarget, target: URL, wordpressOrigin: string): Transform | undefined {
   if (!requestTarget.rewriteTargetOrigin || requestTarget.visibleHost === target.host || !previewProxyTextResponse(headers)) {
     return undefined
   }
@@ -537,9 +547,29 @@ function previewProxyResponseBodyTransform(headers: IncomingHttpHeaders, request
   }
 
   return originRewriteTransform(
-    [target.origin, `${target.protocol}//${target.hostname}`],
+    [target.origin, `${target.protocol}//${target.hostname}`, wordpressOrigin],
     `${requestTarget.protocol}//${requestTarget.visibleHost}`,
   )
+}
+
+function learnWordPressOrigin(locationHeader: string | string[] | undefined, target: URL, wordpressOrigin: PlaygroundWordPressOrigin): void {
+  if (wordpressOrigin.declared) {
+    return
+  }
+
+  const locationValue = headerValue(locationHeader)
+  if (!locationValue) {
+    return
+  }
+
+  try {
+    const location = new URL(locationValue, target)
+    if (location.protocol === target.protocol && location.hostname === target.hostname && location.origin !== target.origin) {
+      wordpressOrigin.value = location.origin
+    }
+  } catch {
+    // Preserve the current origin when WordPress emits a malformed redirect.
+  }
 }
 
 function previewProxyTextResponse(headers: IncomingHttpHeaders): boolean {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -487,7 +487,7 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders, requestTarget: Previe
 
   return {
     ...forwarded,
-    host: wordpressHost,
+    host: requestTarget.rewriteTargetOrigin ? wordpressHost : requestTarget.upstreamHost,
     "x-forwarded-host": requestTarget.visibleHost,
     "x-forwarded-port": requestTarget.port,
     "x-forwarded-proto": requestTarget.protocol.slice(0, -1),

--- a/tests/service-worker-preview-proxy.browser.test.ts
+++ b/tests/service-worker-preview-proxy.browser.test.ts
@@ -7,6 +7,44 @@ import { chromium } from "playwright"
 
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
+test("the preview proxy aligns a custom database drop-in's canonical WordPress origin", async () => {
+  let canonicalOrigin = ""
+  const upstreamHosts: Array<string | undefined> = []
+  const upstream = createServer((request, response) => {
+    upstreamHosts.push(request.headers.host)
+    if (request.headers.host !== new URL(canonicalOrigin).host) {
+      response.writeHead(302, { location: `${canonicalOrigin}${request.url}` })
+      response.end()
+      return
+    }
+    if (request.url === "/redirect") {
+      response.writeHead(302, { location: `${canonicalOrigin}/destination` })
+      response.end()
+      return
+    }
+    response.writeHead(200, { "content-type": "text/html" })
+    response.end(`<a href="${canonicalOrigin}/destination">destination</a>`)
+  })
+  const upstreamUrl = await listenLocalHttpServer(upstream)
+  canonicalOrigin = `${new URL(upstreamUrl).protocol}//${new URL(upstreamUrl).hostname}`
+  const proxy = await withPreviewProxy({
+    playground: { async run() { return { text: "", exitCode: 0 } } },
+    serverUrl: upstreamUrl,
+    async [Symbol.asyncDispose]() {},
+  } satisfies PlaygroundCliServer, 0)
+  try {
+    const page = await fetch(proxy.serverUrl)
+    assert.deepEqual(upstreamHosts.slice(0, 2), [new URL(upstreamUrl).host, new URL(canonicalOrigin).host])
+    assert.equal(await page.text(), `<a href="${proxy.serverUrl}/destination">destination</a>`)
+
+    const redirect = await fetch(`${proxy.serverUrl}/redirect`, { redirect: "manual" })
+    assert.equal(redirect.headers.get("location"), `${proxy.serverUrl}/destination`)
+  } finally {
+    await proxy[Symbol.asyncDispose]()
+    await closeHttpServer(upstream)
+  }
+})
+
 test("the preview proxy registers a service worker after transient upstream redirects", async () => {
   const workerPath = "/runtime/version/sw.js"
   let workerRequests = 0


### PR DESCRIPTION
## Summary
- learn a custom database drop-in’s same-host canonical WordPress origin from its initial redirect
- route subsequent preview requests with the canonical Host header
- rewrite canonical redirects and text response URLs back to the visible preview origin
- cover dynamic-port to portless canonical origin behavior end to end

Fixes #2394.

## Verification
- `npx tsx tests/service-worker-preview-proxy.browser.test.ts`
- `npx tsx tests/page-load-command-contracts.test.ts`
- `npm run build`
- downstream MDI two-boot lifecycle: activation, restart persistence, WP-CLI, REST, and server front-end page load all passed

## AI assistance
OpenAI GPT-5.6-Sol via OpenCode was used to reproduce the custom drop-in redirect failure, implement the preview proxy repair and regression coverage, and run the verification workflow. I directed and reviewed the resulting changes.