### PR TITLE
feat: capture external HTTP load evidence

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -49,6 +49,46 @@ The command contract is intentionally broad enough for future workload types:
 - **REST DB query profile:** configured `rest-db-query-profiler` steps run one or more REST request cases, bracket each request with `$wpdb->queries`, and emit bounded, redacted query-profile metrics and artifacts.
 - **Database inventory:** configured `db-inventory` steps collect table, row, column, index, and byte-count inventory through the benchmark artifact path.
 - **Browser:** `wordpress.browser-probe` captures generic browser performance and memory artifacts. When a recipe runs browser probes before `wordpress.bench`, selected numeric `browser_*` metrics are promoted into each benchmark scenario while raw browser artifacts remain in the bundle.
+- **Runtime HTTP load:** configured `external-http-load` steps issue bounded concurrent requests through the managed runtime preview. The workload accepts a runtime-relative `url`, `method`, `headers`, `body`, `requestCount` (1-100), `concurrency` (1-20), and `expectedStatus` or `expectedStatuses`. It executes the benchmark's configured warmup iterations before measured iterations, rejects a non-matching status or incomplete sample set, and records measured request status, duration, and a safe outcome/error code without response bodies or request headers.
+
+## Runtime HTTP Load
+
+Use `external-http-load` for an HTTP workload against the runtime created for the
+benchmark. Its target must resolve to that runtime's preview origin; it cannot
+be used as an arbitrary outbound HTTP client. This keeps the workload contained
+while permitting any runtime-relative route and HTTP method.
+
+```json
+{
+  "id": "frontend-request",
+  "source": "config",
+  "run": [
+    {
+      "type": "external-http-load",
+      "url": "/example-route?mode=measured",
+      "method": "POST",
+      "headers": { "content-type": "application/json" },
+      "body": "{\"enabled\":true}",
+      "requestCount": 12,
+      "concurrency": 3,
+      "expectedStatuses": [200, 204]
+    }
+  ]
+}
+```
+
+The scenario artifact uses `wp-codebox/wordpress-external-http-load/v1`. Its
+`samples` contain `requestIndex`, `durationMs`, actual `status` when one was
+received, and `matched-status`, `unexpected-status`, or `request-error` outcome.
+The `conditions.expectedStatuses` field states the assertion used for every
+sample. Transport errors use stable error codes rather than raw transport
+messages. The artifact includes only measured iterations; its benchmark step
+records both the executed `warmupIterations` and measured `iterations`.
+
+For instrumentation of outbound requests made by PHP while the workload runs,
+pair this workload with the existing `external-http-guardrail` install/collect
+steps. That WordPress HTTP API hook provides bounded event evidence separately
+from preview-request timing.
 
 ## REST DB Query Profiler
 

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "test:native-agent-task-playground-e2e": "tsx tests/execute-native-agent-task-playground-e2e.test.ts",
     "test:bench-command-step-behavior": "tsx tests/bench-command-step-behavior.test.ts",
     "test:external-http-load-integration": "npm run build && tsx tests/external-http-load.integration.test.ts",
+    "test:external-http-load": "node --experimental-strip-types tests/external-http-load.test.ts",
     "test:generic-primitives": "npm run test:artifact-path-primitives && npm run test:browser-callback-materialization-contracts && npm run test:source-package-compiler-primitives && npm run test:bench-command-step-behavior && npm run test:generic-ability-runtime-run",
     "test:temp-runtime-cleanup": "tsx tests/temp-runtime-cleanup.test.ts",
     "smoke:cli-version": "tsx scripts/cli-version-smoke.ts",

