### PR TITLE
fix(gate): run the full smoke aggregate and deflake rest-db-query-profiler redaction

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -82,7 +82,7 @@
       "npm run build"
     ],
     "test": [
-      "npm run smoke -- --group package",
+      "npm run check",
       "npm run test:release-target",
       "npm run test:sharp-release-runtime",
       "npm run test:prepare-declaration-rebuild",

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -398,7 +398,22 @@ assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].summa
 assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].cases[0].case_id, "posts-list")
 assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].cases[0].samples.length, 1)
 assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].cases[0].samples[0].sql, "SELECT * FROM wp_posts WHERE post_title = '?' AND ID = ?")
-assert.doesNotMatch(JSON.stringify(restDbQueryProfilerPayload), /private title|secret|123/)
+// Scan only string content. Stringifying the whole payload also captures
+// nondeterministic timing floats, where a bare `123` matches digit substrings
+// such as `"duration_ms":0.1235`.
+const collectStringContent = (value: unknown): string[] => {
+  if (typeof value === "string") {
+    return [value]
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(collectStringContent)
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value).flatMap(([key, entry]) => [key, ...collectStringContent(entry)])
+  }
+  return []
+}
+assert.doesNotMatch(collectStringContent(restDbQueryProfilerPayload).join("\n"), /private title|secret|\b123\b/)
 assert.equal(restDbQueryProfilerPayload.metrics.rest_db_query_profile_cases_count, 1)
 assert.equal(restDbQueryProfilerPayload.metrics.rest_db_query_profile_queries_count, 2)
 assert.equal(restDbQueryProfilerPayload.steps[0].type, "rest-db-query-profiler")


### PR DESCRIPTION
Closes #2402 (items 1 and 2).

Two changes. Both are small; the evidence for them is in #2402.

## 1. Point the Homeboy gate at the full smoke aggregate

`homeboy.json` invoked `npm run smoke -- --group package` — 5 commands covering build and packaging contracts. The smoke manifest defines 102 across six groups, and `npm run check` already wires the complete aggregate, but nothing invoked it.

```diff
 "test": [
-  "npm run smoke -- --group package",
+  "npm run check",
```

The four release-packaging entries after it are unchanged. `check` already includes the `package` group, so nothing is lost.

Measured on this branch:

| gate | commands | wall time |
|---|---:|---:|
| before (`--group package`) | 5 | 27.9s |
| after (`npm run check`) | 102 | 5m07s |

## 2. Deflake the rest-db-query-profiler redaction assertion

Because `core` never ran in the gate, a flaky assertion sat undetected in it.

`tests/bench-command-step-behavior.test.ts:401` verifies that SQL sample redaction does not leak the fixture literals `'private title'`, `'secret'`, and `ID = 123`. It stringified the **entire** payload, which includes nondeterministic timing floats, so the bare `123` alternative matched digit substrings inside them:

```
AssertionError: The input was expected to not match /private title|secret|123/
  "rest_db_query_profile_duration_ms": 0.1235
```

Observed at `0.1235` and `0.123166`. **2 failures in 51 runs on `main` (~4%).**

The fix scans string content only and anchors the numeric literal to a word boundary.

## Verification

Run on this branch, Node 24.15.0.

**Flake fixed:**

```
for i in $(seq 1 60); do npx tsx tests/bench-command-step-behavior.test.ts >/dev/null 2>&1 || echo "FAIL $i"; done
```
`main`: 2 failures in 51 runs. This branch: **0 failures in 60 runs.**

**Assertion is not now vacuous.** Confirmed the new form still rejects each leak class it is meant to catch, while accepting a redacted payload carrying a `0.123166` timing:

| input | result |
|---|---|
| redacted SQL + `duration_ms: 0.123166` | passes (was a false failure) |
| `post_title = 'private title'` leaked | still rejected |
| `ID = 123` leaked | still rejected |
| `option_value = 'secret'` leaked | still rejected |

**Full gate green:**

```
npm run check
# [smoke] Running 102 command(s) from check
# exit 0, 5m07s
```

Run twice, exit 0 both times.

## Not in scope

#2402 items 3–5 — package-scoped CI jobs to cover `packages/wordpress-plugin/**` and `packages/runtime-cloudflare/**`, test discovery to retire the `package.json` registry, and triage of the 153 unreachable `test:` scripts. Those are larger and should land separately.

One thing worth a reviewer's judgment: this makes the gate ~4.7 minutes slower on every promotion. That reads as clearly worth it given the aggregate is green and was already finding a real defect, but if there is a reason the gate was deliberately kept at 28 seconds, I would rather hear it than assume drift.

---

*AI assistance disclosure: authored by Claude (Sonnet 4.5) running in OpenCode, directed by @chubes4. The model located the gap by diffing gate registration layers, wrote a harness to execute all 103 manifest commands independently for the timing table, reproduced the flake across 51 runs on `main` and 60 on this branch, and verified the replacement assertion against leaked and redacted fixtures. All figures are measured. Reviewed by a human before opening.*
