### PR TITLE
Fix bounded adaptive screenshot publication

### DIFF
--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -474,16 +474,16 @@ export async function runBrowserActionsCommand({
       try {
         const screenshotCaptureBudgetMs = adaptiveCaptureNavigationUnsettled ? Math.min(adaptiveCaptureBudgetMs, livenessRemainingWallTimeMs(startedAtMs, totalTimeoutMs)) : 0
         if (adaptiveCaptureNavigationUnsettled && screenshotCaptureBudgetMs <= 0) throw new Error("Adaptive screenshot capture budget was exhausted before capture started.")
-        const screenshotCapture = artifactSession.writeGenerated("screenshot", "screenshot.png", (path) => page.screenshot({ path, fullPage: true }).then(() => undefined))
         if (adaptiveCaptureNavigationUnsettled) {
-          await withBrowserCommandLiveness({
+          const screenshot = await withBrowserCommandLiveness({
             command: "wordpress.browser-actions",
             phase: "adaptive partial screenshot capture",
-            operation: screenshotCapture,
+            operation: page.screenshot({ fullPage: true }),
             policy: { wallTimeoutMs: screenshotCaptureBudgetMs, idleTimeoutMs: 0 },
           })
+          await artifactSession.writeBuffer("screenshot", "screenshot.png", screenshot)
         } else {
-          await screenshotCapture
+          await artifactSession.writeGenerated("screenshot", "screenshot.png", (path) => page.screenshot({ path, fullPage: true }).then(() => undefined))
         }
         screenshotSha256 = await fileSha256(screenshotPath)
         if (capture.has("dom-snapshot")) {

--- a/tests/browser-actions-navigation-capture.browser.test.ts
+++ b/tests/browser-actions-navigation-capture.browser.test.ts
@@ -133,7 +133,15 @@ test("adaptive capture classifies unresolved navigation and retains partial evid
     assert(Date.now() - startedAt < 1_500, "capture settlement must remain inside the command budget")
     await access(join(artifactRoot, "files/browser/steps.jsonl"))
     await access(join(artifactRoot, "files/browser/network.jsonl"))
-    await access(join(artifactRoot, "files/browser/screenshot.png"))
+    const screenshotPath = join(artifactRoot, "files/browser/screenshot.png")
+    const screenshotUnavailable = adaptive.result.diagnostics.some(({ code }: { code: string }) => code === "browser_adaptive_capture_screenshot_unavailable")
+    if (result.artifact.summary.screenshot) {
+      assert.equal(screenshotUnavailable, false)
+      await access(screenshotPath)
+    } else {
+      assert.equal(screenshotUnavailable, true)
+      await assert.rejects(access(screenshotPath))
+    }
     await assert.rejects(access(join(artifactRoot, "files/browser/snapshot.html")))
   } finally {
     await context.close()


### PR DESCRIPTION
## Summary

- capture unresolved-navigation screenshots into memory during the bounded attempt
- publish `screenshot.png` only after liveness succeeds
- prevent timed-out Playwright work from materializing an unreferenced artifact later
- accept both documented outcomes in the regression: captured screenshot or typed unavailability

Fixes #2419.

## Root Cause

`withBrowserCommandLiveness` can bound waiting but cannot cancel Playwright’s pending `page.screenshot({ path })`. After timeout, that operation could still write `screenshot.png`, producing either a missing-file test failure or a late orphan file absent from the artifact summary and manifest.

The bounded adaptive path now requests Playwright’s screenshot buffer without a destination path. Only a successful bounded result is written through `BrowserArtifactSession`; late completion after timeout has no filesystem side effect. Normal settled capture remains unchanged.

## Verification

- 10 consecutive runs of `npx tsx --test tests/browser-actions-navigation-capture.browser.test.ts`
- `npx tsx --test tests/browser-actions-navigation-capture.browser.test.ts tests/browser-adaptive-exploration.test.ts` (31 passed)
- `npm run build`
- `git diff --check`

This was discovered in the `v0.26.0` Homeboy release preflight. The failed release rolled back cleanly and created no tag.

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode reproduced both sides of the late-write race, traced the uncancelled Playwright promise through the artifact writer, implemented publish-after-liveness buffering, and ran repeated browser verification under Chris Huber’s direction.