### PR TITLE
Retain complete PHPUnit failure artifacts

### DIFF
--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -266,7 +266,10 @@ export class ArtifactBundleBuilder {
       ...source.browserManifestFiles(),
       ...source.observationManifestFiles(),
       ...commandArtifactManifestFiles(source.artifactRoot, source.commands),
-      ...phpunitCompletedResults.map(({ path }) => artifactManifestFile(join(source.artifactRoot, path), "test-results", "text/plain")),
+      ...phpunitCompletedResults.flatMap(({ path, junitPath }) => [
+        artifactManifestFile(join(source.artifactRoot, path), "test-results", "text/plain"),
+        ...(junitPath ? [artifactManifestFile(join(source.artifactRoot, junitPath), "test-results", "application/junit+xml")] : []),
+      ]),
       ...source.pluginCheckManifestFiles(),
       ...source.themeCheckManifestFiles(),
       ...runtimeSnapshotFiles,

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -529,6 +529,7 @@ $plugin_path = '/wordpress/wp-content/plugins/' . $plugin_slug;
 $runtime_cwd = ${JSON.stringify(options.cwd || `/wordpress/wp-content/plugins/${options.pluginSlug}`)};
 $result_file = ${JSON.stringify(options.resultFile ?? PLUGIN_PHPUNIT_RESULT_FILE)};
 $junit_file = ${JSON.stringify(options.junitFile ?? "/tmp/wp-codebox-phpunit-junit.xml")};
+@unlink($junit_file);
 $current_stage = 'preboot';
 $pg_stage_output_buffering = false;
 $autoload_file = ${JSON.stringify(options.autoloadFile)};

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -31,6 +31,8 @@ export interface PhpunitRunCodeOptions {
    * die() or exit().
    */
   resultFile?: string
+  /** Private JUnit report captured after PHPUnit finishes, including failures. */
+  junitFile?: string
 }
 
 export type PhpunitMultisitePreinstallCodeOptions = Pick<PhpunitRunCodeOptions, "testsDir" | "env" | "wpConfigDefines" | "databaseType" | "resultFile">
@@ -328,6 +330,8 @@ function phpunitArgsPhp(functionName: string, logFunction: string): string {
 
 function ${functionName}(array $argv) {
     $arguments = array('colors' => 'never', 'testdox' => true, 'verbose' => false, 'cacheResult' => false, 'cacheResultFile' => ${functionName}_private_cache_result_file(), 'extensions' => array());
+    global $junit_file;
+    $arguments['junitLogfile'] = $junit_file;
     $selected_testsuites = array();
     $args = array_slice($argv, 1);
     for ($i = 0; $i < count($args); $i++) {
@@ -524,6 +528,7 @@ $plugin_slug = ${JSON.stringify(options.pluginSlug)};
 $plugin_path = '/wordpress/wp-content/plugins/' . $plugin_slug;
 $runtime_cwd = ${JSON.stringify(options.cwd || `/wordpress/wp-content/plugins/${options.pluginSlug}`)};
 $result_file = ${JSON.stringify(options.resultFile ?? PLUGIN_PHPUNIT_RESULT_FILE)};
+$junit_file = ${JSON.stringify(options.junitFile ?? "/tmp/wp-codebox-phpunit-junit.xml")};
 $current_stage = 'preboot';
 $pg_stage_output_buffering = false;
 $autoload_file = ${JSON.stringify(options.autoloadFile)};

--- a/packages/runtime-playground/src/phpunit-test-results.ts
+++ b/packages/runtime-playground/src/phpunit-test-results.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { join, relative } from "node:path"
 import type { ArtifactTestResults, ExecutionResult } from "@automattic/wp-codebox-core"
 
@@ -19,6 +19,7 @@ export interface PhpunitCompletedResult {
 export interface CapturedPhpunitCompletedResult {
   path: string
   result: PhpunitCompletedResult
+  junitPath?: string
 }
 
 export function parsePhpunitCompletedResult(log: string): PhpunitCompletedResult | undefined {
@@ -82,7 +83,11 @@ export async function readCapturedPhpunitCompletedResults(artifactRoot: string):
 
   for (const path of paths) {
     const result = parsePhpunitCompletedResult(await readFile(path, "utf8"))
-    if (result) results.push({ path: relative(artifactRoot, path), result })
+    if (result) {
+      const relativePath = relative(artifactRoot, path)
+      const junitPath = phpunitJunitPath(relativePath)
+      results.push({ path: relativePath, result, ...(await artifactFileExists(join(artifactRoot, junitPath)) ? { junitPath } : {}) })
+    }
   }
   return results
 }
@@ -92,12 +97,13 @@ export function buildPhpunitTestResults(commands: ExecutionResult[], completed: 
   const rawLogReferences = [
     { path: "commands.jsonl", kind: "commands-jsonl" },
     { path: "logs/commands.log", kind: "commands-log" },
-    ...completed.flatMap(({ path }) => [
+    ...completed.flatMap(({ path, junitPath }) => [
       { path, kind: "phpunit-result" },
       { path: phpunitDiagnosticPath(path), kind: "phpunit-output" },
+      ...(junitPath ? [{ path: junitPath, kind: "phpunit-junit" }] : []),
     ]),
   ]
-  const suites: ArtifactTestResults["suites"] = completed.map(({ path, result }, index) => ({
+  const suites: ArtifactTestResults["suites"] = completed.map(({ path, result, junitPath }, index) => ({
     name: completed.length === 1 ? "wordpress.phpunit" : `wordpress.phpunit:${index + 1}`,
     status: result.status,
     tests: result.total,
@@ -105,7 +111,7 @@ export function buildPhpunitTestResults(commands: ExecutionResult[], completed: 
     failed: result.failed,
     skipped: result.skipped,
     unknown: 0,
-    rawLogReferences: [{ path, kind: "phpunit-result" }, { path: phpunitDiagnosticPath(path), kind: "phpunit-output" }, { path: "logs/commands.log", kind: "commands-log" }],
+    rawLogReferences: [{ path, kind: "phpunit-result" }, { path: phpunitDiagnosticPath(path), kind: "phpunit-output" }, ...(junitPath ? [{ path: junitPath, kind: "phpunit-junit" }] : []), { path: "logs/commands.log", kind: "commands-log" }],
   }))
   for (let index = completed.length; index < phpunitCommands.length; index += 1) {
     suites.push({
@@ -177,4 +183,16 @@ function completedResult(total: number, assertions: number, failures: number, er
 
 export function phpunitDiagnosticPath(completedResultPath: string): string {
   return completedResultPath.replace(/\.wp-codebox-result\.txt$/, ".pg-test-result.txt")
+}
+
+export function phpunitJunitPath(completedResultPath: string): string {
+  return completedResultPath.replace(/\.wp-codebox-result\.txt$/, ".wp-codebox-junit.xml")
+}
+
+async function artifactFileExists(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
 }

--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -121,7 +121,7 @@ export function completedPlaygroundCommandError(command: string, cause: unknown)
   return new PlaygroundCommandError(command, {
     cause: commandCause,
     exitCode: playgroundNonzeroExitCode(commandCause) ?? playgroundNonzeroExitCode(cause) ?? 1,
-    errors: diagnostics.length > 0 ? diagnostics.join("\n") : errorMessage(commandCause),
+    errors: diagnostics.length > 0 ? diagnostics.join("\n") : truncateDiagnostic(redactDiagnosticText(errorMessage(commandCause))) ?? "Playground command failed without diagnostics.",
     text: "",
   })
 }

--- a/packages/runtime-playground/src/runtime-diagnostics.ts
+++ b/packages/runtime-playground/src/runtime-diagnostics.ts
@@ -34,6 +34,7 @@ export async function persistPluginPhpunitJunitResult(server: PlaygroundCliServe
   }
 
   try {
+    // Playground exposes only whole-file reads; this caps retained host output, not VFS read allocation.
     const contents = await server.playground.readFileAsText(vfsPath)
     return await captureArtifactFile({
       root: join(artifactRoot, "files", "phpunit", ...(namespace ? [namespace] : [])),

--- a/packages/runtime-playground/src/runtime-diagnostics.ts
+++ b/packages/runtime-playground/src/runtime-diagnostics.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join } from "node:path"
-import { captureArtifactFile, type MountSpec } from "@automattic/wp-codebox-core"
+import { captureArtifactFile, DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, type CapturedArtifactFile, type MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { extractPhpunitFailureMessage } from "./playground-command-errors.js"
 import { PHPUNIT_COMPLETED_RESULT_PREFIX, parsePhpunitCompletedResult, type PhpunitCompletedResult } from "./phpunit-test-results.js"
@@ -15,6 +15,26 @@ export interface PhpunitDiscoveryResult {
 
 export async function persistPluginPhpunitResult(server: PlaygroundCliServer, vfsPath: string, artifactRoot: string, namespace?: string): Promise<void> {
   await persistPhpunitResult(server, vfsPath, join(artifactRoot, "files", "phpunit", ...(namespace ? [namespace] : []), ".pg-test-result.txt"))
+}
+
+export async function persistPluginPhpunitJunitResult(server: PlaygroundCliServer, vfsPath: string, artifactRoot: string, namespace?: string): Promise<CapturedArtifactFile | undefined> {
+  if (!server.playground.readFileAsText) return undefined
+
+  try {
+    const contents = await server.playground.readFileAsText(vfsPath)
+    return await captureArtifactFile({
+      root: join(artifactRoot, "files", "phpunit", ...(namespace ? [namespace] : [])),
+      path: ".wp-codebox-junit.xml",
+      kind: "test-results",
+      contentType: "application/junit+xml",
+      contents,
+      maxBytes: 8 * DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES,
+      redaction: { policy: "applied", sensitive: true, reason: "PHPUnit JUnit failure details are redacted and bounded before private artifact capture." },
+      provenance: { source: "wordpress-playground", operation: "persist-phpunit-junit-result", id: vfsPath },
+    })
+  } catch {
+    return undefined
+  }
 }
 
 export async function persistPluginPhpunitCompletedResult(artifactRoot: string, result: PhpunitCompletedResult, namespace?: string): Promise<void> {

--- a/packages/runtime-playground/src/runtime-diagnostics.ts
+++ b/packages/runtime-playground/src/runtime-diagnostics.ts
@@ -18,7 +18,7 @@ export async function persistPluginPhpunitResult(server: PlaygroundCliServer, vf
 }
 
 export async function clearPluginPhpunitJunitResult(server: PlaygroundCliServer, vfsPath: string): Promise<void> {
-  if (!server.playground.unlink) return
+  if (!server.playground?.unlink) return
 
   try {
     await server.playground.unlink(vfsPath)

--- a/packages/runtime-playground/src/runtime-diagnostics.ts
+++ b/packages/runtime-playground/src/runtime-diagnostics.ts
@@ -17,8 +17,21 @@ export async function persistPluginPhpunitResult(server: PlaygroundCliServer, vf
   await persistPhpunitResult(server, vfsPath, join(artifactRoot, "files", "phpunit", ...(namespace ? [namespace] : []), ".pg-test-result.txt"))
 }
 
-export async function persistPluginPhpunitJunitResult(server: PlaygroundCliServer, vfsPath: string, artifactRoot: string, namespace?: string): Promise<CapturedArtifactFile | undefined> {
-  if (!server.playground.readFileAsText) return undefined
+export async function clearPluginPhpunitJunitResult(server: PlaygroundCliServer, vfsPath: string): Promise<void> {
+  if (!server.playground.unlink) return
+
+  try {
+    await server.playground.unlink(vfsPath)
+  } catch {
+    // A missing report is expected before the first PHPUnit command.
+  }
+}
+
+export async function persistPluginPhpunitJunitResult(server: PlaygroundCliServer, vfsPath: string, artifactRoot: string, namespace?: string): Promise<CapturedArtifactFile> {
+  const artifactPath = join("files", "phpunit", ...(namespace ? [namespace] : []), ".wp-codebox-junit.xml")
+  if (!server.playground.readFileAsText) {
+    return { schema: "wp-codebox/captured-artifact-file/v1", status: "failed", path: artifactPath, reason: "runtime-read-unavailable" }
+  }
 
   try {
     const contents = await server.playground.readFileAsText(vfsPath)
@@ -33,8 +46,13 @@ export async function persistPluginPhpunitJunitResult(server: PlaygroundCliServe
       provenance: { source: "wordpress-playground", operation: "persist-phpunit-junit-result", id: vfsPath },
     })
   } catch {
-    return undefined
+    return { schema: "wp-codebox/captured-artifact-file/v1", status: "failed", path: artifactPath, reason: "runtime-read-failed" }
   }
+}
+
+export function phpunitJunitCaptureDiagnostic(capture: CapturedArtifactFile): string | undefined {
+  if (capture.status === "captured") return undefined
+  return `JUnit artifact capture ${capture.status}: ${capture.reason ?? "unknown"}.`
 }
 
 export async function persistPluginPhpunitCompletedResult(artifactRoot: string, result: PhpunitCompletedResult, namespace?: string): Promise<void> {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -53,7 +53,7 @@ import {
 import { bootstrapAbilityPhpCode, bootstrapPhpCode, phpCodeFromArgs, splitLeadingStrictTypesDeclare } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk, attachPlaygroundDiagnostics, completedPlaygroundCommandError, playgroundCommandDiagnosticText, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
-import { persistCorePhpunitResult, persistPluginPhpunitCompletedResult, persistPluginPhpunitJunitResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitCompletedResult, readPluginPhpunitDiagnostic, readPluginPhpunitDiscoveryResult } from "./runtime-diagnostics.js"
+import { clearPluginPhpunitJunitResult, persistCorePhpunitResult, persistPluginPhpunitCompletedResult, persistPluginPhpunitJunitResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, phpunitJunitCaptureDiagnostic, readCorePhpunitDiagnostic, readPluginPhpunitCompletedResult, readPluginPhpunitDiagnostic, readPluginPhpunitDiscoveryResult } from "./runtime-diagnostics.js"
 import { phpunitExecutionSemantics, requiresManagedMultisitePreinstall } from "./phpunit-command-semantics.js"
 import { parsePhpunitOutput } from "./phpunit-test-results.js"
 import { runRuntimeExternalHttpLoad, waitForRuntimePreviewReady, type RuntimeExternalHttpLoadResult } from "./external-http-load.js"
@@ -1007,6 +1007,7 @@ export async function runPhpunitCommand({
     throw new Error("wordpress.phpunit requires plugin-slug=<slug> when code/code-file is not provided")
   }
   let response: PlaygroundRunResponse
+  await clearPluginPhpunitJunitResult(server, junitFile)
   try {
     const bootstrapArgs = explicitCode ? args : [...args, "bootstrap=runtime-only"]
     if (managedMultisitePreinstalled) {
@@ -1023,14 +1024,16 @@ export async function runPhpunitCommand({
     response = await runPlaygroundCommand("wordpress.phpunit", server, { code: bootstrapPhpCode(runtimeSpec, code, bootstrapArgs, undefined, resultFile) })
   } catch (error) {
     // Capture before the runtime teardown can reset the command VFS.
-    await persistPluginPhpunitJunitResult(server, junitFile, artifactRoot, processIdentity)
+    const junitCapture = await persistPluginPhpunitJunitResult(server, junitFile, artifactRoot, processIdentity)
     await persistPluginPhpunitResult(server, resultFile, artifactRoot, processIdentity)
     await persistVfsDiagnosticFileToHost(server, resultFile, diagnosticHostFile, mounts)
     await captureCommandResultPaths(server, spec, artifactRoot)
     const completed = await readPluginPhpunitCompletedResult(server, resultFile) ?? parsePhpunitOutput(playgroundCommandDiagnosticText(error))
     if (completed) {
       await persistPluginPhpunitCompletedResult(artifactRoot, completed, processIdentity)
-      throw attachPlaygroundDiagnostics(completedPlaygroundCommandError("wordpress.phpunit", error), "wordpress.phpunit completed result", `completed ${completed.status}; total ${completed.total}; failed ${completed.failed}; skipped ${completed.skipped}; failures ${completed.failures}; errors ${completed.errors}`)
+      const completedError = attachPlaygroundDiagnostics(completedPlaygroundCommandError("wordpress.phpunit", error), "wordpress.phpunit completed result", `completed ${completed.status}; total ${completed.total}; failed ${completed.failed}; skipped ${completed.skipped}; failures ${completed.failures}; errors ${completed.errors}`)
+      const diagnostic = phpunitJunitCaptureDiagnostic(junitCapture)
+      throw diagnostic ? attachPlaygroundDiagnostics(completedError, "wordpress.phpunit JUnit artifact", diagnostic) : completedError
     }
     const structured = await readPluginPhpunitDiagnostic(server, resultFile)
     if (structured) {
@@ -1039,7 +1042,7 @@ export async function runPhpunitCommand({
     throw error
   }
 
-  await persistPluginPhpunitJunitResult(server, junitFile, artifactRoot, processIdentity)
+  const junitCapture = await persistPluginPhpunitJunitResult(server, junitFile, artifactRoot, processIdentity)
   await persistPluginPhpunitResult(server, resultFile, artifactRoot, processIdentity)
   await persistVfsDiagnosticFileToHost(server, resultFile, diagnosticHostFile, mounts)
   const structured = await readPluginPhpunitDiagnostic(server, resultFile)
@@ -1051,6 +1054,10 @@ export async function runPhpunitCommand({
   try {
     assertPlaygroundResponseOk("wordpress.phpunit", response)
   } catch (error) {
+    const diagnostic = phpunitJunitCaptureDiagnostic(junitCapture)
+    if (diagnostic) {
+      throw attachPlaygroundDiagnostics(error, "wordpress.phpunit JUnit artifact", diagnostic)
+    }
     if (structured) {
       throw attachPlaygroundDiagnostics(error, "wordpress.phpunit structured diagnostics", structured)
     }

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -1055,13 +1055,11 @@ export async function runPhpunitCommand({
     assertPlaygroundResponseOk("wordpress.phpunit", response)
   } catch (error) {
     const diagnostic = phpunitJunitCaptureDiagnostic(junitCapture)
-    if (diagnostic) {
-      throw attachPlaygroundDiagnostics(error, "wordpress.phpunit JUnit artifact", diagnostic)
-    }
     if (structured) {
-      throw attachPlaygroundDiagnostics(error, "wordpress.phpunit structured diagnostics", structured)
+      const structuredError = attachPlaygroundDiagnostics(error, "wordpress.phpunit structured diagnostics", structured)
+      throw diagnostic ? attachPlaygroundDiagnostics(structuredError, "wordpress.phpunit JUnit artifact", diagnostic) : structuredError
     }
-    throw error
+    throw diagnostic ? attachPlaygroundDiagnostics(error, "wordpress.phpunit JUnit artifact", diagnostic) : error
   }
 
   if (discoveryOnly) {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -939,6 +939,9 @@ export async function runPhpunitCommand({
   spec: ExecutionSpec
 }): Promise<string | RuntimeCommandResultEnvelope> {
   const args = spec.args ?? []
+  const processIdentity = boundedProcessIdentity(spec.processIdentity)
+  const junitFile = processIdentity ? `/tmp/wp-codebox-phpunit-junit-${processIdentity}.xml` : "/tmp/wp-codebox-phpunit-junit.xml"
+  await clearPluginPhpunitJunitResult(server, junitFile)
   const phpunitXmlArg = argValue(args, "phpunit-xml")
   const explicitCode = argValue(args, "code") || argValue(args, "code-file")
   const pluginSlug = argValue(args, "plugin-slug")?.trim() || ""
@@ -962,10 +965,8 @@ export async function runPhpunitCommand({
   }
   const autoloadFile = argValue(args, "autoload-file")?.trim() || (bootstrapMode === "project" ? "" : "/wp-codebox-vendor/autoload.php")
   const autoloadFileRole = argValue(args, "autoload-file-role")?.trim() === "harness" ? "harness" : undefined
-  const processIdentity = boundedProcessIdentity(spec.processIdentity)
   const managedMultisitePreinstalled = !explicitCode && !discoveryOnly && requiresManagedMultisitePreinstall(args, runtimeSpec)
   const resultFile = processIdentity ? `/tmp/wp-codebox-phpunit-result-${processIdentity}.txt` : PLUGIN_PHPUNIT_RESULT_FILE
-  const junitFile = processIdentity ? `/tmp/wp-codebox-phpunit-junit-${processIdentity}.xml` : "/tmp/wp-codebox-phpunit-junit.xml"
   const diagnosticHostFile = `/wordpress/wp-content/plugins/${pluginSlug}/.pg-test-result${processIdentity ? `-${processIdentity}` : ""}.txt`
   const code = explicitCode ? await phpCodeFromArgs(args, "wordpress.phpunit", false) : phpunitRunCode({
     pluginSlug,
@@ -1007,7 +1008,6 @@ export async function runPhpunitCommand({
     throw new Error("wordpress.phpunit requires plugin-slug=<slug> when code/code-file is not provided")
   }
   let response: PlaygroundRunResponse
-  await clearPluginPhpunitJunitResult(server, junitFile)
   try {
     const bootstrapArgs = explicitCode ? args : [...args, "bootstrap=runtime-only"]
     if (managedMultisitePreinstalled) {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -53,7 +53,7 @@ import {
 import { bootstrapAbilityPhpCode, bootstrapPhpCode, phpCodeFromArgs, splitLeadingStrictTypesDeclare } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk, attachPlaygroundDiagnostics, completedPlaygroundCommandError, playgroundCommandDiagnosticText, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
-import { persistCorePhpunitResult, persistPluginPhpunitCompletedResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitCompletedResult, readPluginPhpunitDiagnostic, readPluginPhpunitDiscoveryResult } from "./runtime-diagnostics.js"
+import { persistCorePhpunitResult, persistPluginPhpunitCompletedResult, persistPluginPhpunitJunitResult, persistPluginPhpunitResult, persistVfsDiagnosticFileToHost, readCorePhpunitDiagnostic, readPluginPhpunitCompletedResult, readPluginPhpunitDiagnostic, readPluginPhpunitDiscoveryResult } from "./runtime-diagnostics.js"
 import { phpunitExecutionSemantics, requiresManagedMultisitePreinstall } from "./phpunit-command-semantics.js"
 import { parsePhpunitOutput } from "./phpunit-test-results.js"
 import { runRuntimeExternalHttpLoad, waitForRuntimePreviewReady, type RuntimeExternalHttpLoadResult } from "./external-http-load.js"
@@ -965,6 +965,7 @@ export async function runPhpunitCommand({
   const processIdentity = boundedProcessIdentity(spec.processIdentity)
   const managedMultisitePreinstalled = !explicitCode && !discoveryOnly && requiresManagedMultisitePreinstall(args, runtimeSpec)
   const resultFile = processIdentity ? `/tmp/wp-codebox-phpunit-result-${processIdentity}.txt` : PLUGIN_PHPUNIT_RESULT_FILE
+  const junitFile = processIdentity ? `/tmp/wp-codebox-phpunit-junit-${processIdentity}.xml` : "/tmp/wp-codebox-phpunit-junit.xml"
   const diagnosticHostFile = `/wordpress/wp-content/plugins/${pluginSlug}/.pg-test-result${processIdentity ? `-${processIdentity}` : ""}.txt`
   const code = explicitCode ? await phpCodeFromArgs(args, "wordpress.phpunit", false) : phpunitRunCode({
     pluginSlug,
@@ -1000,6 +1001,7 @@ export async function runPhpunitCommand({
     databaseType,
     managedMultisitePreinstalled,
     resultFile,
+    junitFile,
   })
   if (!explicitCode && !pluginSlug) {
     throw new Error("wordpress.phpunit requires plugin-slug=<slug> when code/code-file is not provided")
@@ -1020,6 +1022,8 @@ export async function runPhpunitCommand({
     }
     response = await runPlaygroundCommand("wordpress.phpunit", server, { code: bootstrapPhpCode(runtimeSpec, code, bootstrapArgs, undefined, resultFile) })
   } catch (error) {
+    // Capture before the runtime teardown can reset the command VFS.
+    await persistPluginPhpunitJunitResult(server, junitFile, artifactRoot, processIdentity)
     await persistPluginPhpunitResult(server, resultFile, artifactRoot, processIdentity)
     await persistVfsDiagnosticFileToHost(server, resultFile, diagnosticHostFile, mounts)
     await captureCommandResultPaths(server, spec, artifactRoot)
@@ -1035,6 +1039,7 @@ export async function runPhpunitCommand({
     throw error
   }
 
+  await persistPluginPhpunitJunitResult(server, junitFile, artifactRoot, processIdentity)
   await persistPluginPhpunitResult(server, resultFile, artifactRoot, processIdentity)
   await persistVfsDiagnosticFileToHost(server, resultFile, diagnosticHostFile, mounts)
   const structured = await readPluginPhpunitDiagnostic(server, resultFile)

--- a/tests/phpunit-runtime-failure-diagnostics.test.ts
+++ b/tests/phpunit-runtime-failure-diagnostics.test.ts
@@ -32,12 +32,27 @@ await assert.rejects(
   (error: Error) => {
     assert.match(error.message, /wordpress\.phpunit failed with exit code 1/)
     assert.match(error.message, /wordpress\.phpunit structured diagnostics/)
+    assert.match(error.message, /wordpress\.phpunit JUnit artifact/)
     assert.match(error.message, /Bootstrap failed with token: \[redacted\]/)
     assert.match(error.message, /\[diagnostic truncated\]/)
     assert.doesNotMatch(error.message, new RegExp(secret))
     return true
   },
 )
+
+const clearedJunitFiles: string[] = []
+await assert.rejects(
+  () => runPhpunitCommand({
+    artifactRoot,
+    mounts: [],
+    runPlaygroundCommand: async () => ({ exitCode: 0, errors: "", text: "" }),
+    runtimeSpec: wordpressRuntimeSpec({ commands: ["wordpress.phpunit"] }),
+    server: { playground: { unlink: async (path: string) => { clearedJunitFiles.push(path) } } } as never,
+    spec: { command: "wordpress.phpunit", args: ["discovery-only=true", "code=<?php"] },
+  }),
+  /discovery-only cannot be combined/,
+)
+assert.deepEqual(clearedJunitFiles, ["/tmp/wp-codebox-phpunit-junit.xml"])
 
 const captured = await readFile(join(artifactRoot, "files", "phpunit", ".pg-test-result.txt"), "utf8")
 assert.match(captured, /Bootstrap failed with token: \[redacted\]/)

--- a/tests/playground-phpunit-readonly-cache.integration.test.ts
+++ b/tests/playground-phpunit-readonly-cache.integration.test.ts
@@ -120,7 +120,7 @@ try {
   assert.equal(passingEvidence.status, "passed")
   assert.deepEqual(passingEvidence.summary, { total: 6, passed: 6, failed: 0, skipped: 0, unknown: 0 })
 
-  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_passes(): void { $this->assertTrue(true); } public static function failure_cases(): array { return array_map(static fn(int $index): array => ['fixture-case-' . $index, $index], range(1, 51)); } /** @dataProvider failure_cases */ public function test_large_failure_output(string $identity): void { $this->fail($identity . ' Authorization: Bearer literal-credential-for-redaction ' . str_repeat('response-cap-detail ', 256)); } public function test_skips(): void { $this->markTestSkipped('fixture skipped'); } }\n")
+  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_passes(): void { $this->assertTrue(true); } public static function failure_cases(): array { return array_map(static fn(int $index): array => ['fixture-case-' . $index, $index], range(1, 49)); } /** @dataProvider failure_cases */ public function test_large_failure_output(string $identity): void { $this->fail($identity . ' Authorization: Bearer literal-credential-for-redaction ' . str_repeat('response-cap-detail ', 256)); } public function test_error_output(): void { throw new RuntimeException('fixture-error-50 credential=literal-credential-for-redaction ' . str_repeat('response-cap-detail ', 256)); } public function test_fixture_skip_51(): void { $this->markTestSkipped('fixture-skip-51'); } }\n")
   const failedOutput = await runFailedRecipe()
   assert.equal(failedOutput.success, false)
   assert.match(failedOutput.error?.message ?? "", /failureClassification=runtime-command-failure/)
@@ -130,15 +130,17 @@ try {
   const failedRuntime = JSON.parse(await readFile(join(failingArtifactsPath, "latest-runtime.json"), "utf8")) as { paths?: { runtimeDirectory?: string } }
   const failingEvidence = await readTestResults(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory)
   assert.equal(failingEvidence.status, "failed")
-  assert.deepEqual(failingEvidence.summary, { total: 53, passed: 1, failed: 51, skipped: 1, unknown: 0 })
+  assert.deepEqual(failingEvidence.summary, { total: 52, passed: 1, failed: 50, skipped: 1, unknown: 0 })
   assert(failingEvidence.rawLogReferences.some((reference) => reference.path === "files/phpunit/.pg-test-result.txt"))
   assert(failingEvidence.rawLogReferences.some((reference) => reference.path === "files/phpunit/.wp-codebox-junit.xml"))
   const junitPath = join(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory ?? "", "files/phpunit/.wp-codebox-junit.xml")
   const junit = await readFile(junitPath, "utf8")
   assert(Buffer.byteLength(junit) > 20_000, "JUnit artifact must retain failure detail beyond the bounded command response")
-  for (let index = 1; index <= 51; index += 1) {
+  for (let index = 1; index <= 49; index += 1) {
     assert.match(junit, new RegExp(`fixture-case-${index}`), `JUnit artifact must retain fixture-case-${index}`)
   }
+  assert.match(junit, /fixture-error-50/)
+  assert.match(junit, /name="test_fixture_skip_51" class="ReadonlyCacheTest"/)
   assert.doesNotMatch(junit, /literal-credential-for-redaction/)
   const manifest = JSON.parse(await readFile(join(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory ?? "", "manifest.json"), "utf8")) as { files?: Array<{ path?: string, contentType?: string, sha256?: { value?: string } }> }
   const junitManifest = manifest.files?.find((file) => file.path === "files/phpunit/.wp-codebox-junit.xml")

--- a/tests/playground-phpunit-readonly-cache.integration.test.ts
+++ b/tests/playground-phpunit-readonly-cache.integration.test.ts
@@ -120,16 +120,30 @@ try {
   assert.equal(passingEvidence.status, "passed")
   assert.deepEqual(passingEvidence.summary, { total: 6, passed: 6, failed: 0, skipped: 0, unknown: 0 })
 
-  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_passes(): void { $this->assertTrue(true); } public function test_fails(): void { $this->assertTrue(false); } public function test_errors(): void { throw new RuntimeException('fixture error'); } public function test_skips(): void { $this->markTestSkipped('fixture skipped'); } }\n")
+  await writeFile(join(plugin, "tests", "ReadonlyCacheTest.php"), "<?php\nclass ReadonlyCacheTest extends WP_UnitTestCase { public function test_passes(): void { $this->assertTrue(true); } public static function failure_cases(): array { return array_map(static fn(int $index): array => ['fixture-case-' . $index, $index], range(1, 51)); } /** @dataProvider failure_cases */ public function test_large_failure_output(string $identity): void { $this->fail($identity . ' Authorization: Bearer literal-credential-for-redaction ' . str_repeat('response-cap-detail ', 256)); } public function test_skips(): void { $this->markTestSkipped('fixture skipped'); } }\n")
   const failedOutput = await runFailedRecipe()
   assert.equal(failedOutput.success, false)
   assert.match(failedOutput.error?.message ?? "", /failureClassification=runtime-command-failure/)
   assert.doesNotMatch(failedOutput.error?.message ?? "", /crashed before producing a structured response/)
+  assert(Buffer.byteLength(failedOutput.error?.message ?? "") <= 50_000, "failed command response must remain bounded")
+  assert.doesNotMatch(failedOutput.error?.message ?? "", /literal-credential-for-redaction/)
   const failedRuntime = JSON.parse(await readFile(join(failingArtifactsPath, "latest-runtime.json"), "utf8")) as { paths?: { runtimeDirectory?: string } }
   const failingEvidence = await readTestResults(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory)
   assert.equal(failingEvidence.status, "failed")
-  assert.deepEqual(failingEvidence.summary, { total: 4, passed: 1, failed: 2, skipped: 1, unknown: 0 })
+  assert.deepEqual(failingEvidence.summary, { total: 53, passed: 1, failed: 51, skipped: 1, unknown: 0 })
   assert(failingEvidence.rawLogReferences.some((reference) => reference.path === "files/phpunit/.pg-test-result.txt"))
+  assert(failingEvidence.rawLogReferences.some((reference) => reference.path === "files/phpunit/.wp-codebox-junit.xml"))
+  const junitPath = join(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory ?? "", "files/phpunit/.wp-codebox-junit.xml")
+  const junit = await readFile(junitPath, "utf8")
+  assert(Buffer.byteLength(junit) > 20_000, "JUnit artifact must retain failure detail beyond the bounded command response")
+  for (let index = 1; index <= 51; index += 1) {
+    assert.match(junit, new RegExp(`fixture-case-${index}`), `JUnit artifact must retain fixture-case-${index}`)
+  }
+  assert.doesNotMatch(junit, /literal-credential-for-redaction/)
+  const manifest = JSON.parse(await readFile(join(failingArtifactsPath, failedRuntime.paths?.runtimeDirectory ?? "", "manifest.json"), "utf8")) as { files?: Array<{ path?: string, contentType?: string, sha256?: { value?: string } }> }
+  const junitManifest = manifest.files?.find((file) => file.path === "files/phpunit/.wp-codebox-junit.xml")
+  assert.equal(junitManifest?.contentType, "application/junit+xml")
+  assert.match(junitManifest?.sha256?.value ?? "", /^[a-f0-9]{64}$/)
 } finally {
   await rm(root, { recursive: true, force: true })
 }


### PR DESCRIPTION
## Summary

Retain PHPUnit JUnit XML as a bounded, redacted artifact before runtime teardown on success and failure. Test-results and the manifest reference the artifact with `application/junit+xml` and SHA-256, while command failure responses remain bounded.

Clear prior reports before each invocation and validation path so a failed or discovery-only command cannot reuse stale testcase evidence. Capture failures retain structured diagnostics. The capture bound applies to retained output; the Playground text-read API does not itself bound allocation before reading.

## Verification

- Final head `f09b8b5117990c199aa0fced150e2f2322de8742`: all five GitHub checks passed.
- Focused structured-evidence, result-path and failure-diagnostics tests passed.
- Real failed-PHPUnit integration verifies complete failure/error identities beyond the response cap, XML metadata/digest, credential redaction and stale-report cleanup.
- Real MDI/DME parity runs used the capture contract to retain all 1,053 testcase identities. Parent verification read and parsed both native and MySQL JUnit artifacts, including a native run with 47 failed/error identities and a passing MySQL control. These results validate evidence retention, not MDI parity.

Reproduction: normal `npm ci` (including postinstall), `npm run build`, then `npx tsx tests/phpunit-structured-evidence.test.ts`, `npx tsx tests/phpunit-result-paths.test.ts`, and `npx tsx tests/playground-phpunit-readonly-cache.integration.test.ts`.

Supports Automattic/markdown-database-integration#393 and #377. No release or deployment.

## AI Assistance

GPT-6 Astra (`openai/gpt-6-astra`) and GPT-5.6 Terra (`openai/gpt-5.6-terra`) via OpenCode implemented and verified the capture changes. Astra reviewed stale-output handling and bounds, independently checked real native/MySQL artifacts and final CI, and finalized the PR under Chris Huber's direction.
