### PR TITLE
Fix bounded plan concurrency test synchronization

### DIFF
--- a/tests/bounded-recipe-plan.test.ts
+++ b/tests/bounded-recipe-plan.test.ts
@@ -9,13 +9,19 @@ const root = await mkdtemp(join(tmpdir(), "wp-codebox-bounded-recipe-plan-"))
 const executed: ExecutionSpec[] = []
 let active = 0
 let maximumActive = 0
+let releaseExecutions: () => void = () => undefined
+const executionsReady = new Promise<void>((resolve, reject) => {
+  releaseExecutions = resolve
+  setTimeout(() => reject(new Error("Timed out waiting for concurrent runtime executions.")), 5_000).unref()
+})
 const runtime = {
   async execute(spec: ExecutionSpec) {
     executed.push(spec)
     active++
     maximumActive = Math.max(maximumActive, active)
     try {
-      await new Promise((resolve) => setTimeout(resolve, spec.args?.some((arg) => arg.includes("suite-one")) ? 15 : 1))
+      if (active === 2) releaseExecutions()
+      await executionsReady
       const failed = spec.args?.some((arg) => arg.includes("suite-failed"))
       return {
         id: failed ? "failed" : "one",


### PR DESCRIPTION
## Summary

- replace timer-based bounded-plan concurrency inference with a two-party execution barrier
- retain a bounded timeout so a real single-worker regression fails instead of hanging
- preserve result ordering, counts, artifact, and redaction coverage

Closes #2458.

## Verification

- 30 consecutive focused runs under Node 24.15.0
- `npm run check` (343 commands)

## AI assistance disclosure

GPT-5.6-Sol via OpenCode diagnosed the aggregate release-gate failure, implemented the deterministic test synchronization, and ran verification under human direction.
