### PR TITLE
Fix portable editor canvas recipe validation

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1713,10 +1713,6 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
   }
 
   if (step.command === "wordpress.editor-canvas-probe") {
-    if (!recipeStepArgValue(step.args ?? [], "url")?.trim()) {
-      addIssue("missing-url", `${path}.args`, "wordpress.editor-canvas-probe requires url=<path-or-url>.")
-    }
-
     const timeoutMs = recipeStepArgValue(step.args ?? [], "timeout-ms") ?? recipeStepArgValue(step.args ?? [], "timeoutMs")
     if (timeoutMs && !/^[1-9]\d*$/.test(timeoutMs)) {
       addIssue("invalid-timeout-ms", `${path}.args`, "wordpress.editor-canvas-probe timeout-ms must be a positive integer.")

--- a/tests/recipe-validation-descriptors.test.ts
+++ b/tests/recipe-validation-descriptors.test.ts
@@ -16,6 +16,7 @@ await withTempDir("wp-codebox-recipe-validation-descriptors-", async (recipeDire
         { command: "wordpress.browser-actions", args: ["capture=steps,bogus", "timeout=forever"] },
         { command: "wordpress.browser-scenario", args: ["capture=performance,bogus", "step-timeout=forever"] },
         { command: "wordpress.editor-actions", args: ["capture=steps,bogus", "wait-timeout=forever"] },
+        { command: "wordpress.editor-canvas-probe", args: ["target=front-page"] },
       ],
     },
   }
@@ -42,6 +43,7 @@ await withTempDir("wp-codebox-recipe-validation-descriptors-", async (recipeDire
     { code: "invalid-duration", path: "$.workflow.steps[3].args", message: "wordpress.editor-actions wait-timeout must look like 500ms or 2s." },
     { code: "invalid-capture", path: "$.workflow.steps[3].args", message: "wordpress.editor-actions capture does not support: bogus" },
   ])
+  assert.deepEqual(issues.filter((issue) => issue.path === "$.workflow.steps[4].args"), [])
 })
 
 await withTempDir("wp-codebox-recipe-geolocation-validation-", async (recipeDirectory) => {


### PR DESCRIPTION
## Summary
- align recipe validation with the portable editor targets accepted by `wordpress.editor-canvas-probe`
- cover `target=front-page` as a valid recipe argument

## Verification
- `npx tsx tests/recipe-validation-descriptors.test.ts`
- validated the complete 15-step Static Site Importer solved-fixture recipe with zero issues
- `npm run smoke` (319 commands)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode diagnosed the cross-repository validation mismatch, implemented the focused fix, and ran the verification above. Chris Huber reviewed and orchestrated the work.