### PR TITLE
fix(bench): preserve skipped workload results

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -227,6 +227,13 @@ Metrics are numeric and named by the workload/runtime surface. WP Codebox record
 them; it does not decide whether a value is good, bad, passing, failing, or
 regressed.
 
+Workloads can return `{ "status": "skipped", "reason": "..." }` or
+`{ "skipped": "..." }`. The scenario then records `status: "skipped"` and
+`skip_reason`, has zero executed iterations, and emits no metrics or timing
+samples. The envelope's `completeness.required` summary marks the benchmark
+`incomplete` when any required scenario is skipped. Benchmark matrices preserve
+that result as an incomplete cell instead of treating it as a successful timing.
+
 ## Running Benchmarks
 
 Use a recipe workflow step with `wordpress.bench`:

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "test:native-agent-task-interruption": "node tests/execute-native-agent-task-interruption.test.mjs",
     "test:native-agent-task-playground-e2e": "tsx tests/execute-native-agent-task-playground-e2e.test.ts",
     "test:bench-command-step-behavior": "tsx tests/bench-command-step-behavior.test.ts",
+    "test:bench-skip-results": "tsx tests/bench-skip-results.test.ts",
     "test:external-http-load-integration": "npm run build && tsx tests/external-http-load.integration.test.ts",
     "test:external-http-load": "node --experimental-strip-types tests/external-http-load.test.ts",
     "test:generic-primitives": "npm run test:artifact-path-primitives && npm run test:browser-callback-materialization-contracts && npm run test:source-package-compiler-primitives && npm run test:bench-command-step-behavior && npm run test:generic-ability-runtime-run",

--- a/packages/cli/src/commands/benchmark.ts
+++ b/packages/cli/src/commands/benchmark.ts
@@ -253,7 +253,7 @@ async function runBenchmarkRecipeMatrix(options: BenchmarkMatrixOptions): Promis
     matrix,
     cells,
     benchResults: cells
-      .filter((cell): cell is BenchmarkMatrixCellResult & { benchResultsList: BenchResults[] } => cell.status === "succeeded" && Array.isArray(cell.benchResultsList))
+      .filter((cell): cell is BenchmarkMatrixCellResult & { benchResultsList: BenchResults[] } => cell.status !== "failed" && Array.isArray(cell.benchResultsList))
       .map((cell) => ({ cellId: cell.cell.id, cell: cell.cell, results: cell.benchResultsList })),
     diagnostics: cells.flatMap((cell) => cell.diagnostics),
     provenance: {
@@ -483,6 +483,7 @@ function printBenchmarkMatrixHumanOutput(output: BenchmarkMatrixRunOutput): void
   console.log(`Recipe: ${output.source.recipePath}`)
   console.log(`Cells: ${output.cells.length}`)
   console.log(`Succeeded: ${output.cells.filter((cell) => cell.status === "succeeded").length}`)
+  console.log(`Incomplete: ${output.cells.filter((cell) => cell.status === "incomplete").length}`)
   console.log(`Failed: ${output.cells.filter((cell) => cell.status === "failed").length}`)
 }
 

