### PR TITLE
fix(test): align release package coverage with the current Homeboy gate

### DIFF
--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -25,7 +25,7 @@ assert.deepEqual(homeboy.release?.package_coverage, [{
 assert.deepEqual(homeboy.extensions?.nodejs, { settings: { release_package_script: "release:package" } }, "the Node release provider must receive the project artifact manifest setting")
 assert.deepEqual(homeboy.scripts?.build, ["npm run package:wordpress-plugin"], "component builds retain singular WordPress deploy-artifact ownership")
 assert.deepEqual(homeboy.scripts?.test, [
-  "npm run smoke -- --group package",
+  "npm run check",
   "npm run test:release-target",
   "npm run test:sharp-release-runtime",
   "npm run test:prepare-declaration-rebuild",


### PR DESCRIPTION
Fixes a regression I introduced in #2403.

## What broke

#2403 changed `homeboy.json` `scripts.test[0]` from `npm run smoke -- --group package` to `npm run check`. `tests/release-package-coverage.test.ts` asserts that array verbatim:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected
  [
+   'npm run check',
-   'npm run smoke -- --group package',
    'npm run test:release-target',
    ...
```

The Homeboy gate has been red since #2403 merged. One-line fix.

## Why it escaped

`test:release-package-coverage` is registered **only** in `homeboy.json`:

| gate | contains it |
|---|---|
| `scripts/smoke-manifest.ts` | no |
| `homeboy.json` `scripts.test` | **yes** |
| `.github/workflows/**` | no |

So `npm run check` never runs it, CI never runs it, and #2403 and #2404 both merged green while it was broken. It only executes when someone runs the Homeboy gate locally, which a GitHub merge bypasses.

This is precisely the failure mode #2402 describes — a test registered in exactly one of four layers — and I walked straight into it. Worth noting as evidence for the discovery work rather than just as an embarrassment: the four-layer registry is not a theoretical hazard.

## Verification

```
# on main
npm run test:release-package-coverage   -> exit 1, deepEqual failure on homeboy.scripts.test

# on this branch, after the plugin zip exists
npm run test:release-package-coverage   -> exit 0, "release package coverage passed"
```

The test needs `packages/wordpress-plugin/dist/wp-codebox.zip`, which is produced by `package:wordpress-plugin` — Homeboy's `build` step — not by npm's `build` (which is `tsc -b`). That ordering is why it passes under Homeboy and fails standalone.

## Why this is not being added to the smoke aggregate

The obvious follow-up is to put it in `npm run check` so it cannot regress again. Measured cost:

| step | time |
|---|---:|
| `npm run package:wordpress-plugin` | 396s |
| `npm run test:release-package-coverage` | 10m22s |

The plugin artifact is **427 MB**. Adding both would take `check` from about 5 minutes to over 20, which is a bad trade for one config assertion.

Two cheaper options exist, both out of scope here:

1. Split the fast `homeboy.json` contract assertions (four `deepEqual` calls, no artifact needed) from the slow zip-coverage walk, and put only the fast half in `check`.
2. Add the four `homeboy.json` release scripts to CI as a separate, non-blocking job.

I would rather land the fix now and decide that separately. Flagging option 1 as the one I would pick.

---

*AI assistance disclosure: authored by Claude (Sonnet 4.5) running in OpenCode, directed by @chubes4. The model found this while auditing test discoverability for #2402, root-caused it to its own change in #2403, confirmed the failure on `main` and the fix here, and measured the build and test costs that argue against adding it to the aggregate. Reviewed by a human before opening.*
