### PR TITLE
Assemble the WordPress plugin zip once per release

### DIFF
--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -7,7 +7,6 @@ import { createRequire } from "node:module"
 import { dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 
-import { assembleWordpressPluginZip } from "./lib/assemble-wordpress-plugin-zip.ts"
 import { materializeSharpReleaseRuntime, sharpRuntimePackageNames } from "./lib/materialize-sharp-release-runtime.ts"
 import { normalizeReleasePlatform } from "./lib/release-target.ts"
 
@@ -100,10 +99,12 @@ exec "\${NODE_BIN}" "\${SCRIPT_DIR}/../packages/cli/dist/index.js" "$@"
   })
 
   // The deployable artifact is the WordPress plugin zip declared by homeboy.json
-  // (build_artifact: packages/wordpress-plugin/dist/wp-codebox.zip). It bundles
-  // the CLI release tree staged above, so build it here and surface it in the
+  // (build_artifact: packages/wordpress-plugin/dist/wp-codebox.zip). The component
+  // build script already assembles it, and `assembleWordpressPluginZip` stages the
+  // packages it bundles itself rather than reading the CLI tree staged above, so
+  // rebuilding it here produced a second set of bytes at the same path and made
+  // the release asset's authority ambiguous. Surface the built artifact in the
   // manifest so the release pipeline uploads it as a GitHub Release asset.
-  await assembleWordpressPluginZip(repoRoot)
 
   process.stdout.write(
     JSON.stringify([


### PR DESCRIPTION
Fixes #2397.

## What

Assemble the WordPress plugin zip once per release, in the component build script only.

## Why

`homeboy release wp-codebox` fails and no release can be cut:

```
release assets targeting 'wp-codebox.zip' have conflicting authoritative bytes
from scripts.build and extension:nodejs
```

`assembleWordpressPluginZip()` ran twice per release:

- `scripts.build` -> `npm run package:wordpress-plugin`
- again inside `release:package` (`scripts/package-release-artifact.ts`)

Both wrote `packages/wordpress-plugin/dist/wp-codebox.zip`, producing two different sets of bytes at one declared asset path, so the release could not establish which bytes were authoritative.

The rebuild inside `release:package` was unnecessary. `assembleWordpressPluginZip()` stages the packages it bundles itself and does not read the CLI tree staged earlier in that script, so the artifact produced by the build script is already complete.

## Change

Removed the duplicate `assembleWordpressPluginZip( repoRoot )` call from `release:package`. The manifest still reports the artifact so the release pipeline uploads it as a GitHub Release asset, and `homeboy.json` still declares it as `build_artifact`.

## Verification

- `npm run test:release-package-coverage` passes, so the declared coverage shape and the manifest contract are unchanged.
- `npx tsc --noEmit` reports no errors.
- Confirmed against a real `homeboy release wp-codebox` run: the release now advances past both the package-coverage gate and the artifact-authority gate that previously blocked it.

## Related

The package-coverage gate that first surfaced this needed a Homeboy fix to stop counting one declared artifact twice; that work is tracked separately in the Homeboy repository.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-sol`, orchestrated by Chris Huber. Used to trace the blocked release through both gates, identify the duplicate assembly, and validate this change.
