### PR TITLE
Persist collected workload results in fuzz artifact bundles

### DIFF
--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -476,6 +476,7 @@ export interface FuzzSuiteArtifactRef {
   bytes?: number
   name?: string
   metadata?: Record<string, unknown>
+  payload?: unknown
 }
 
 export interface FuzzReplayCaseRef {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -1521,6 +1521,7 @@ function fuzzSuiteArtifactRefFromTrace(ref: RuntimeEpisodeTraceRef): FuzzSuiteAr
     contentType: ref.contentType,
     sha256: ref.digest?.algorithm === "sha256" ? ref.digest.value : undefined,
     metadata: stripUndefined({ id: ref.id, artifactId: ref.artifactId, digest: ref.digest, sourcePath: ref.sourcePath }),
+    payload: ref.payload,
   })
 }
 

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -877,6 +877,7 @@ export interface RuntimeEpisodeTraceRef {
   path?: string
   sourcePath?: string
   contentType?: string
+  payload?: unknown
 }
 
 export interface RuntimeEpisodeActionRecord {

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -10,6 +10,7 @@ import {
   artifactFileDigest,
   artifactStoragePath,
   resolveArtifactPath,
+  safeArtifactRelativePath,
   WORDPRESS_HOTSPOTS_SCHEMA,
   QUERY_OBSERVATION_SCHEMA,
   createRuntime,
@@ -956,7 +957,7 @@ export function createWordPressFuzzSuiteRuntimeWorkloadExecutor(episode: Pick<Ru
       const executions: ExecutionResult[] = []
       for (const [stepIndex, step] of steps.entries()) {
         const execution = step.command === "wordpress.collect-workload-result"
-          ? collectWorkloadResultExecution(step, executions, startedAt)
+          ? collectWorkloadResultExecution(step, executions, startedAt, workload)
           : (await episode.step({ kind: "command", command: step.command, args: step.args, timeoutMs: step.timeoutMs, metadata: stripUndefined({ ...step.metadata, phase: step.phase, phaseIndex: step.phaseIndex, workloadStepIndex: stepIndex }) }, { type: "command-result" })).execution
         executions.push(execution)
         if (execution.exitCode !== 0 && !step.allowFailure && !step.advisory) {
@@ -1009,7 +1010,7 @@ function workloadExecutionArtifacts(executions: ExecutionResult[]): Record<strin
   return artifacts
 }
 
-function collectWorkloadResultExecution(step: { command: string; args?: string[] }, priorExecutions: ExecutionResult[], startedAt: string): ExecutionResult {
+function collectWorkloadResultExecution(step: { command: string; args?: string[] }, priorExecutions: ExecutionResult[], startedAt: string, workload: Record<string, unknown>): ExecutionResult {
   const args = stepArgMap(step.args)
   const artifact = args.artifact ?? args.name ?? ""
   const expectedSchema = args.schema
@@ -1031,6 +1032,11 @@ function collectWorkloadResultExecution(step: { command: string; args?: string[]
       : undefined
   const payload = payloads[0]?.payload ?? {}
   const stdout = `${JSON.stringify(payload)}\n`
+  const declaration = arrayValue(workload.artifacts).map(recordValue).find((candidate) => {
+    const name = stringValue(candidate?.name)
+    return name !== undefined && artifactNameMatches(name, artifact || payloads[0]?.name || "")
+  })
+  const artifactPath = workloadResultArtifactPath(stringValue(declaration?.path), artifact || payloads[0]?.name || "workload-result")
   return {
     id: `wordpress-collect-workload-result-${artifact || "workload-result"}`,
     command: "wordpress.collect-workload-result",
@@ -1041,7 +1047,7 @@ function collectWorkloadResultExecution(step: { command: string; args?: string[]
     result: { schema: "wp-codebox/runtime-command-result/v1", status: diagnostic ? "error" : "ok", json: payload, diagnostics: diagnostic ? [diagnostic] : undefined },
     startedAt,
     finishedAt: new Date().toISOString(),
-    artifactRefs: payloads[0] ? [{ kind: payloads[0].name, id: artifact || payloads[0].name, artifactId: artifact || payloads[0].name, path: `files/workload-results/${safeArtifactSegment(artifact || payloads[0].name)}.json`, payload } as NonNullable<ExecutionResult["artifactRefs"]>[number]] : [],
+    artifactRefs: payloads[0] ? [{ kind: payloads[0].name, id: artifact || payloads[0].name, artifactId: artifact || payloads[0].name, path: artifactPath, payload }] : [],
   }
 }
 
@@ -1343,6 +1349,13 @@ async function writeFuzzArtifactBundle(input: {
   const replayCaseRefs: FuzzReplayCaseRef[] = []
   const queryObservationArtifacts: Array<ReturnType<typeof queryObservationArtifactMetadata>> = []
   const restDbQueryProfileArtifacts: Array<ReturnType<typeof restDbQueryProfileArtifactMetadata>> = []
+  const artifactPathCounts = input.result.cases
+    .flatMap((fuzzCase) => fuzzCase.artifactRefs ?? [])
+    .reduce((counts, ref) => counts.set(ref.path, (counts.get(ref.path) ?? 0) + 1), new Map<string, number>())
+  for (const [index, profile] of input.restDbQueryProfiles.entries()) {
+    const path = `files/workload-results/${safeArtifactSegment(profile.caseId ?? "case")}-rest-db-query-profile-${index + 1}.json`
+    artifactPathCounts.set(path, (artifactPathCounts.get(path) ?? 0) + 1)
+  }
 
   artifactRefs.push(wordpressHotspots.ref, fuzzObservationSet.ref, fuzzHotspotSet.ref)
 
@@ -1368,7 +1381,7 @@ async function writeFuzzArtifactBundle(input: {
 
   for (const fuzzCase of input.result.cases) {
     const dbWriteSet = recordValue(fuzzCase.metadata?.dbWriteSet)
-    const caseArtifactRefs = await Promise.all((fuzzCase.artifactRefs ?? []).map((ref) => importFuzzCaseArtifactRef(writer, storage, bundlePath, ref)))
+    const caseArtifactRefs = await Promise.all((fuzzCase.artifactRefs ?? []).map((ref, index) => importFuzzCaseArtifactRef(writer, storage, bundlePath, ref, (artifactPathCounts.get(ref.path) ?? 0) > 1 ? `${fuzzCase.id}-${index + 1}` : undefined)))
     fuzzCase.artifactRefs = dedupeFuzzSuiteArtifactRefs(caseArtifactRefs)
     artifactRefs.push(...caseArtifactRefs)
     if (dbWriteSet) {
@@ -1465,20 +1478,43 @@ async function writeFuzzArtifactBundle(input: {
   }
 }
 
-async function importFuzzCaseArtifactRef(writer: ArtifactBundleWriter, storage: RuntimeArtifactStorageDescriptor, bundlePath: string, ref: FuzzSuiteArtifactRef): Promise<FuzzSuiteArtifactRef> {
+async function importFuzzCaseArtifactRef(writer: ArtifactBundleWriter, storage: RuntimeArtifactStorageDescriptor, bundlePath: string, ref: FuzzSuiteArtifactRef, collisionNamespace?: string): Promise<FuzzSuiteArtifactRef> {
+  const path = collisionNamespace ? namespacedArtifactPath(ref.path, collisionNamespace) : ref.path
   const sourcePath = stringValue(ref.metadata?.sourcePath)
-  if (!sourcePath) return ref
-  await writer.importFile(ref.path, sourcePath, {
-    kind: ref.kind,
-    contentType: ref.contentType ?? "application/octet-stream",
-    provenance: { source: "runtime-action", operation: "import-fuzz-case-artifact" },
-  })
-  const content = await readFile(writer.path(ref.path))
-  const digest = artifactFileDigest(content)
-  return {
-    ...fuzzArtifactRef(storage, bundlePath, ref.path, ref.kind, ref.contentType ?? "application/octet-stream", digest.value, content.byteLength),
-    metadata: stripUndefined({ ...(ref.metadata ?? {}), sourcePath: undefined, importedFrom: ref.path, storage: "runtime-artifact-layout" }),
+  if (sourcePath) {
+    await writer.importFile(path, sourcePath, {
+      kind: ref.kind,
+      contentType: ref.contentType ?? "application/octet-stream",
+      provenance: { source: "runtime-action", operation: "import-fuzz-case-artifact" },
+    })
+    const content = await readFile(writer.path(path))
+    const digest = artifactFileDigest(content)
+    return {
+      ...fuzzArtifactRef(storage, bundlePath, path, ref.kind, ref.contentType ?? "application/octet-stream", digest.value, content.byteLength),
+      metadata: stripUndefined({ ...(ref.metadata ?? {}), sourcePath: undefined, importedFrom: ref.path, declaredPath: collisionNamespace ? ref.path : undefined, storage: "runtime-artifact-layout" }),
+    }
   }
+
+  if (ref.payload === undefined) return ref
+  const content = `${JSON.stringify(ref.payload, null, 2)}\n`
+  const schema = stringValue(recordValue(ref.payload)?.schema) ?? "wp-codebox/typed-workload-artifact/v1"
+  const written = await writeFuzzJsonArtifact(writer, storage, bundlePath, path, ref.kind, schema, content, ref.payload, ref.contentType ?? "application/json")
+  return { ...written.ref, name: ref.name ?? written.ref.name, metadata: stripUndefined({ ...(ref.metadata ?? {}), ...(written.ref.metadata ?? {}), schema, declaredPath: collisionNamespace ? ref.path : undefined }) }
+}
+
+function namespacedArtifactPath(path: string, namespace: string): string {
+  const separator = path.lastIndexOf("/")
+  const basename = separator === -1 ? path : path.slice(separator + 1)
+  return `files/case-artifacts/${safeArtifactSegment(namespace)}/${basename}`
+}
+
+function workloadResultArtifactPath(declaredPath: string | undefined, artifact: string): string {
+  const normalized = declaredPath?.replace(/\\/g, "/")
+  if (normalized?.startsWith("files/workload-results/") && !normalized.split("/").includes("..") && !normalized.endsWith("/")) {
+    return safeArtifactRelativePath(normalized)
+  }
+  const declaredName = normalized?.slice(normalized.lastIndexOf("/") + 1)
+  return `files/workload-results/${safeArtifactSegment(declaredName || artifact)}${declaredName?.includes(".") ? "" : ".json"}`
 }
 
 function resultWithRequiredRestDbQueryProfilePayloads(result: FuzzSuiteResultEnvelope, profiles: RestDbQueryProfileArtifact[]): FuzzSuiteResultEnvelope {

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -64,6 +64,23 @@ const episode = {
         schema: "wp-codebox/recipe-run/v1",
         success: true,
         executions: [{ result: { json: { schema: "wp-codebox/bench-results/v1", scenarios: [{ id: "recipe-profile", artifacts: { "rest-db-query-profile": { schema: "wp-codebox/wordpress-rest-db-query-profile/v1", cases: [{ case_id: "recipe-products", method: "GET", path: "/wc/store/v1/products", summary: { query_count: 11, total_time_ms: 14.5 } }] } } }] } } }],
+      } : runPhpCode.includes("large-workload-report-second") ? {
+        schema: "wp-codebox/json-workload-result/v1",
+        artifacts: { "large-workload-report": { schema: "example/large-workload-report/v1", marker: "second" } },
+      } : runPhpCode.includes("large-workload-report") ? {
+        schema: "wp-codebox/json-workload-result/v1",
+        artifacts: {
+          "large-workload-report": {
+            schema: "example/large-workload-report/v1",
+            marker: "x".repeat(1_100_000),
+          },
+        },
+      } : runPhpCode.includes("colliding-workload-reports") ? {
+        schema: "wp-codebox/json-workload-result/v1",
+        artifacts: {
+          "collision-a": { schema: "example/collision-a/v1", marker: "a" },
+          "collision-b": { schema: "example/collision-b/v1", marker: "b" },
+        },
       } : runPhpCode.includes("rest-db-query-profiler") ? {
         schema: "wp-codebox/json-workload-result/v1",
         steps: [{
@@ -224,7 +241,10 @@ try {
     cases: [
       { id: "durable-rest", target: { kind: "rest", id: "/wp/v2/types" }, input: { method: "GET" } },
       { id: "durable-delete", target: { kind: "runtime-action" }, input: { type: "rest_request", method: "DELETE", path: "/wp/v2/posts/123" }, mutation: { intent: "delete", destructive: true } },
-      { id: "durable-profile-collection", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ type: "rest-db-query-profiler", rest_request_cases: [{ id: "products", method: "GET", path: "/wc/store/v1/products" }] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=rest_db_query_profile"] }] } },
+      { id: "durable-profile-collection", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ type: "rest-db-query-profiler", rest_request_cases: [{ id: "products", method: "GET", path: "/wc/store/v1/products" }] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=rest_db_query_profile"] }], artifacts: [{ name: "rest_db_query_profile", path: "files/workload-results/durable-profile-collection-rest-db-query-profile-1.json" }] } },
+      { id: "durable-large-report", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.run-php", args: ["code=large-workload-report"] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=large-workload-report", "schema=example/large-workload-report/v1"] }], artifacts: [{ name: "large-workload-report", path: "files/workload-results//declared-large-report.json" }] } },
+      { id: "durable-second-report", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.run-php", args: ["code=large-workload-report-second"] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=large-workload-report", "schema=example/large-workload-report/v1"] }], artifacts: [{ name: "large-workload-report", path: "files/workload-results/declared-large-report.json" }] } },
+      { id: "durable-same-case-collision", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.run-php", args: ["code=colliding-workload-reports"] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=collision-a"] }, { command: "wordpress.collect-workload-result", args: ["artifact=collision-b"] }], artifacts: [{ name: "collision-a", path: "result/fuzz-suite-result.json" }, { name: "collision-b", path: "result/fuzz-suite-result.json" }] } },
     ],
   }), { artifactStorage: { root: artifactRoot }, requireCoverage: true })
   const durableArtifacts = durableResult.metadata?.artifacts as {
@@ -257,6 +277,15 @@ try {
   const durableWriteSet = JSON.parse(await readFile(join(artifactRoot, durableWriteSetPath), "utf8"))
   const queryObservationArtifact = JSON.parse(await readFile(join(artifactRoot, durableArtifacts?.queryObservations?.observations?.[0]?.ref?.path ?? ""), "utf8"))
   const restDbQueryProfileArtifact = JSON.parse(await readFile(join(artifactRoot, durableArtifacts?.restDbQueryProfiles?.profiles?.[0]?.ref?.path ?? ""), "utf8"))
+  const largeReportRef = durableResult.cases[3]?.artifactRefs?.find((ref) => ref.path.endsWith("/files/case-artifacts/durable-large-report-2/declared-large-report.json"))
+  assert.ok(largeReportRef)
+  const largeReportArtifact = JSON.parse(await readFile(join(artifactRoot, largeReportRef.path), "utf8"))
+  const secondReportRef = durableResult.cases[4]?.artifactRefs?.find((ref) => ref.path.endsWith("/files/case-artifacts/durable-second-report-2/declared-large-report.json"))
+  assert.ok(secondReportRef)
+  const secondReportArtifact = JSON.parse(await readFile(join(artifactRoot, secondReportRef.path), "utf8"))
+  const collidingReportRefs = durableResult.cases[5]?.artifactRefs?.filter((ref) => ref.kind === "collision-a" || ref.kind === "collision-b") ?? []
+  assert.equal(collidingReportRefs.length, 2)
+  const collidingReportArtifacts = await Promise.all(collidingReportRefs.map(async (ref) => JSON.parse(await readFile(join(artifactRoot, ref.path), "utf8"))))
   assert.equal(resultArtifact.schema, "wp-codebox/fuzz-suite-result/v1")
   assert.equal(replayArtifact.schema, "wp-codebox/fuzz-replay-case-input/v1")
   assert.equal(replayArtifact.case.id, "durable-rest")
@@ -271,6 +300,21 @@ try {
   assert.equal(queryObservationArtifact.tables.some((table: { name?: string }) => table.name === "wp_posts"), true)
   assert.equal(restDbQueryProfileArtifact.schema, "wp-codebox/wordpress-rest-db-query-profile/v1")
   assert.equal(restDbQueryProfileArtifact.cases[0].case_id, "products")
+  assert.equal(largeReportArtifact.schema, "example/large-workload-report/v1")
+  assert.equal(largeReportArtifact.marker.length, 1_100_000)
+  assert.equal(largeReportRef.bytes, Buffer.byteLength(`${JSON.stringify(largeReportArtifact, null, 2)}\n`))
+  assert.equal(typeof largeReportRef.sha256, "string")
+  assert.equal("payload" in largeReportRef, false)
+  assert.equal(largeReportRef.metadata?.declaredPath, "files/workload-results/declared-large-report.json")
+  assert.equal(secondReportArtifact.marker, "second")
+  assert.notEqual(secondReportRef.sha256, largeReportRef.sha256)
+  assert.equal(secondReportRef.metadata?.declaredPath, "files/workload-results/declared-large-report.json")
+  assert.deepEqual(collidingReportArtifacts.map((artifact) => artifact.marker).sort(), ["a", "b"])
+  assert.equal(collidingReportRefs.every((ref) => ref.path.includes("/files/case-artifacts/durable-same-case-collision-")), true)
+  assert.equal(collidingReportRefs.every((ref) => ref.metadata?.declaredPath === "files/workload-results/fuzz-suite-result.json"), true)
+  const collidingProfileRef = durableResult.cases[2]?.artifactRefs?.find((ref) => ref.metadata?.declaredPath === "files/workload-results/durable-profile-collection-rest-db-query-profile-1.json")
+  assert.ok(collidingProfileRef)
+  assert.equal(collidingProfileRef.path.includes("/files/case-artifacts/durable-profile-collection-"), true)
   assert.equal(durableResult.cases[2]?.artifactRefs?.some((ref) => ref.kind === "rest-db-query-profile"), true)
   assert.equal(resultArtifact.artifactRefs.some((ref: { kind?: string }) => ref.kind === "rest-db-query-profile"), true)
 } finally {


### PR DESCRIPTION
## Summary

- carry inline typed workload payloads through runtime-to-fuzz artifact refs
- persist collected payloads at safe declared workload-result paths with digest and byte metadata
- prevent cross-case, same-case, generated-profile, reserved-path, and normalized-path collisions
- cover complete export of a report larger than the 1 MiB command-output retention ceiling

Closes #2468.

## Verification

- `npm run build`
- `npx tsx tests/playground-fuzz-suite-public.test.ts`
- `npx tsx tests/fuzz-suite-runner.test.ts`
- `npx tsx tests/runtime-episode-contracts.test.ts`
- `git diff --check`
- `npm run check` completed 330/332 discovered tests; unrelated runtime integration failures remained in readonly-mount staging timeout and PHP-WASM worker shutdown

## AI assistance disclosure

GPT-5.6 Sol via OpenCode traced the artifact lifecycle, implemented the durable export and collision handling, added behavioral coverage, and ran verification. I directed the implementation and reviewed the resulting patch.