### PR TITLE
Fix configured PHP benchmark workload reuse

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -1666,6 +1666,7 @@ function wp_codebox_bench_assert_required_observations(array $workload, array $p
 }
 
 function wp_codebox_bench_run_configured_workload(array $workload, string $plugin_path) {
+    static $php_file_results = array();
     $steps = wp_codebox_bench_workload_run_steps($workload);
     $payload = array('metrics' => array(), 'metadata' => array(), 'artifacts' => array(), 'steps' => array(), 'diagnostics' => array());
     if (isset($workload['metadata']) && is_array($workload['metadata'])) {
@@ -1679,7 +1680,10 @@ function wp_codebox_bench_run_configured_workload(array $workload, string $plugi
         if ($type === 'php') {
             if (isset($step['file']) && is_string($step['file'])) {
                 $file = $plugin_path . '/' . ltrim($step['file'], '/');
-                $callable = require $file;
+                if (!array_key_exists($file, $php_file_results)) {
+                    $php_file_results[$file] = require $file;
+                }
+                $callable = $php_file_results[$file];
                 $result = is_callable($callable) ? $callable() : $callable;
             } else {
                 $result = null;

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -188,6 +188,38 @@ assert.match(requiredObservationGate[0], /"step_count":0/)
 assert.match(requiredObservationGate[1], /observation:rest-db-query-profiler/)
 assert.equal(requiredObservationGate[2], "report")
 
+const configuredPhpFileIterations = await withTempDir("wp-codebox-configured-php-file-", async (directory) => {
+  const workloadFile = join(directory, "workload.php")
+  const phpTestFile = join(directory, "configured-php-file.php")
+  await writeFile(
+    workloadFile,
+    `<?php
+$GLOBALS['wp_codebox_test_load_count'] = ($GLOBALS['wp_codebox_test_load_count'] ?? 0) + 1;
+function wp_codebox_test_configured_workload_result(): array {
+    $GLOBALS['wp_codebox_test_call_count'] = ($GLOBALS['wp_codebox_test_call_count'] ?? 0) + 1;
+    return array('metrics' => array('calls' => $GLOBALS['wp_codebox_test_call_count']));
+}
+return 'wp_codebox_test_configured_workload_result';
+`,
+  )
+  await writeFile(
+    phpTestFile,
+    `<?php
+${configuredWorkloadHelpers}
+$workload = array('run' => array(array('type' => 'php', 'file' => 'workload.php')));
+wp_codebox_bench_run_configured_workload($workload, ${JSON.stringify(directory)});
+$payload = wp_codebox_bench_run_configured_workload($workload, ${JSON.stringify(directory)});
+echo json_encode(array(
+    'loads' => $GLOBALS['wp_codebox_test_load_count'],
+    'calls' => $GLOBALS['wp_codebox_test_call_count'],
+    'metrics' => $payload['metrics'],
+), JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<{ loads: number; calls: number; metrics: { calls: number } }>(phpTestFile)
+})
+assert.deepEqual(configuredPhpFileIterations, { loads: 1, calls: 2, metrics: { calls: 2 } })
+
 const externalHttpGuardrailPayload = await withTempDir("wp-codebox-external-http-guardrail-", async (directory) => {
   const phpTestFile = join(directory, "external-http-guardrail.php")
   await writeFile(


### PR DESCRIPTION
## Summary

- load each configured PHP workload file once per benchmark command
- reuse its returned callable across warmup and measured iterations
- cover named helper declarations and per-iteration callable execution

## Verification

- `npm exec -- tsx tests/bench-command-step-behavior.test.ts`
- `npm run build`
- `git diff --check`

Fixes #2446.

## AI assistance

GPT-5.6 Sol via OpenCode diagnosed the configured-workload lifecycle mismatch from retained `homeboy-lab` evidence, implemented the focused repair and regression coverage under Chris Huber’s direction, and ran the listed verification.