### PR TITLE
fix(test): publish process markers atomically

### DIFF
--- a/.github/scripts/run-agent-task/execute-native-agent-task.mjs
+++ b/.github/scripts/run-agent-task/execute-native-agent-task.mjs
@@ -1,5 +1,5 @@
 import { constants, rmSync } from "node:fs"
-import { appendFile, lstat, mkdir, open, readFile, realpath, rm, writeFile } from "node:fs/promises"
+import { appendFile, lstat, mkdir, open, readFile, realpath, rename, rm, writeFile } from "node:fs/promises"
 import { isUtf8 } from "node:buffer"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -523,7 +523,9 @@ async function testPauseAfterSeedSnapshot(seedSnapshot) {
   if (process.env.NODE_ENV !== "test") return
   const markerPath = string(process.env.WP_CODEBOX_TEST_SEED_SNAPSHOT_PAUSE_FILE)
   if (!markerPath) return
-  await writeFile(markerPath, `${JSON.stringify({ schema: "wp-codebox/test-seed-snapshot-pause/v1", seed_snapshot_source: seedSnapshot?.source ?? "" })}\n`)
+  const pendingMarkerPath = `${markerPath}.${process.pid}.tmp`
+  await writeFile(pendingMarkerPath, `${JSON.stringify({ schema: "wp-codebox/test-seed-snapshot-pause/v1", seed_snapshot_source: seedSnapshot?.source ?? "" })}\n`)
+  await rename(pendingMarkerPath, markerPath)
   await new Promise((resolvePause) => setTimeout(resolvePause, 120_000))
 }
 

--- a/tests/fixtures/playground-cache-lease-child.ts
+++ b/tests/fixtures/playground-cache-lease-child.ts
@@ -1,4 +1,4 @@
-import { lstat, writeFile } from "node:fs/promises"
+import { lstat, rename, writeFile } from "node:fs/promises"
 
 import { acquirePlaygroundArchiveReference } from "../../packages/runtime-playground/src/playground-wordpress-archive-cache.js"
 
@@ -8,7 +8,9 @@ if (!archivePath || !readyPath || !stopPath) {
 }
 
 const reference = await acquirePlaygroundArchiveReference(archivePath)
-await writeFile(readyPath, reference.path)
+const pendingReadyPath = `${readyPath}.${process.pid}.tmp`
+await writeFile(pendingReadyPath, reference.path)
+await rename(pendingReadyPath, readyPath)
 
 while (!await exists(stopPath)) {
   await new Promise((resolve) => setTimeout(resolve, 25))


### PR DESCRIPTION
## Summary

- publish the native interruption pause marker through a same-directory atomic rename
- publish the archive-cache child readiness marker through the same complete-payload contract
- prevent existence-based readers from observing empty or partial readiness payloads under concurrent smoke load

## Evidence

- PR #2453 smoke run https://github.com/Automattic/wp-codebox/actions/runs/33530273032 failed with an empty JSON interruption marker
- v0.26.6 Homeboy release preflight failed independently with an empty archive-cache reference marker and rolled back before mutation

## Verification

- `npx tsx tests/playground-custom-archive-cache-process.test.ts`
- `node tests/execute-native-agent-task-interruption.test.mjs`
- `npm run build`
- `npm run check` (342 commands, concurrency 8)

Fixes #2454.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode correlated the two release-blocking failures, identified the shared readiness-publication race, implemented the atomic marker protocol, and ran focused and full concurrent verification. Chris Huber directed and owns the work.