--- a/packages/runtime-playground/src/external-http-load.ts
+++ b/packages/runtime-playground/src/external-http-load.ts
@@ -10,8 +10,12 @@ export interface RuntimeExternalHttpLoadResult {
   statusDistribution: Record<string, number>
   durationMs: number
   latenciesMs: number[]
+  samples: RuntimeExternalHttpLoadSample[]
   latency: Record<string, number>
   diagnostics: Array<Record<string, unknown>>
+  conditions: {
+    expectedStatuses: number[]
+  }
   provenance: {
     source: "host-side-external-http"
     transport: "runtime-preview-http"
@@ -19,6 +23,14 @@ export interface RuntimeExternalHttpLoadResult {
     target: string
     method: string
   }
+}
+
+export interface RuntimeExternalHttpLoadSample {
+  requestIndex: number
+  durationMs: number
+  status?: number
+  outcome: "matched-status" | "unexpected-status" | "request-error"
+  errorCode?: "fetch-failed" | "response-read-failed"
 }
 
 export async function runRuntimeExternalHttpLoad(action: Record<string, unknown>, runtimeBaseUrl?: string): Promise<RuntimeExternalHttpLoadResult> {
@@ -45,6 +57,7 @@ export async function runRuntimeExternalHttpLoad(action: Record<string, unknown>
   const expectedStatuses = normalizeExpectedStatuses(action.expectedStatuses ?? (action.expectedStatus === undefined ? undefined : [action.expectedStatus]))
   const statusDistribution: Record<string, number> = {}
   const latenciesMs: number[] = []
+  const samples: RuntimeExternalHttpLoadSample[] = []
   const diagnostics: Array<Record<string, unknown>> = []
   let nextRequest = 0
   let activeRequests = 0
@@ -64,20 +77,34 @@ export async function runRuntimeExternalHttpLoad(action: Record<string, unknown>
       maxObservedConcurrency = Math.max(maxObservedConcurrency, activeRequests)
       const started = performance.now()
       try {
-        const response = await fetch(resolvedUrl, { method, headers, body })
+        const response = await fetch(resolvedUrl, { method, headers, body, redirect: "error" })
         statusDistribution[String(response.status)] = (statusDistribution[String(response.status)] ?? 0) + 1
-        await response.arrayBuffer()
-        latenciesMs.push(performance.now() - started)
+        try {
+          await response.arrayBuffer()
+        } catch {
+          const durationMs = performance.now() - started
+          latenciesMs.push(durationMs)
+          samples.push({ requestIndex, durationMs, status: response.status, outcome: "request-error", errorCode: "response-read-failed" })
+          failureCount++
+          diagnostics.push({ code: "response_read_failed", requestIndex, actualStatus: response.status })
+          continue
+        }
+        const durationMs = performance.now() - started
+        latenciesMs.push(durationMs)
         if (expectedStatuses.includes(response.status)) {
           successCount++
+          samples.push({ requestIndex, durationMs, status: response.status, outcome: "matched-status" })
         } else {
           failureCount++
+          samples.push({ requestIndex, durationMs, status: response.status, outcome: "unexpected-status" })
           diagnostics.push({ code: "unexpected_status", requestIndex, expectedStatuses, actualStatus: response.status })
         }
       } catch (error) {
-        latenciesMs.push(performance.now() - started)
+        const durationMs = performance.now() - started
+        latenciesMs.push(durationMs)
+        samples.push({ requestIndex, durationMs, outcome: "request-error", errorCode: "fetch-failed" })
         failureCount++
-        diagnostics.push({ code: "request_failed", requestIndex, message: errorMessage(error) })
+        diagnostics.push({ code: "request_failed", requestIndex, errorType: errorType(error) })
       } finally {
         completedCount++
         activeRequests--
@@ -102,8 +129,10 @@ export async function runRuntimeExternalHttpLoad(action: Record<string, unknown>
     statusDistribution,
     durationMs: performance.now() - loadStarted,
     latenciesMs,
+    samples,
     latency: numericSummary(latenciesMs),
     diagnostics,
+    conditions: { expectedStatuses },
     provenance: {
       source: "host-side-external-http",
       transport: "runtime-preview-http",
@@ -154,6 +183,6 @@ function numericSummary(values: number[]): Record<string, number> {
   }
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+function errorType(error: unknown): string {
+  return error instanceof Error && error.name ? error.name : "unknown"
 }

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -1209,6 +1209,9 @@ async function benchMergeExternalHttpLoadResults(
         measured.push(result)
       }
     }
+    if (measured.length !== options.iterations || measured.some((result) => result.samples.length !== result.requestCount)) {
+      throw new Error(`external-http-load did not collect every measured request sample for scenario ${plan.scenarioId}`)
+    }
 
     const prefix = benchExternalHttpMetricPrefix(plan.step)
     scenario.metrics ??= {}
@@ -1241,6 +1244,7 @@ async function benchMergeExternalHttpLoadResults(
       requestCount: artifact.requestCount,
       concurrency: artifact.concurrency,
       maxObservedConcurrency: artifact.maxObservedConcurrency,
+      warmupIterations: options.warmupIterations,
       iterations: measured.length,
       provenance: artifact.provenance,
     })
@@ -1307,9 +1311,11 @@ function benchAggregateExternalHttpLoadResults(results: RuntimeExternalHttpLoadR
     statusDistribution,
     durationMs: results.reduce((sum, result) => sum + result.durationMs, 0),
     latenciesMs,
+    samples: results.flatMap((result) => result.samples),
     latency: benchNumericSummary(latenciesMs),
     runs: results,
     diagnostics: results.flatMap((result) => result.diagnostics),
+    conditions: first.conditions ?? {},
     provenance: first.provenance ?? {},
   }
 }

--- a/tests/external-http-load.integration.test.ts
+++ b/tests/external-http-load.integration.test.ts
@@ -49,6 +49,8 @@ await withTempDir("wp-codebox-external-http-load-integration-", async (artifactR
               successCount: number
               failureCount: number
               maxObservedConcurrency: number
+              samples: Array<{ requestIndex: number; status: number; durationMs: number; outcome: string }>
+              runs: Array<{ samples: unknown[] }>
               provenance: { source: string; transport: string; runtimeScope: string }
             }>
           }>
@@ -67,6 +69,10 @@ await withTempDir("wp-codebox-external-http-load-integration-", async (artifactR
   assert.equal(load.successCount, 4)
   assert.equal(load.failureCount, 0)
   assert.equal(load.maxObservedConcurrency, 2)
+  assert.equal(load.samples.length, 4)
+  assert.deepEqual(load.samples.map((sample) => sample.status), [200, 200, 200, 200])
+  assert.ok(load.samples.every((sample) => sample.durationMs >= 0 && sample.outcome === "matched-status"))
+  assert.equal(load.runs.length, 1)
   assert.deepEqual(load.provenance, {
     source: "host-side-external-http",
     transport: "runtime-preview-http",

--- a/tests/external-http-load.test.ts
+++ b/tests/external-http-load.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import { runRuntimeExternalHttpLoad } from "../packages/runtime-playground/src/external-http-load.ts"
+
+let activeRequests = 0
+let maxActiveRequests = 0
+let requestCount = 0
+let receivedMethod = ""
+let receivedBody = ""
+let receivedSecret = ""
+let redirectTargetRequests = 0
+
+const redirectTarget = createServer((_request, response) => {
+  redirectTargetRequests++
+  response.writeHead(204).end()
+})
+await listen(redirectTarget)
+const redirectTargetAddress = redirectTarget.address()
+assert.ok(redirectTargetAddress && typeof redirectTargetAddress === "object")
+
+const runtime = createServer(async (request, response) => {
+  if (request.url === "/broken") {
+    response.destroy()
+    return
+  }
+  if (request.url === "/partial") {
+    response.writeHead(200, { "content-length": "10" })
+    response.end("x")
+    return
+  }
+  if (request.url === "/redirect") {
+    response.writeHead(302, { location: `http://127.0.0.1:${redirectTargetAddress.port}/outside` }).end()
+    return
+  }
+
+  activeRequests++
+  maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
+  requestCount++
+  receivedMethod = request.method ?? ""
+  receivedSecret = String(request.headers["x-test-secret"] ?? "")
+  for await (const chunk of request) {
+    receivedBody += chunk
+  }
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  activeRequests--
+  response.writeHead(204).end()
+})
+await listen(runtime)
+const runtimeAddress = runtime.address()
+assert.ok(runtimeAddress && typeof runtimeAddress === "object")
+const runtimeUrl = `http://127.0.0.1:${runtimeAddress.port}`
+
+try {
+  const matched = await runRuntimeExternalHttpLoad({
+    url: "/matched",
+    method: "POST",
+    headers: { "x-test-secret": "request-secret" },
+    body: "request-body",
+    requestCount: 6,
+    concurrency: 3,
+    expectedStatuses: [204],
+  }, runtimeUrl)
+  assert.equal(matched.success, true)
+  assert.equal(matched.completedCount, 6)
+  assert.equal(matched.successCount, 6)
+  assert.equal(matched.failureCount, 0)
+  assert.equal(matched.maxObservedConcurrency, 3)
+  assert.equal(maxActiveRequests, 3)
+  assert.equal(requestCount, 6)
+  assert.equal(receivedMethod, "POST")
+  assert.equal(receivedBody, "request-body".repeat(6))
+  assert.equal(receivedSecret, "request-secret")
+  assert.deepEqual(matched.statusDistribution, { 204: 6 })
+  assert.deepEqual(matched.conditions, { expectedStatuses: [204] })
+  assert.equal(matched.samples.length, 6)
+  assert.ok(matched.samples.every((sample) => sample.status === 204 && sample.durationMs >= 0 && sample.outcome === "matched-status"))
+  assert.equal(JSON.stringify(matched).includes("request-secret"), false)
+  assert.equal(JSON.stringify(matched).includes("request-body"), false)
+
+  const unexpected = await runRuntimeExternalHttpLoad({
+    url: "/unexpected",
+    requestCount: 2,
+    concurrency: 1,
+    expectedStatuses: [200],
+  }, runtimeUrl)
+  assert.equal(unexpected.success, false)
+  assert.equal(unexpected.completedCount, 2)
+  assert.equal(unexpected.failureCount, 2)
+  assert.deepEqual(unexpected.samples.map((sample) => sample.outcome), ["unexpected-status", "unexpected-status"])
+  assert.deepEqual(unexpected.samples.map((sample) => sample.status), [204, 204])
+
+  const connectionError = await runRuntimeExternalHttpLoad({
+    url: "/broken",
+    requestCount: 1,
+    concurrency: 1,
+    expectedStatuses: [204],
+  }, runtimeUrl)
+  assert.equal(connectionError.success, false)
+  assert.equal(connectionError.completedCount, 1)
+  assert.deepEqual(connectionError.samples[0].outcome, "request-error")
+  assert.equal(connectionError.samples[0].errorCode, "fetch-failed")
+  assert.equal(connectionError.diagnostics[0].code, "request_failed")
+  assert.equal(JSON.stringify(connectionError).includes(runtimeUrl), false)
+
+  const partialBody = await runRuntimeExternalHttpLoad({
+    url: "/partial",
+    requestCount: 1,
+    concurrency: 1,
+    expectedStatuses: [200],
+  }, runtimeUrl)
+  assert.equal(partialBody.success, false)
+  assert.equal(partialBody.completedCount, 1)
+  assert.equal(partialBody.samples[0].outcome, "request-error")
+  assert.ok(["fetch-failed", "response-read-failed"].includes(partialBody.samples[0].errorCode ?? ""))
+
+  const redirect = await runRuntimeExternalHttpLoad({
+    url: "/redirect",
+    requestCount: 1,
+    concurrency: 1,
+    expectedStatuses: [204],
+  }, runtimeUrl)
+  assert.equal(redirect.success, false)
+  assert.equal(redirect.samples[0].errorCode, "fetch-failed")
+  assert.equal(redirectTargetRequests, 0)
+} finally {
+  await close(runtime)
+  await close(redirectTarget)
+}
+
+console.log("external HTTP load behavioral test passed")
+
+function listen(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+}
+
+function close(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+}

--- a/tests/runtime-wp-cli-bridge.test.ts
+++ b/tests/runtime-wp-cli-bridge.test.ts
@@ -61,6 +61,10 @@ try {
 let activeRequests = 0
 let maxActiveRequests = 0
 const target = createServer(async (_request, response) => {
+  if (_request.url === "/broken") {
+    response.destroy()
+    return
+  }
   activeRequests++
   maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
   await delay(30)
@@ -102,6 +106,10 @@ try {
   assert.equal(maxActiveRequests, 3)
   assert.deepEqual(loadResponse.statusDistribution, { 204: 8 })
   assert.equal(loadResponse.latenciesMs.length, 8)
+  assert.equal(loadResponse.samples.length, 8)
+  assert.deepEqual(loadResponse.samples.map((sample) => sample.status), Array.from({ length: 8 }, () => 204))
+  assert.deepEqual(loadResponse.samples.map((sample) => sample.outcome), Array.from({ length: 8 }, () => "matched-status"))
+  assert.ok(loadResponse.samples.every((sample) => sample.durationMs >= 0))
   assert.equal(loadResponse.provenance.source, "host-side-external-http")
   assert.equal(loadResponse.provenance.runtimeScope, "single-runtime")
 
@@ -114,6 +122,20 @@ try {
   assert.equal(statusFailure.success, false)
   assert.equal(statusFailure.failureCount, 2)
   assert.equal(statusFailure.diagnostics[0].code, "unexpected_status")
+  assert.deepEqual(statusFailure.samples.map((sample) => sample.outcome), ["unexpected-status", "unexpected-status"])
+
+  const transportFailure = await runRuntimeExternalHttpLoad({
+    url: "/broken",
+    requestCount: 1,
+    concurrency: 1,
+    expectedStatuses: [204],
+  }, targetUrl)
+  assert.equal(transportFailure.success, false)
+  assert.equal(transportFailure.completedCount, 1)
+  assert.equal(transportFailure.failureCount, 1)
+  assert.deepEqual(transportFailure.samples, [{ requestIndex: 0, durationMs: transportFailure.samples[0].durationMs, outcome: "request-error", errorCode: "fetch-failed" }])
+  assert.equal(transportFailure.diagnostics[0].code, "request_failed")
+  assert.equal(typeof transportFailure.diagnostics[0].errorType, "string")
 } finally {
   await new Promise<void>((resolve, reject) => target.close((error) => error ? reject(error) : resolve()))
 }


### PR DESCRIPTION
Related to #2473.

## Summary

Adds per-request, reviewer-safe evidence to the generic `external-http-load` benchmark primitive.

- Captures a status, duration, outcome, and stable error code for every request without persisting response bodies, request headers, request bodies, or transport messages.
- Fails closed when a measured run is incomplete and records expected-status conditions plus warmup iteration provenance.
- Rejects redirects and covers matched, unexpected-status, failed-body, connection, and redirect behavior with direct `node:http` tests.

## Verification

- `npm run build:release` passed. The normal incremental `npm run build` initially failed because existing stale `runtime-core/dist` output omitted declarations; the declared forced dependency-graph build repaired that state, and the subsequent incremental build passed.
- `npm run test:external-http-load` passed.
- `npm run test:external-http-load-integration` was run three times against a real WordPress Playground preview. Each run failed closed on request index 0: three of four requests received `200`; the remaining request produced a `TypeError` before a status was available. No retry or bypass was added.
- `homeboy review test wp-codebox --placement local --changed-since origin/main --summary` failed for the same real-Playground integration; the direct behavioral and runtime bridge tests passed.

This remains a draft until the preview startup/transport failure is resolved with a real Playground integration.

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode assisted with repository inspection, implementation review, build and test execution, failure diagnosis, and PR drafting. Chris Huber authorized the changes and PR.