### PR TITLE
Isolate native MariaDB startup attempts

### DIFF
--- a/packages/cli/src/runtime-services.ts
+++ b/packages/cli/src/runtime-services.ts
@@ -532,15 +532,15 @@ async function provisionMysqlNativeService(service: WorkspaceRecipeRuntimeServic
     for (let attempt = 0; attempt < NATIVE_MARIADB_START_ATTEMPTS; attempt += 1) {
       port = await (dependencies.allocateNativePort ?? allocateLoopbackPort)()
       await writeFile(logFile, "", { mode: 0o600 })
-      processState = spawnOwnedNativeMariaDb(binaries.limiter, [...nativeMariaDbLimitArguments(), "--", binaries.server, ...nativeMariaDbDaemonArguments({ datadir, socket, pidFile, logFile, temporaryDirectory, pluginDirectory, secureFileDirectory, port, userArgument })], childEnvironment, false, temporaryDirectory)
+      const candidate = spawnOwnedNativeMariaDb(binaries.limiter, [...nativeMariaDbLimitArguments(), "--", binaries.server, ...nativeMariaDbDaemonArguments({ datadir, socket, pidFile, logFile, temporaryDirectory, pluginDirectory, secureFileDirectory, port, userArgument })], childEnvironment, false, temporaryDirectory)
       try {
-        await waitForNativeMariaDbReady(binaries, socket, processState, root, dependencies, signal)
+        await waitForNativeMariaDbReady(binaries, socket, candidate, root, dependencies, signal)
+        processState = candidate
         break
       } catch (error) {
-        await stopOwnedNativeMariaDb(processState, root, dependencies, binaries, socket)
-        const bindCollision = await nativeMariaDbBindCollision(logFile, processState)
-        if (!processState.exited) throw new Error("Native MariaDB process exit was not proven")
-        processState = undefined
+        await stopOwnedNativeMariaDb(candidate, root, dependencies, binaries, socket)
+        const bindCollision = await nativeMariaDbBindCollision(logFile, candidate)
+        if (!candidate.exited) throw new Error("Native MariaDB process exit was not proven")
         if (!bindCollision || attempt === NATIVE_MARIADB_START_ATTEMPTS - 1) throw error
       }
     }

--- a/tests/native-mariadb-runtime-service.test.ts
+++ b/tests/native-mariadb-runtime-service.test.ts
@@ -71,7 +71,7 @@ const port = Number(value('--port')); const log = value('--log-error'); const so
 fs.writeFileSync(value('--pid-file'), '1');
 fs.writeFileSync(value('--pid-file') + '.actual', String(process.pid));
 const server = net.createServer(); server.on('error', (error) => { fs.appendFileSync(log, error.code === 'EADDRINUSE' ? 'address already in use' : 'daemon crash: ' + error.code); process.exit(1); });
-server.listen(port, '127.0.0.1'); const timer = setInterval(() => { if (fs.existsSync(socket + '.shutdown')) { clearInterval(timer); server.close(() => process.exit(0)); } }, 10);
+server.listen(port, '127.0.0.1', () => fs.writeFileSync(socket + '.ready', '')); const timer = setInterval(() => { if (fs.existsSync(socket + '.shutdown')) { clearInterval(timer); server.close(() => process.exit(0)); } }, 10);
 process.on('SIGTERM', () => server.close(() => process.exit(0)));
 `
 const limiterScript = `#!/bin/sh
@@ -121,7 +121,15 @@ try {
         assert.ok(socket)
         await writeFile(`${socket}.shutdown`, "")
       }
-      if (basename(effectiveCommand) === "mariadb" && options.stdin === "SELECT 1;\n") await new Promise((resolve) => setTimeout(resolve, 200))
+      if (basename(effectiveCommand) === "mariadb" && options.stdin === "SELECT 1;\n" && effectiveArgs.includes("--protocol=SOCKET")) {
+        const socket = effectiveArgs.find((arg) => arg.startsWith("--socket="))?.slice("--socket=".length)
+        assert.ok(socket)
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          try { await readFile(`${socket}.ready`); return { stdout: "1\n" } } catch {}
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+        throw new Error("fixture MariaDB daemon did not bind")
+      }
       if (options.stdin === "SHOW ENGINES;\n") return { stdout: "InnoDB\tDEFAULT\tTransactional\nFEDERATED\tNO\tOutbound\nMEMORY\tYES\tMemory\n" }
       return { stdout: options.stdin === "SELECT 1;\n" ? "1\n" : "" }
     },


### PR DESCRIPTION
## Summary

- keep each native MariaDB startup candidate local until readiness is proven
- prevent failed-attempt process state from becoming shared cleanup state
- replace the fake client's timing-based readiness with explicit daemon-bind evidence

Closes #2435.

## Root Cause

The fake MariaDB client returned socket readiness after an arbitrary 200 ms. On a hot host, it could report success before the fake daemon processed `EADDRINUSE`, so provisioning accepted an unbound first attempt and the retry assertion failed nondeterministically.

## Verification

- focused native MariaDB test passed five sequential repetitions
- `npm run check` passed all 343 commands
- an unrelated fanout event-order assertion failed on the first full run, passed focused, and passed in the complete rerun

## AI Assistance

GPT-5.6 Sol via OpenCode diagnosed the host-timing race, implemented the startup-state simplification and deterministic fixture readiness, and ran focused and full verification. I reviewed and orchestrated the work.