### PR TITLE
Allow explicit native MDI sources

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -169,6 +169,9 @@ function nativeMdiPlugin(plugins: readonly WorkspaceRecipeExtraPlugin[]): Worksp
   }
   const candidate = candidates[0]
   if (candidate) {
+    if (candidate.loadAs !== undefined && candidate.loadAs !== "plugin") {
+      throw new Error("mdi-native markdown-database-integration source must use loadAs=plugin")
+    }
     return {
       ...candidate,
       slug: "markdown-database-integration",

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -78,9 +78,16 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
   const pluginTarget = `/wordpress/wp-content/plugins/${pluginSlug}`
   const autoloadFile = options.autoloadFile ?? (options.bootstrapMode === "project" ? "" : "/wp-codebox-vendor/autoload.php")
   const services = phpunitRuntimeServices(options.databaseType, options.services)
-  const extraPlugins = options.databaseType === "mdi-native"
-    ? [...normalizeExtraPlugins(options.extra_plugins), mdiNativePlugin()]
-    : normalizeExtraPlugins(options.extra_plugins)
+  const extraPlugins = normalizeExtraPlugins(options.extra_plugins)
+  if (options.databaseType === "mdi-native") {
+    const nativePlugin = nativeMdiPlugin(extraPlugins)
+    const nativeIndex = extraPlugins.findIndex((plugin) => plugin.slug === "markdown-database-integration")
+    if (nativeIndex === -1) {
+      extraPlugins.push(nativePlugin)
+    } else {
+      extraPlugins[nativeIndex] = nativePlugin
+    }
+  }
 
   return {
     schema: "wp-codebox/workspace-recipe/v1",
@@ -155,7 +162,25 @@ function phpunitDependencyPlugins(mounts: readonly string[], plugins: readonly W
   })
 }
 
-function mdiNativePlugin(): WorkspaceRecipeExtraPlugin {
+function nativeMdiPlugin(plugins: readonly WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeExtraPlugin {
+  const candidates = plugins.filter((plugin) => plugin.slug === "markdown-database-integration")
+  if (candidates.length > 1) {
+    throw new Error("mdi-native accepts at most one markdown-database-integration extra plugin source")
+  }
+  const candidate = candidates[0]
+  if (candidate) {
+    return {
+      ...candidate,
+      slug: "markdown-database-integration",
+      pluginFile: "markdown-database-integration/markdown-database-integration.php",
+      activate: false,
+      metadata: {
+        ...candidate.metadata,
+        phase: "pre-install",
+        databaseDropIn: true,
+      },
+    }
+  }
   return {
     source: "wp-codebox:mdi-native",
     sha256: "b01d119e994c5c498373edcd2e3a62fcaec72bc8ad360f6c9a209341e1c5cc88",
@@ -297,6 +322,9 @@ function normalizeExtraPlugins(plugins: readonly WorkspaceRecipeExtraPlugin[] = 
     }
     if (plugin.composer !== undefined) {
       normalized.composer = plugin.composer
+    }
+    if (plugin.metadata !== undefined) {
+      normalized.metadata = plugin.metadata
     }
 
     return normalized

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -134,6 +134,14 @@ assert.throws(
   }),
   /at most one markdown-database-integration extra plugin source/,
 )
+assert.throws(
+  () => buildWordPressPhpunitRecipe({
+    pluginSlug: "example",
+    databaseType: "mdi-native",
+    extra_plugins: [{ source: "/tmp/mdi", slug: "markdown-database-integration", loadAs: "mu-plugin" }],
+  }),
+  /must use loadAs=plugin/,
+)
 assert.equal(buildWordPressPhpunitRecipe({ pluginSlug: "example", wordpressInstallMode: "do-not-attempt-installing" }).runtime?.wordpressInstallMode, "do-not-attempt-installing")
 const builderDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-phpunit-builder-"))
 try {

--- a/tests/runtime-services.test.ts
+++ b/tests/runtime-services.test.ts
@@ -103,6 +103,37 @@ try {
 } finally {
   await cleanupRecipePreparedSources([], preparedMdiPlugins)
 }
+const candidateMdiSource = "/tmp/markdown-database-integration"
+const candidateMdiRecipe = buildWordPressPhpunitRecipe({
+  pluginSlug: "example",
+  databaseType: "mdi-native",
+  extra_plugins: [{
+    source: candidateMdiSource,
+    slug: "markdown-database-integration",
+    sha256: "0123456789abcdef",
+    activate: true,
+    metadata: { revision: "548042c47efac724d13d25744765dbc65a851b20" },
+  }],
+})
+assert.deepEqual(candidateMdiRecipe.inputs?.extra_plugins, [{
+  source: candidateMdiSource,
+  slug: "markdown-database-integration",
+  sha256: "0123456789abcdef",
+  pluginFile: "markdown-database-integration/markdown-database-integration.php",
+  activate: false,
+  metadata: { revision: "548042c47efac724d13d25744765dbc65a851b20", phase: "pre-install", databaseDropIn: true },
+}])
+assert.throws(
+  () => buildWordPressPhpunitRecipe({
+    pluginSlug: "example",
+    databaseType: "mdi-native",
+    extra_plugins: [
+      { source: "/tmp/one", slug: "markdown-database-integration" },
+      { source: "/tmp/two", slug: "markdown-database-integration" },
+    ],
+  }),
+  /at most one markdown-database-integration extra plugin source/,
+)
 assert.equal(buildWordPressPhpunitRecipe({ pluginSlug: "example", wordpressInstallMode: "do-not-attempt-installing" }).runtime?.wordpressInstallMode, "do-not-attempt-installing")
 const builderDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-phpunit-builder-"))
 try {


### PR DESCRIPTION
## Summary
- Select one explicitly declared `markdown-database-integration` extra plugin as the `mdi-native` source.
- Preserve native pre-install, custom-drop-in, fixed entrypoint, and inactive-plugin invariants.
- Retain the pinned bundled archive when no candidate is supplied; supplied archive SHA-256 remains in the normal source-validation path.

Unblocks Automattic/markdown-database-integration#393 and follows its native parity prerequisite (#377).

## Validation
- `npx tsx tests/runtime-services.test.ts` on homeboy-lab

AI assistance disclosure: OpenCode with OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`) implemented the source-selection contract and focused tests under human direction.