### PR TITLE
Fix editor canvas probe authentication

### DIFF
--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -109,6 +109,7 @@ export async function runEditorCanvasProbeCommand({
       await routeBrowserPreviewContextNetwork(context, networkPolicy, topology.origins.localProxyOrigin, routeTracker)
     }
     const page = context ? await context.newPage() : await browser.newPage()
+    await installWordPressAdminAuthCookies({ command: "wordpress.editor-canvas-probe", cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
     viewport = await browserProbeViewport(page)
     attachBrowserCaptureListeners({
       captureConsole: false,

--- a/tests/browser-routed-command-security.test.ts
+++ b/tests/browser-routed-command-security.test.ts
@@ -136,14 +136,18 @@ test("real browser commands sanitize console, artifacts, stdout, and failure std
       },
     },
   } as RuntimeCreateSpec
-  const runPlaygroundCommand = async (command: string) => ({
-    text: command === "wordpress.editor-open.capture-presentation-contract"
+  let editorCanvasAuthCalls = 0
+  const runPlaygroundCommand = async (command: string) => {
+    if (command === "wordpress.editor-canvas-probe.auth") editorCanvasAuthCalls += 1
+    return {
+      text: command === "wordpress.editor-open.capture-presentation-contract"
       ? editorPresentationContractOutput({ identities: GROWING_PRESENTATION_IDENTITIES, complete: true })
       : command === "wordpress.editor-canvas-probe.resolve-front-page"
         ? "7"
         : "[]",
-    exitCode: 0,
-  })
+      exitCode: 0,
+    }
+  }
 
   try {
     await withTempDir("wp-codebox-real-browser-actions-security-", async (artifactRoot) => {
@@ -409,6 +413,7 @@ test("real browser commands sanitize console, artifacts, stdout, and failure std
         spec: { command: "wordpress.editor-canvas-probe", args: ["target=front-page", "route-host=routed.test", "timeout=5s"] },
       })
       await assertCommandSurfacesSafe(result, artifactRoot, ["files/browser/editor-canvas-summary.json"])
+      assert.equal(editorCanvasAuthCalls, 1)
     })
 
     await withTempDir("wp-codebox-real-multi-actor-security-", async (artifactRoot) => {


### PR DESCRIPTION
## Summary
- install WordPress admin auth cookies before `wordpress.editor-canvas-probe` navigates to an editor target
- cover the authenticated portable front-page probe in the routed browser contract

## Root cause
The probe resolved `target=front-page` to `/wp-admin/post.php`, but unlike the other editor commands it launched a fresh browser without installing WordPress auth cookies. Real runs redirected away from the editor and timed out with `iframe-missing`.

## Verification
- `npm run test:browser-routed-command-security`
- `npm run build`
- SSI promotion evidence showed the preceding authenticated `editor-open` found one canvas iframe and 474/474 valid blocks; the unauthenticated probe alone failed

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode analyzed the retained CI browser artifacts, isolated the missing authentication call, implemented the focused fix, and ran the verification above. Chris Huber reviewed and orchestrated the work.