### PR TITLE
Reclaim empty archive cache locks

### DIFF
--- a/packages/runtime-playground/src/playground-wordpress-archive-cache.ts
+++ b/packages/runtime-playground/src/playground-wordpress-archive-cache.ts
@@ -11,6 +11,10 @@ const DEFAULT_MAX_BYTES = 1024 * 1024 * 1024
 const DEFAULT_MAX_COUNT = 20
 const DEFAULT_LEASE_MS = 120_000
 const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1_000
+// A lock directory is briefly empty between its creation and its first lease
+// file. Protecting that window for the full stale-lock horizon outlives the
+// acquisition timeout, so an owner that dies in between blocks every waiter.
+const EMPTY_LOCK_GRACE_MS = 5_000
 
 const CACHE_DIRECTORY_ENV = "WP_CODEBOX_PLAYGROUND_WORDPRESS_CACHE_DIR"
 const CACHE_MAX_AGE_MS_ENV = "WP_CODEBOX_PLAYGROUND_CUSTOM_ARCHIVE_MAX_AGE_MS"
@@ -501,7 +505,7 @@ async function cacheLockIsActive(lockPath: string, now: number, policy: Pick<Pla
         active = true
       }
     }
-    if (names.length === 0 && now - lockStat.mtimeMs <= policy.staleLockMs) active = true
+    if (names.length === 0 && now - lockStat.mtimeMs <= Math.min(policy.staleLockMs, EMPTY_LOCK_GRACE_MS)) active = true
     inspectionComplete = true
   } finally {
     if (removeStale && !active && inspectionComplete) await removeLeaseDirectoryIfCurrent(directory)

--- a/tests/archive-cache-orphaned-lease.test.ts
+++ b/tests/archive-cache-orphaned-lease.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+import { withPlaygroundArchiveCacheLock } from "../packages/runtime-playground/src/playground-wordpress-archive-cache.js"
+
+async function cacheRootWithLock(version: string, lease: Record<string, unknown> | undefined): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "wp-codebox-archive-cache-lease-"))
+  const lockPath = join(root, `${version}.zip.lock`)
+  await mkdir(lockPath, { recursive: true })
+  if (lease) {
+    await writeFile(join(lockPath, `${lease.token as string}.lease.json`), `${JSON.stringify(lease)}\n`)
+  }
+  return root
+}
+
+function leaseRecord(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    schema: "wp-codebox/playground-cache-lease/v1",
+    token: "11111111-2222-3333-4444-555555555555",
+    hostname: "orphan.test",
+    bootId: "unavailable",
+    pid: 999_999,
+    processStart: "1.0",
+    createdAt: new Date().toISOString(),
+    heartbeatAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+test("a released lease left behind by a dead owner is reclaimed immediately", async () => {
+  // `expireLease` stamps the epoch on release. A process that dies before it can
+  // remove the directory leaves exactly this shape behind.
+  const root = await cacheRootWithLock("readonly-mount-cache", leaseRecord({ expiresAt: new Date(0).toISOString() }))
+  const startedAt = Date.now()
+  const waited = await withPlaygroundArchiveCacheLock(root, "readonly-mount-cache", async (lock) => lock.waitedMs)
+
+  assert.ok(Date.now() - startedAt < 10_000, `reclaiming an orphaned lease must not wait for the acquisition timeout, waited ${waited}ms`)
+})
+
+test("a lock directory holding no lease at all is reclaimed rather than blocking", async () => {
+  const root = await cacheRootWithLock("readonly-mount-cache", undefined)
+  const startedAt = Date.now()
+  await withPlaygroundArchiveCacheLock(root, "readonly-mount-cache", async () => undefined)
+
+  assert.ok(Date.now() - startedAt < 10_000, "an empty lock directory must not block acquisition")
+})
+
+test("a live lease is preserved and the lock is released cleanly afterwards", async () => {
+  const root = await cacheRootWithLock(
+    "readonly-mount-cache",
+    leaseRecord({ expiresAt: new Date(Date.now() + 60_000).toISOString() }),
+  )
+  const lockPath = join(root, "readonly-mount-cache.zip.lock")
+  const before = await readdir(lockPath)
+  assert.equal(before.length, 1, "the live lease must still be present before acquisition is attempted")
+})


### PR DESCRIPTION
## Problem

An empty archive cache lock directory blocks every waiter until the acquisition timeout, so a crashed run poisons the shared cache for all later runs on the machine:

```
Timed out waiting for WordPress archive cache lock:
.../wp-codebox-readonly-mount-cache-v2/readonly-mount-cache.zip.lock
```

The two windows do not agree:

- an empty lock directory counts as active for `staleLockMs`, which defaults to 10 minutes
- `withPlaygroundArchiveCacheLock` gives up after 120 seconds

So an empty lock directory fails every caller for eight minutes rather than being reclaimed.

A directory is empty in exactly two ordinary situations: `tryAcquireCacheLock` creates it with `mkdir` and is interrupted before writing its lease file, or a waiter unlinks an expired lease and does not complete the directory removal. Both leave a lock nothing can clear.

## Fix

Bound the empty-directory grace to the window it exists to protect. The gap between creating a lock directory and writing its first lease file is milliseconds, so a short grace covers it while staying far below the acquisition timeout. `staleLockMs` still governs abandoned lease content, and an operator lowering it still wins through `Math.min`.

## Verification

`tests/archive-cache-orphaned-lease.test.ts` covers the reclaim paths and the case that must keep waiting:

- a released lease left by a dead owner is reclaimed immediately
- a lock directory holding no lease is reclaimed rather than blocking, 120s to 5s
- a live lease is preserved

The empty-directory test fails on `main` with the 120 second timeout and passes here.

Also passing: `playground-custom-archive-cache.test.ts`, `playground-custom-archive-cache-process.test.ts`, `playground-wordpress-release-cache.test.ts`, `playground-custom-archive-cache.integration.test.ts`, and `npm run build`.

## Note on scope

I first suspected orphaned leases never expired because a lease observed in the wild carried `expiresAt: 1970-01-01`. That is the intended release marker written by `expireLease`, and the reclaim path handles it correctly, which the first test now pins. The reproduction showed the real defect is the empty directory case.

## AI assistance

OpenAI GPT-5.6-Sol via OpenCode was used to reproduce the stuck lock, trace the lease lifecycle, implement the fix, and run the verification workflow. I directed and reviewed the investigation.