### PR TITLE
fix(smoke): isolate parallel tsx transforms

### DIFF
--- a/scripts/smoke-discovery.ts
+++ b/scripts/smoke-discovery.ts
@@ -100,11 +100,11 @@ export function discoverSmokeFiles(root = process.cwd()): string[] {
   return files.filter((file) => !excluded.has(file)).sort()
 }
 
-function toCommand(file: string): SmokeCommand {
+function toCommand(file: string, disableTsxCache = false): SmokeCommand {
   return {
     name: file,
     command: file.endsWith(".php") ? "php" : file.endsWith(".mjs") ? "node" : "tsx",
-    args: [file],
+    args: disableTsxCache && file.endsWith(".ts") ? ["--no-cache", file] : [file],
   }
 }
 
@@ -114,7 +114,7 @@ export function discoveredCommands(root = process.cwd()): SmokeCommand[] {
 
 /** Files safe to run concurrently. */
 export function discoveredParallelCommands(root = process.cwd()): SmokeCommand[] {
-  return discoverSmokeFiles(root).filter((file) => !serial.has(file)).map(toCommand)
+  return discoverSmokeFiles(root).filter((file) => !serial.has(file)).map((file) => toCommand(file, true))
 }
 
 /** Files that must run one at a time, after the parallel phase. */

--- a/tests/smoke-discovery.test.ts
+++ b/tests/smoke-discovery.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { discoveredParallelCommands, discoveredSerialCommands } from "../scripts/smoke-discovery.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-smoke-discovery-"))
+
+try {
+  await mkdir(join(root, "tests"))
+  await mkdir(join(root, "scripts"))
+  await writeFile(join(root, "tests", "parallel.test.ts"), "")
+  await writeFile(join(root, "tests", "recipe-step-continuation.integration.test.ts"), "")
+  await writeFile(join(root, "scripts", "native-smoke.php"), "")
+
+  assert.deepEqual(discoveredParallelCommands(root), [
+    { name: "scripts/native-smoke.php", command: "php", args: ["scripts/native-smoke.php"] },
+    { name: "tests/parallel.test.ts", command: "tsx", args: ["--no-cache", "tests/parallel.test.ts"] },
+  ])
+  assert.deepEqual(discoveredSerialCommands(root), [
+    { name: "tests/recipe-step-continuation.integration.test.ts", command: "tsx", args: ["tests/recipe-step-continuation.integration.test.ts"] },
+  ])
+} finally {
+  await rm(root, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- disable tsx's shared disk transform cache for parallel discovered TypeScript tests
- preserve existing cached behavior for declared and serial commands
- add a focused discovery contract for TypeScript, PHP, and serial command shapes

## Evidence

PR #2455 run https://github.com/Automattic/wp-codebox/actions/runs/33534543967 failed in the parallel phase with a missing named export that is present in source. Focused, package, and contract runs pass, and no parallel test mutates the affected source. The bare `tsx` workers shared the only remaining cross-process state: tsx's global per-user transform cache.

## Verification

- `npx tsx tests/smoke-discovery.test.ts`
- `npm run build`
- `npx -p node@22 node node_modules/tsx/dist/cli.mjs scripts/run-smoke.ts --group=check` (343 commands, concurrency 8, Node 22.23.2)

Fixes #2456.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed the CI-only loader failure, audited shared repository mutation and tsx cache boundaries, implemented the parallel-worker isolation, and ran the exact Node 22 aggregate. Chris Huber directed and owns the work.