--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -55,6 +55,8 @@ export interface BenchmarkScenarioRecord {
   source: BenchmarkScenarioSource
   file?: string
   iterations: number
+  status?: "passed" | "skipped"
+  skip_reason?: string
   metrics: Record<string, BenchmarkMetricRecord>
   memory?: {
     peak_bytes?: number
@@ -65,6 +67,15 @@ export interface BenchmarkScenarioRecord {
   artifacts?: Record<string, BenchmarkArtifactRef | BenchmarkInlineArtifact>
   metadata?: Record<string, unknown>
   provenance?: Record<string, unknown>
+}
+
+export interface BenchmarkCompleteness {
+  status: "complete" | "incomplete"
+  required: {
+    total: number
+    passed: number
+    skipped: number
+  }
 }
 
 export interface BenchmarkRunProvenance {
@@ -98,6 +109,7 @@ export interface BenchResults {
     betweenScenarios: string
     events?: Array<Record<string, unknown>>
   }
+  completeness?: BenchmarkCompleteness
   scenarios: BenchmarkScenarioRecord[]
   diagnostics: BenchmarkDiagnostic[]
   artifacts?: Record<string, BenchmarkArtifactRef>
@@ -213,6 +225,7 @@ export function createBenchResultsJsonSchema(): BenchmarkJsonSchema {
       warmup_iterations: { type: "integer", minimum: 0 },
       lifecycle: { $ref: "#/$defs/lifecycle" },
       reset_policy: { $ref: "#/$defs/resetPolicy" },
+      completeness: { $ref: "#/$defs/completeness" },
       scenarios: { type: "array", items: { $ref: "#/$defs/scenario" } },
       diagnostics: { type: "array", items: { $ref: "#/$defs/diagnostic" } },
       artifacts: { $ref: "#/$defs/artifactMap" },
@@ -337,6 +350,24 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         events: { type: "array", items: { type: "object", additionalProperties: true } },
       },
     },
+    completeness: {
+      type: "object",
+      additionalProperties: false,
+      required: ["status", "required"],
+      properties: {
+        status: { enum: ["complete", "incomplete"] },
+        required: {
+          type: "object",
+          additionalProperties: false,
+          required: ["total", "passed", "skipped"],
+          properties: {
+            total: { type: "integer", minimum: 0 },
+            passed: { type: "integer", minimum: 0 },
+            skipped: { type: "integer", minimum: 0 },
+          },
+        },
+      },
+    },
     scenario: {
       type: "object",
       additionalProperties: false,
@@ -345,7 +376,9 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         id: { type: "string", minLength: 1 },
         source: { type: "string", minLength: 1 },
         file: { type: "string" },
-        iterations: { type: "integer", minimum: 1 },
+        iterations: { type: "integer", minimum: 0 },
+        status: { enum: ["passed", "skipped"] },
+        skip_reason: { type: "string", minLength: 1 },
         metrics: { type: "object", additionalProperties: { $ref: "#/$defs/metric" } },
         memory: {
           type: "object",

--- a/packages/runtime-core/src/benchmark-substrate.ts
+++ b/packages/runtime-core/src/benchmark-substrate.ts
@@ -57,8 +57,8 @@ export interface BenchmarkMatrixExpansion {
 }
 
 export interface BenchmarkMatrixCellDiagnostic {
-  type: "cell-failed"
-  severity: "error"
+  type: "cell-failed" | "cell-incomplete"
+  severity: "error" | "warning"
   cellId: string
   message: string
   code?: string
@@ -67,7 +67,7 @@ export interface BenchmarkMatrixCellDiagnostic {
 export interface BenchmarkMatrixCellResult {
   schema: "wp-codebox/benchmark-matrix-cell-result/v1"
   cell: BenchmarkMatrixCell
-  status: "succeeded" | "failed"
+  status: "succeeded" | "incomplete" | "failed"
   benchResults?: BenchmarkResultEnvelope
   benchResultsList?: BenchmarkResultEnvelope[]
   diagnostics: BenchmarkMatrixCellDiagnostic[]
@@ -181,23 +181,25 @@ export function expandBenchmarkMatrix(dimensions: readonly BenchmarkMatrixDimens
 }
 
 export function createBenchmarkMatrixCellResult(cell: BenchmarkMatrixCell, benchResults: BenchmarkResultEnvelope): BenchmarkMatrixCellResult {
-  return {
-    schema: "wp-codebox/benchmark-matrix-cell-result/v1",
-    cell,
-    status: "succeeded",
-    benchResults,
-    diagnostics: [],
-  }
+  const { benchResultsList: _benchResultsList, ...result } = createBenchmarkMatrixCellResults(cell, [benchResults])
+  return { ...result, benchResults }
 }
 
 export function createBenchmarkMatrixCellResults(cell: BenchmarkMatrixCell, benchResultsList: BenchmarkResultEnvelope[]): BenchmarkMatrixCellResult {
+  const incomplete = benchResultsList.some(benchmarkResultsIncomplete)
   return {
     schema: "wp-codebox/benchmark-matrix-cell-result/v1",
     cell,
-    status: "succeeded",
+    status: incomplete ? "incomplete" : "succeeded",
     ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
     benchResultsList,
-    diagnostics: [],
+    diagnostics: incomplete ? [{
+      type: "cell-incomplete",
+      severity: "warning",
+      cellId: cell.id,
+      message: `Benchmark matrix cell "${cell.id}" has skipped required scenarios.`,
+      code: "required-scenarios-skipped",
+    }] : [],
   }
 }
 
@@ -252,11 +254,16 @@ export async function executeBenchmarkMatrix(dimensions: readonly BenchmarkMatri
     matrix,
     cells,
     benchResults: cells
-      .filter((cell): cell is BenchmarkMatrixCellResult & { benchResultsList: BenchmarkResultEnvelope[] } => cell.status === "succeeded" && Array.isArray(cell.benchResultsList))
+      .filter((cell): cell is BenchmarkMatrixCellResult & { benchResultsList: BenchmarkResultEnvelope[] } => cell.status !== "failed" && Array.isArray(cell.benchResultsList))
       .map((cell) => ({ cellId: cell.cell.id, cell: cell.cell, results: cell.benchResultsList })),
     diagnostics: cells.flatMap((cell) => cell.diagnostics),
     provenance: matrixRunProvenance(options),
   }
+}
+
+function benchmarkResultsIncomplete(result: BenchmarkResultEnvelope): boolean {
+  const completeness = result.completeness
+  return typeof completeness === "object" && completeness !== null && (completeness as { status?: unknown }).status === "incomplete"
 }
 
 export function compareBenchmarkResults(baseline: BenchmarkResultEnvelope, candidate: BenchmarkResultEnvelope, options: CompareBenchmarkResultsOptions = {}): BenchmarkComparison {

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -107,7 +107,25 @@ function wp_codebox_bench_metrics(array $timings, array $metric_samples): array 
     return $metrics;
 }
 
-function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?array &$metadata, ?array &$artifacts = null, ?array &$steps = null, ?array &$diagnostics = null): void {
+function wp_codebox_bench_skip_reason($payload): ?string {
+    if (!is_array($payload)) {
+        return null;
+    }
+
+    $skipped = ($payload['status'] ?? null) === 'skipped' || array_key_exists('skipped', $payload);
+    if (!$skipped) {
+        return null;
+    }
+
+    foreach (array('skip_reason', 'reason', 'skipped') as $field) {
+        if (isset($payload[$field]) && is_string($payload[$field]) && trim($payload[$field]) !== '') {
+            return trim($payload[$field]);
+        }
+    }
+    return 'unspecified';
+}
+
+function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?array &$metadata, ?array &$artifacts = null, ?array &$steps = null, ?array &$diagnostics = null, bool $record_metrics = true): void {
     if (!is_array($payload)) {
         return;
     }
@@ -137,6 +155,9 @@ function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?arra
     }
 
     foreach ($metrics as $name => $value) {
+        if (!$record_metrics) {
+            continue;
+        }
         if (!is_string($name) || $name === '' || !is_numeric($value)) {
             continue;
         }
@@ -1728,6 +1749,12 @@ function wp_codebox_bench_run_configured_workload(array $workload, string $plugi
             if (isset($result['diagnostics']) && is_array($result['diagnostics'])) {
                 $payload['diagnostics'] = array_merge($payload['diagnostics'], $result['diagnostics']);
             }
+            $skip_reason = wp_codebox_bench_skip_reason($result);
+            if ($skip_reason !== null) {
+                $payload['status'] = 'skipped';
+                $payload['skip_reason'] = $skip_reason;
+                return $payload;
+            }
         }
     }
     wp_codebox_bench_assert_required_observations($workload, $payload);
@@ -1827,6 +1854,8 @@ foreach ($workload_files as $workload_file) {
     $artifacts = null;
     $steps = null;
     $diagnostics = null;
+    $status = 'passed';
+    $skip_reason = null;
 
     if (function_exists('memory_reset_peak_usage')) {
         memory_reset_peak_usage();
@@ -1844,6 +1873,14 @@ foreach ($workload_files as $workload_file) {
         $payload = $callable();
         $elapsed_ms = (hrtime(true) - $started) / 1000000;
 
+        $iteration_skip_reason = wp_codebox_bench_skip_reason($payload);
+        if ($iteration_skip_reason !== null) {
+            $status = 'skipped';
+            $skip_reason = $iteration_skip_reason;
+            wp_codebox_bench_record_payload($payload, $metric_samples, $metadata, $artifacts, $steps, $diagnostics, false);
+            break;
+        }
+
         if (!$is_warmup) {
             $timings[] = $elapsed_ms;
             wp_codebox_bench_record_payload($payload, $metric_samples, $metadata, $artifacts, $steps, $diagnostics);
@@ -1855,8 +1892,9 @@ foreach ($workload_files as $workload_file) {
         'id' => $scenario_id,
         'source' => 'in_tree',
         'file' => $relative_file,
-        'iterations' => $iterations,
-        'metrics' => wp_codebox_bench_metrics($timings, $metric_samples),
+        'iterations' => count($timings),
+        'status' => $status,
+        'metrics' => $status === 'skipped' ? new stdClass() : wp_codebox_bench_metrics($timings, $metric_samples),
         'memory' => array('peak_bytes' => memory_get_peak_usage(true)),
         'diagnostics' => array(),
         'provenance' => array('workload_file' => $relative_file),
@@ -1873,6 +1911,9 @@ foreach ($workload_files as $workload_file) {
     }
     if (is_array($diagnostics) && !empty($diagnostics)) {
         $scenario['diagnostics'] = $diagnostics;
+    }
+    if ($skip_reason !== null) {
+        $scenario['skip_reason'] = $skip_reason;
     }
 
     wp_codebox_bench_run_lifecycle_phase($bench_lifecycle, 'teardown', $plugin_path, $lifecycle_diagnostics);
@@ -1895,6 +1936,8 @@ foreach ($configured_workloads as $index => $workload) {
     $artifacts = null;
     $steps = null;
     $diagnostics = null;
+    $status = 'passed';
+    $skip_reason = null;
 
     wp_codebox_bench_reset($bench_reset_policy, 'betweenScenarios', $reset_events);
     wp_codebox_bench_run_lifecycle_phase($bench_lifecycle, 'prepare', $plugin_path, $lifecycle_diagnostics);
@@ -1906,6 +1949,13 @@ foreach ($configured_workloads as $index => $workload) {
         $started = hrtime(true);
         $payload = wp_codebox_bench_run_configured_workload($workload, $plugin_path);
         $elapsed_ms = (hrtime(true) - $started) / 1000000;
+        $iteration_skip_reason = wp_codebox_bench_skip_reason($payload);
+        if ($iteration_skip_reason !== null) {
+            $status = 'skipped';
+            $skip_reason = $iteration_skip_reason;
+            wp_codebox_bench_record_payload($payload, $metric_samples, $metadata, $artifacts, $steps, $diagnostics, false);
+            break;
+        }
         if (!$is_warmup) {
             $timings[] = $elapsed_ms;
             wp_codebox_bench_record_payload($payload, $metric_samples, $metadata, $artifacts, $steps, $diagnostics);
@@ -1914,8 +1964,9 @@ foreach ($configured_workloads as $index => $workload) {
     $scenario = array(
         'id' => $scenario_id,
         'source' => wp_codebox_bench_configured_scenario_source($workload),
-        'iterations' => $iterations,
-        'metrics' => wp_codebox_bench_metrics($timings, $metric_samples),
+        'iterations' => count($timings),
+        'status' => $status,
+        'metrics' => $status === 'skipped' ? new stdClass() : wp_codebox_bench_metrics($timings, $metric_samples),
         'memory' => array('peak_bytes' => memory_get_peak_usage(true)),
         'diagnostics' => array(),
         'provenance' => array('workload_index' => $index),
@@ -1932,6 +1983,9 @@ foreach ($configured_workloads as $index => $workload) {
     if (is_array($diagnostics) && !empty($diagnostics)) {
         $scenario['diagnostics'] = $diagnostics;
     }
+    if ($skip_reason !== null) {
+        $scenario['skip_reason'] = $skip_reason;
+    }
     wp_codebox_bench_run_lifecycle_phase($bench_lifecycle, 'teardown', $plugin_path, $lifecycle_diagnostics);
     $scenarios[] = $scenario;
 }
@@ -1942,6 +1996,12 @@ if (!empty($selected_scenario_ids) && empty($scenarios)) {
         'selected_scenario_ids' => array_keys($selected_scenario_ids),
     ), JSON_UNESCAPED_SLASHES));
 }
+
+$required_scenario_count = count($scenarios);
+$skipped_scenario_count = count(array_filter($scenarios, static function (array $scenario): bool {
+    return ($scenario['status'] ?? 'passed') === 'skipped';
+}));
+$passed_scenario_count = $required_scenario_count - $skipped_scenario_count;
 
 echo wp_json_encode(array(
     'schema' => 'wp-codebox/bench-results/v1',
@@ -1959,12 +2019,25 @@ echo wp_json_encode(array(
         'betweenScenarios' => wp_codebox_bench_normalize_reset_mode($bench_reset_policy['betweenScenarios'] ?? 'none'),
         'events' => $reset_events,
     ),
+    'completeness' => array(
+        'status' => $skipped_scenario_count > 0 ? 'incomplete' : 'complete',
+        'required' => array(
+            'total' => $required_scenario_count,
+            'passed' => $passed_scenario_count,
+            'skipped' => $skipped_scenario_count,
+        ),
+    ),
     'scenarios' => $scenarios,
     'diagnostics' => empty($scenarios) ? array(array(
         'severity' => 'warning',
         'code' => 'no-benchmark-scenarios',
         'message' => 'wordpress.bench completed without runnable scenarios.',
-    )) : array(),
+    )) : ($skipped_scenario_count > 0 ? array(array(
+        'severity' => 'warning',
+        'code' => 'required-scenarios-skipped',
+        'message' => 'wordpress.bench completed with skipped required scenarios.',
+        'details' => array('skipped' => $skipped_scenario_count, 'total' => $required_scenario_count),
+    )) : array()),
     'provenance' => array(
         'command' => 'wordpress.bench',
         'generated_at' => gmdate('c'),

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -58,6 +58,7 @@ const commandStepHelpers = [
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
 const configuredWorkloadHelpers = [
+  "wp_codebox_bench_skip_reason",
   "wp_codebox_bench_metric_prefix",
   "wp_codebox_bench_command_step_record",
   "wp_codebox_bench_run_command_step",

--- a/tests/bench-skip-results.test.ts
+++ b/tests/bench-skip-results.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+import { executeBenchmarkMatrix } from "../packages/runtime-core/src/benchmark-substrate.js"
+import { benchRunCode } from "../packages/runtime-playground/src/bench-command-handlers.js"
+
+const execFileAsync = promisify(execFile)
+
+async function withTempDir<T>(prefix: string, callback: (directory: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), prefix))
+  try {
+    return await callback(directory)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+async function runPhpFileJson<T>(path: string): Promise<T> {
+  const { stdout } = await execFileAsync("php", [path])
+  return JSON.parse(stdout) as T
+}
+
+const benchResult = await withTempDir("wp-codebox-bench-skips-", async (directory) => {
+  const wordpressDirectory = join(directory, "wordpress")
+  const pluginDirectory = join(directory, "plugins", "component")
+  await mkdir(join(wordpressDirectory, "wp-admin", "includes"), { recursive: true })
+  await mkdir(join(pluginDirectory, "tests", "bench"), { recursive: true })
+  await writeFile(join(wordpressDirectory, "wp-admin", "includes", "plugin.php"), "<?php\n")
+  await writeFile(join(pluginDirectory, "component.php"), "<?php\n/* Plugin Name: Component */\n")
+  await writeFile(join(pluginDirectory, "tests", "bench", "passed.php"), "<?php\nreturn static fn() => array('metrics' => array('work_count' => 1));\n")
+  await writeFile(join(pluginDirectory, "tests", "bench", "skipped.php"), "<?php\nreturn static fn() => array('skipped' => 'missing_bench_boot_phase', 'metrics' => array('work_count' => 99));\n")
+
+  const phpTestFile = join(directory, "bench-skips.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+define('ABSPATH', ${JSON.stringify(`${wordpressDirectory}/`)});
+define('WP_PLUGIN_DIR', ${JSON.stringify(join(directory, "plugins"))});
+$wp_filter = array();
+function wp_json_encode($value, $flags = 0) { return json_encode($value, $flags); }
+function sanitize_key($value) { return strtolower(preg_replace('/[^a-z0-9_-]/', '', $value)); }
+function is_plugin_active($plugin) { return false; }
+function activate_plugin($plugin) { return null; }
+function is_wp_error($value) { return false; }
+function get_option($name, $default = false) { return $default; }
+function update_option($name, $value) { return true; }
+function get_bloginfo($name) { return 'test'; }
+function did_action($hook) { return false; }
+${benchRunCode({ componentId: "component", pluginSlug: "component", iterations: 2, warmupIterations: 0, dependencySlugs: [], env: {}, bootstrapFiles: [], workloads: [], lifecycle: {}, resetPolicy: {} })}
+`,
+  )
+  return runPhpFileJson<{
+    completeness: { status: string; required: { total: number; passed: number; skipped: number } }
+    scenarios: Array<{ id: string; status: string; skip_reason?: string; iterations: number; metrics: Record<string, unknown> }>
+  }>(phpTestFile)
+})
+
+assert.deepEqual(benchResult.completeness, { status: "incomplete", required: { total: 2, passed: 1, skipped: 1 } })
+const passed = benchResult.scenarios.find((scenario) => scenario.id === "passed")
+const skipped = benchResult.scenarios.find((scenario) => scenario.id === "skipped")
+assert.equal(passed?.status, "passed")
+assert.equal(passed?.iterations, 2)
+assert.ok("duration" in (passed?.metrics ?? {}))
+assert.equal(skipped?.status, "skipped")
+assert.equal(skipped?.skip_reason, "missing_bench_boot_phase")
+assert.equal(skipped?.iterations, 0)
+assert.deepEqual(skipped?.metrics, {})
+
+const matrix = await executeBenchmarkMatrix(
+  [{ id: "outcome", values: [{ id: "passed" }, { id: "skipped" }, { id: "failed" }] }],
+  async (cell) => {
+    const outcome = cell.dimensions.outcome?.id
+    if (outcome === "failed") throw new Error("callable failed")
+    return {
+      scenarios: [],
+      completeness: outcome === "skipped"
+        ? { status: "incomplete", required: { total: 1, passed: 0, skipped: 1 } }
+        : { status: "complete", required: { total: 1, passed: 1, skipped: 0 } },
+    }
+  },
+)
+
+assert.deepEqual(matrix.cells.map((cell) => cell.status), ["succeeded", "incomplete", "failed"])
+assert.equal(matrix.benchResults.length, 2)
+assert.deepEqual(matrix.diagnostics.map((diagnostic) => diagnostic.type), ["cell-incomplete", "cell-failed"])
+
+console.log("bench skip results ok")


### PR DESCRIPTION
## Summary
- preserve explicit skipped workload status and reason through the generated benchmark dispatcher
- exclude skipped workload calls from timing and metric samples while reporting required-scenario completeness
- make benchmark matrix aggregation report incomplete cells separately from passed and failed cells

## Verification
- `/Users/chubes/Developer/wp-codebox/node_modules/.bin/tsx tests/bench-skip-results.test.ts`
- `NODE_PATH=/Users/chubes/Developer/wp-codebox/node_modules /Users/chubes/Developer/wp-codebox/node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli --force`

Fixes #2495.

## AI Assistance
GPT-5.6 Terra through OpenCode (openai/gpt-5.6-terra) implemented and verified this repair under Chris Huber's direction.