### PR TITLE
Bench: select custom drop-in setup for pre-install db.php mounts

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -210,16 +210,21 @@ function normalizeRecipeSteps(steps: readonly WorkspaceRecipeStep[], label: stri
 export function buildWordPressBenchRecipe(options: WordPressBenchRecipeOptions): WorkspaceRecipe {
   const pluginSlug = requiredPluginSlug(options.pluginSlug, "buildWordPressBenchRecipe")
   const componentId = options.componentId?.trim() || pluginSlug
+  const mounts = normalizeRecipeMounts(options.mounts, { defaultMode: "readonly" })
+  const hasCustomDatabaseDropIn = mounts.some((mount) => mount.type === "file"
+    && mount.phase === "pre-install"
+    && mount.target === "/wordpress/wp-content/db.php")
 
   return {
     schema: "wp-codebox/workspace-recipe/v1",
     runtime: {
       wp: options.wordpressVersion ?? DEFAULT_WORDPRESS_VERSION,
+      ...(hasCustomDatabaseDropIn ? { databaseSetup: "custom-drop-in" as const } : {}),
       blueprint: blueprintWithWpConfigDefines(options.blueprint ?? {}, options.wpConfigDefines ?? {}),
     },
     inputs: {
       extra_plugins: normalizeExtraPlugins(options.extra_plugins),
-      mounts: normalizeRecipeMounts(options.mounts, { defaultMode: "readonly" }),
+      mounts,
     },
     workflow: {
       ...(options.prepareSteps && options.prepareSteps.length > 0 ? { before: normalizeRecipeSteps(options.prepareSteps, "prepareSteps") } : {}),

--- a/tests/recipe-builder-bench-steps.test.ts
+++ b/tests/recipe-builder-bench-steps.test.ts
@@ -32,5 +32,29 @@ assert.deepEqual(recipe.inputs.extra_plugins?.[0], {
   originalSource: "/tmp/monorepo/plugins/fixture-plugin",
   slug: "fixture-plugin",
 })
+assert.equal(recipe.runtime.databaseSetup, undefined)
+
+const customDropInRecipe = buildWordPressBenchRecipe({
+  pluginSlug: "fixture-plugin",
+  mounts: [{
+    type: "file",
+    source: "/tmp/db.php",
+    target: "//wordpress//wp-content//db.php",
+    phase: "pre-install",
+  }],
+})
+assert.equal(customDropInRecipe.runtime.databaseSetup, "custom-drop-in")
+assert.equal(customDropInRecipe.inputs.mounts?.[0]?.target, "/wordpress/wp-content/db.php")
+
+const postInstallDropInRecipe = buildWordPressBenchRecipe({
+  pluginSlug: "fixture-plugin",
+  mounts: [{
+    type: "file",
+    source: "/tmp/db.php",
+    target: "/wordpress/wp-content/db.php",
+    phase: "post-install",
+  }],
+})
+assert.equal(postInstallDropInRecipe.runtime.databaseSetup, undefined)
 
 console.log("recipe builder bench steps ok")


### PR DESCRIPTION
## Summary

- normalize bench mounts once before recipe construction
- select `runtime.databaseSetup: custom-drop-in` for explicit pre-install file mounts at `/wordpress/wp-content/db.php`
- preserve runtime-managed setup for ordinary and post-install mounts

Closes #2409.

## Verification

- `npx tsx tests/recipe-builder-bench-steps.test.ts`
- `npm run build`
- `git diff --check`
- `npm run smoke -- --all --concurrency=8` completed all declared checks and all 328 parallel discovered files without a reported failure; the command exceeded the 10-minute local timeout during the 9-file serial integration tail, so the full smoke gate is not claimed as complete

## AI Assistance

GPT-5.6 Sol via OpenCode traced the custom database bootstrap failure, implemented the bounded recipe-lowering fix, added coverage, and ran verification under my direction.