### PR TITLE
Complete editor presentation capture from expected identities

### DIFF
--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -648,9 +648,9 @@ export async function runEditorOpenCommand({
 
     if (editorReadiness) {
       await dismissWordPressOnboardingDialogs(page)
-      editorPresentation = await captureEditorPresentation(page, waitTimeoutMs)
+      const expected = await captureExpectedEditorPresentationIdentities(target, runPlaygroundCommand, runtimeSpec, server)
+      editorPresentation = await captureEditorPresentation(page, waitTimeoutMs, expected?.complete ? expected.identities : [])
       if (editorPresentation) {
-        const expected = await captureExpectedEditorPresentationIdentities(target, runPlaygroundCommand, runtimeSpec, server)
         await dismissWordPressOnboardingDialogs(page)
         const idleCanvas = await captureEditorIdleCanvas(page)
         editorPresentation = {
@@ -861,7 +861,7 @@ export function summarizeEditorPresentation(capture: EditorPresentationCapture):
   }
 }
 
-export async function captureEditorPresentation(page: import("playwright").Page, timeoutMs: number): Promise<BrowserEditorPresentationSummary | undefined> {
+export async function captureEditorPresentation(page: import("playwright").Page, timeoutMs: number, expectedIdentities: string[] = []): Promise<BrowserEditorPresentationSummary | undefined> {
   const startedAtMs = Date.now()
   const deadlineMs = startedAtMs + Math.min(timeoutMs, EDITOR_PRESENTATION_MAX_CAPTURE_MS)
   let previousFingerprint: string | undefined
@@ -902,7 +902,13 @@ export async function captureEditorPresentation(page: import("playwright").Page,
       const summary = summarizeEditorPresentation(capture)
       const fingerprint = `${capture.documentIdentity}\n${JSON.stringify(summary)}`
       const observedAtMs = Date.now()
-      if (fingerprint === previousFingerprint) {
+      const expectedIdentitiesObserved = expectedIdentities.length > 0
+        && expectedIdentities.every((identity) => summary.generatedPresentationIdentities.includes(identity))
+      const summarySettled = fingerprint === previousFingerprint
+        && stableSinceMs !== undefined
+        && observedAtMs - stableSinceMs >= EDITOR_PRESENTATION_SETTLE_MS
+      if ((expectedIdentitiesObserved || summarySettled)
+        && capture.documentAgeMs >= EDITOR_PRESENTATION_MIN_OBSERVATION_MS) {
         const currentDocumentIdentity = capture.canvasDocumentType === "iframe"
           ? await resolveEditorCanvasFrame(page, EDITOR_CANVAS_DEFAULT_IFRAME_SELECTOR)
               .then(async (currentFrame) => currentFrame && currentFrame === frame ? await currentFrame.evaluate(() => `${location.href}\n${performance.timeOrigin}`) : undefined)
@@ -910,13 +916,11 @@ export async function captureEditorPresentation(page: import("playwright").Page,
           : await resolveEditorCanvasFrame(page, EDITOR_CANVAS_DEFAULT_IFRAME_SELECTOR)
               .then(async (currentFrame) => currentFrame ? undefined : await page.evaluate(() => `${location.href}\n${performance.timeOrigin}`))
               .catch(() => undefined)
-        if (stableSinceMs !== undefined
-          && observedAtMs - stableSinceMs >= EDITOR_PRESENTATION_SETTLE_MS
-          && capture.documentAgeMs >= EDITOR_PRESENTATION_MIN_OBSERVATION_MS
-          && currentDocumentIdentity === capture.documentIdentity) {
+        if (currentDocumentIdentity === capture.documentIdentity) {
           return summary
         }
-      } else {
+      }
+      if (fingerprint !== previousFingerprint) {
         previousFingerprint = fingerprint
         stableSinceMs = observedAtMs
       }

--- a/tests/browser-routed-command-security.test.ts
+++ b/tests/browser-routed-command-security.test.ts
@@ -23,6 +23,7 @@ const DELAYED_CANVAS_PRESENTATION_IDENTITY = "e".repeat(64)
 const PARENT_CANVAS_PRESENTATION_IDENTITY = "f".repeat(64)
 const SLOW_PRESENTATION_IDENTITY = "1".repeat(64)
 const PENDING_STYLES_PRESENTATION_IDENTITY = "2".repeat(64)
+const GROWING_PRESENTATION_IDENTITIES = ["3".repeat(64), "4".repeat(64)]
 const matchedPresentationMarkup = `<style>html,body{margin:0}.block-editor-block-list__layout{box-sizing:border-box;width:200px;height:400px;background:linear-gradient(#123,#abc);color:white;padding:12px}</style><div class="block-editor-block-list__layout">Matched presentation</div>`
 const editorShell = `<!doctype html><script>
 globalThis.__name = (value) => value
@@ -48,11 +49,14 @@ const replacingCanvasEditorHtml = `${editorShell}<iframe name="editor-canvas" sr
 const delayedCanvasEditorHtml = `${editorShell}<div class="block-editor-block-list__layout"><div class="block-editor-block-list__block" data-block="transition">Transition</div></div><script>setTimeout(() => { const iframe = document.createElement('iframe'); iframe.name = 'editor-canvas'; iframe.srcdoc = '<style>/* blocks-engine-presentation:${DELAYED_CANVAS_PRESENTATION_IDENTITY} */<\\/style>'; document.body.append(iframe) }, 300)</script>`
 const slowPresentationEditorHtml = `${editorShell}<iframe name="editor-canvas" srcdoc="<script>setTimeout(() => { const style = document.createElement('style'); style.textContent = '/* blocks-engine-presentation:${SLOW_PRESENTATION_IDENTITY} */'; document.head.append(style) }, 3500)<\/script><div class='block-editor-block-list__layout'><div class='block-editor-block-list__block' data-block='slow'>Slow</div></div>"></iframe>`
 const pendingStylesEditorHtml = `${editorShell}<iframe name="editor-canvas" srcdoc="<link rel='stylesheet' href='http://127.0.0.1:9/unavailable.css'><style>/* blocks-engine-presentation:${PENDING_STYLES_PRESENTATION_IDENTITY} */<\/style><div class='block-editor-block-list__layout'><div class='block-editor-block-list__block' data-block='pending'>Pending</div></div>"></iframe>`
+const growingPresentationEditorHtml = `${editorShell}<iframe name="editor-canvas" srcdoc="<style>/* blocks-engine-presentation:${GROWING_PRESENTATION_IDENTITIES[0]} */<\/style><script>let identity = 0; setInterval(() => { const style = document.createElement('style'); style.textContent = '/* blocks-engine-presentation:' + (identity++).toString(16).padStart(64, '9') + ' */'; document.head.append(style) }, 100); setTimeout(() => { const style = document.createElement('style'); style.textContent = '/* blocks-engine-presentation:${GROWING_PRESENTATION_IDENTITIES[1]} */'; document.head.append(style) }, 4100)<\/script><div class='block-editor-block-list__layout'><div class='block-editor-block-list__block' data-block='growing'>Growing</div></div>"></iframe>`
 
 test("real browser commands sanitize console, artifacts, stdout, and failure stderr", async () => {
   const httpServer = createServer((request, response) => {
     response.setHeader("content-type", "text/html")
-    response.end(request.url?.startsWith("/broken")
+    response.end(request.url?.startsWith("/wp-admin/post.php")
+      ? growingPresentationEditorHtml
+      : request.url?.startsWith("/broken")
       ? "<main>Broken editor fixture</main>"
       : request.url?.startsWith("/presentation")
         ? "<main>Deliberately different frontend fixture</main>"
@@ -88,7 +92,12 @@ test("real browser commands sanitize console, artifacts, stdout, and failure std
       },
     },
   } as RuntimeCreateSpec
-  const runPlaygroundCommand = async () => ({ text: "[]", exitCode: 0 })
+  const runPlaygroundCommand = async (command: string) => ({
+    text: command === "wordpress.editor-open.capture-presentation-contract"
+      ? JSON.stringify({ identities: GROWING_PRESENTATION_IDENTITIES, complete: true })
+      : "[]",
+    exitCode: 0,
+  })
 
   try {
     await withTempDir("wp-codebox-real-browser-actions-security-", async (artifactRoot) => {
@@ -237,6 +246,20 @@ test("real browser commands sanitize console, artifacts, stdout, and failure std
       })
       const output = JSON.parse(result.output) as { summary: { editorPresentation: { generatedPresentationIdentities: string[] } } }
       assert.deepEqual(output.summary.editorPresentation.generatedPresentationIdentities, [PENDING_STYLES_PRESENTATION_IDENTITY])
+    })
+
+    await withTempDir("wp-codebox-real-editor-growing-presentation-security-", async (artifactRoot) => {
+      const result = await runEditorOpenCommand({
+        artifactRoot,
+        runPlaygroundCommand,
+        runtimeSpec,
+        server,
+        spec: { command: "wordpress.editor-open", args: ["post-id=1", "capture=steps", "wait-timeout=5s"] },
+      })
+      const output = JSON.parse(result.output) as { summary: { editorPresentation: { generatedPresentationIdentities: string[]; expectedGeneratedPresentationIdentities: string[]; expectedGeneratedPresentationIdentitiesComplete: boolean } } }
+      assert.deepEqual(output.summary.editorPresentation.expectedGeneratedPresentationIdentities, GROWING_PRESENTATION_IDENTITIES)
+      assert.equal(output.summary.editorPresentation.expectedGeneratedPresentationIdentitiesComplete, true)
+      assert.equal(GROWING_PRESENTATION_IDENTITIES.every((identity) => output.summary.editorPresentation.generatedPresentationIdentities.includes(identity)), true)
     })
 
     await withTempDir("wp-codebox-real-editor-canvas-security-", async (artifactRoot) => {


### PR DESCRIPTION
## Summary
- query the independently complete editor-presentation identity contract before observing the canvas
- finish capture when the mature, still-current canvas contains every expected identity
- preserve fingerprint stabilization for editor targets without an expected identity contract
- cover a real browser canvas whose identity set keeps growing beyond the normal settle window

Closes #2425.

## Verification
- `npm run test:browser-routed-command-security`
- `npm run check` (343 commands)
- `git diff --check`

## Evidence
The regression reproduces the downstream timing shape: the canvas adds presentation markers every 100 ms, adds the final required marker after 4.1 seconds, and must emit complete expected/observed evidence within a 5-second command timeout.

## AI Assistance
GPT-5.6 Sol via OpenCode analyzed the SSI promotion evidence, implemented the expected-identity completion condition and real-browser regression, and ran focused and repository-wide verification. I reviewed and orchestrated the work.