### PR TITLE
Exercise production release packaging in coverage test

### DIFF
--- a/scripts/build-wordpress-plugin-zip.ts
+++ b/scripts/build-wordpress-plugin-zip.ts
@@ -7,11 +7,13 @@ import { assembleWordpressPluginZip } from "./lib/assemble-wordpress-plugin-zip.
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
 
-await execFileAsync("npm", ["run", "release:package"], {
+const releasePackage = await execFileAsync("npm", ["run", "release:package"], {
 	cwd: repoRoot,
 	env: process.env,
 	maxBuffer: 1024 * 1024 * 20,
 })
+process.stdout.write(releasePackage.stdout)
+process.stderr.write(releasePackage.stderr)
 
 const outputZip = await assembleWordpressPluginZip(repoRoot)
 console.log(`Built ${outputZip}`)

--- a/tests/release-package-coverage.test.ts
+++ b/tests/release-package-coverage.test.ts
@@ -41,7 +41,7 @@ await writeFile(staleDistPath, "export const staleBuild = true\n")
 
 let stdout = ""
 try {
-  ({ stdout } = await execFileAsync("npm", ["run", "release:package"], {
+  ({ stdout } = await execFileAsync("npm", ["run", "package:wordpress-plugin"], {
     cwd: repositoryRoot,
     env: {
       ...process.env,
@@ -53,7 +53,9 @@ try {
 } finally {
   await writeFile(staleDistPath, currentDist)
 }
-const artifacts = JSON.parse(stdout.trim().split("\n").at(-1) ?? "[]")
+const artifactManifest = stdout.split("\n").find((line) => line.startsWith('[{"path":'))
+assert.ok(artifactManifest, "production package command did not emit its artifact manifest")
+const artifacts = JSON.parse(artifactManifest)
 assert.equal(artifacts.length, 2, "release package emitted unexpected artifacts")
 assert.deepEqual(artifacts.filter((artifact: { type: string }) => artifact.type === "wordpress-plugin-zip"), [
   { path: pluginArtifact, type: "wordpress-plugin-zip" },


### PR DESCRIPTION
## Summary

- run the production `package:wordpress-plugin` entrypoint from release package coverage
- forward the nested release artifact manifest through the wrapper
- validate both release artifacts after one packaging pass
- remove the test's dependency on later Homeboy package-step ordering

Closes #2417.

## Verification

- `npm run test:release-package-coverage`
- `git diff --check`

## AI assistance

GPT-5.6 Sol via OpenCode diagnosed the v0.26.0 release-gate failure, simplified the package/test contract, and ran the focused end-to-end package coverage test.